### PR TITLE
Update links to split GitHub repos

### DIFF
--- a/docs/hub/adding-a-library.md
+++ b/docs/hub/adding-a-library.md
@@ -89,7 +89,7 @@ We recommend adding a code snippet to explain how a model should be used in your
 
 ![/docs/assets/hub/code_snippet.png](/docs/assets/hub/code_snippet.png)
 
-Add a code snippet by updating the [Libraries Typescript file](https://github.com/huggingface/huggingface_hub/blob/main/js/src/lib/interfaces/Libraries.ts) with instructions for your model. For example, the [Asteroid](https://huggingface.co/asteroid-team) integration includes a brief code snippet for how to load and use an Asteroid model:
+Add a code snippet by updating the [Libraries Typescript file](https://github.com/huggingface/hub-docs/blob/main/js/src/lib/interfaces/Libraries.ts) with instructions for your model. For example, the [Asteroid](https://huggingface.co/asteroid-team) integration includes a brief code snippet for how to load and use an Asteroid model:
 
 ```typescript
 const asteroid = (model: ModelData) =>
@@ -151,12 +151,12 @@ Lastly, it is important to add a model card, so users understand how to use your
 
 Our Inference API powers models uploaded to the Hub through your library.
 
-All third-party libraries are Dockerized, so you can install the dependencies you'll need for your library to work correctly. Add your library to the existing Docker images by navigating to the [Docker images folder](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community/docker_images).
+All third-party libraries are Dockerized, so you can install the dependencies you'll need for your library to work correctly. Add your library to the existing Docker images by navigating to the [Docker images folder](https://github.com/huggingface/api-inference-community/tree/main/docker_images).
 
 1. Copy the `common` folder and rename it with the name of your library (e.g. `docker/common` to `docker/your-awesome-library`).
 2. There are four files you need to edit:
     * List the packages required for your library to work in `requirements.txt`.
-    * Update `app/main.py` with the tasks supported by your model (see [here](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community) for a complete list of available tasks). Look out for the `IMPLEMENT_THIS` flag to add your supported task.
+    * Update `app/main.py` with the tasks supported by your model (see [here](https://github.com/huggingface/api-inference-community) for a complete list of available tasks). Look out for the `IMPLEMENT_THIS` flag to add your supported task.
 
        ```python
        ALLOWED_TASKS: Dict[str, Type[Pipeline]] = {
@@ -164,7 +164,7 @@ All third-party libraries are Dockerized, so you can install the dependencies yo
        }
        ```
 
-    * For each task your library supports, modify the `app/pipelines/task_name.py` files accordingly. We have also added an `IMPLEMENT_THIS` flag in the pipeline files to guide you. If there isn't a pipeline that supports your task, feel free to add one. Open an [issue](https://github.com/huggingface/huggingface_hub/issues/new) here, and we will be happy to help you.
+    * For each task your library supports, modify the `app/pipelines/task_name.py` files accordingly. We have also added an `IMPLEMENT_THIS` flag in the pipeline files to guide you. If there isn't a pipeline that supports your task, feel free to add one. Open an [issue](https://github.com/huggingface/hub-docs/issues/new) here, and we will be happy to help you.
     * Add your model and task to the `tests/test_api.py` file. For example, if you have a text generation model:
 
        ```python

--- a/docs/hub/adding-a-task.md
+++ b/docs/hub/adding-a-task.md
@@ -43,21 +43,21 @@ Once the pipeline is submitted and deployed, you should be able to use the Infer
 
 ## Using Community Inference API with a supported library
 
-The Hub also supports over 10 open-source libraries in the [Community Inference API](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community). 
+The Hub also supports over 10 open-source libraries in the [Community Inference API](https://github.com/huggingface/api-inference-community). 
 
 **Adding a new task is relatively straightforward and requires 2 PRs:**
-* PR 1: Add the new task to the API [validation](https://github.com/huggingface/huggingface_hub/blob/main/api-inference-community/api_inference_community/validation.py). This code ensures that the inference input is valid for a given task. Some PR examples:
+* PR 1: Add the new task to the API [validation](https://github.com/huggingface/api-inference-community/blob/main/api_inference_community/validation.py). This code ensures that the inference input is valid for a given task. Some PR examples:
     * [Add text-to-image](https://github.com/huggingface/huggingface_hub/commit/5f040a117cf2a44d704621012eb41c01b103cfca#diff-db8bbac95c077540d79900384cfd524d451e629275cbb5de7a31fc1cd5d6c189)
     * [Add audio-classification](https://github.com/huggingface/huggingface_hub/commit/141e30588a2031d4d5798eaa2c1250d1d1b75905#diff-db8bbac95c077540d79900384cfd524d451e629275cbb5de7a31fc1cd5d6c189)
     * [Add structured-data-classification](https://github.com/huggingface/huggingface_hub/commit/dbea604a45df163d3f0b4b1d897e4b0fb951c650#diff-db8bbac95c077540d79900384cfd524d451e629275cbb5de7a31fc1cd5d6c189)
-* PR 2: Add the new task to a library docker image. You should also add a template to [`docker_images/common/app/pipelines`](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community/docker_images/common/app/pipelines) to facilitate integrating the task in other libraries. Here is an example PR:
+* PR 2: Add the new task to a library docker image. You should also add a template to [`docker_images/common/app/pipelines`](https://github.com/huggingface/api-inference-community/tree/main/docker_images/common/app/pipelines) to facilitate integrating the task in other libraries. Here is an example PR:
     * [Add text-classification to spaCy](https://github.com/huggingface/huggingface_hub/commit/6926fd9bec23cb963ce3f58ec53496083997f0fa#diff-3f1083a92ca0047b50f9ad2d04f0fe8dfaeee0e26ab71eb8835e365359a1d0dc)
 
 ## Adding Community Inference API for a quick prototype
 
 **My model is not supported by any library. Am I doomed? 😱**
 
-No, you're not! We have an experimental Docker image for quick prototyping of new tasks and introduction of new libraries. This is the [generic Inference API](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community/docker_images/generic) and should allow you to have a new task in production with very little development from your side.
+No, you're not! We have an experimental Docker image for quick prototyping of new tasks and introduction of new libraries. This is the [generic Inference API](https://github.com/huggingface/api-inference-community/tree/main/docker_images/generic) and should allow you to have a new task in production with very little development from your side.
 
 How does it work from the user point of view? Users create a copy of a [template](https://huggingface.co/templates) repo for their given task. Users then need to define their `requirements.txt` and fill `pipeline.py`. Note that this is not intended for fast production use cases, but more for quick experimentation and prototyping.
 
@@ -68,7 +68,7 @@ The Hub allows users to filter models by a given task. In order to do this, you 
 
 1. Add the task type to `Types.ts`
 
-In [interfaces/Types.ts](https://github.com/huggingface/huggingface_hub/blob/main/js/src/lib/interfaces/Types.ts), you need to do a couple of things
+In [interfaces/Types.ts](https://github.com/huggingface/hub-docs/blob/main/js/src/lib/interfaces/Types.ts), you need to do a couple of things
 
 * Add the type to `PipelineType`. Note that they are sorted in different categories (NLP, Audio, Computer Vision and others).
 * Specify the task color in `PIPELINE_COLOR`. 
@@ -76,11 +76,11 @@ In [interfaces/Types.ts](https://github.com/huggingface/huggingface_hub/blob/mai
 
 2. Choose an icon
 
-You can add an icon in the [lib/Icons](https://github.com/huggingface/huggingface_hub/tree/main/js/src/lib/Icons) directory. We usually choose carbon icons from https://icones.js.org/collection/carbon. 
+You can add an icon in the [lib/Icons](https://github.com/huggingface/hub-docs/tree/main/js/src/lib/Icons) directory. We usually choose carbon icons from https://icones.js.org/collection/carbon. 
 
 
 ## Widget
 
 Once the task is in production, what could be more exciting that implementing some way for users to play directly with the models in their browser? 🤩 You can find all the widgets [here](https://huggingface-widgets.netlify.app/). 
 
-In case you would be interested in contributing with a widget, you can look at the [implementation](https://github.com/huggingface/huggingface_hub/tree/main/js/src/lib/components/InferenceWidget/widgets) of all the widgets. You can also find WIP documentation on how to implement a widget in https://github.com/huggingface/huggingface_hub/tree/main/js. 
+In case you would be interested in contributing with a widget, you can look at the [implementation](https://github.com/huggingface/hub-docs/tree/main/js/src/lib/components/InferenceWidget/widgets) of all the widgets. You can also find WIP documentation on how to implement a widget in https://github.com/huggingface/hub-docs/tree/main/js. 

--- a/docs/hub/inference.md
+++ b/docs/hub/inference.md
@@ -16,7 +16,7 @@ On top of `Pipelines` and depending on the model type, we build a number of prod
 - maintaining a Least Recently Used cache ensuring that the most popular models are always loaded,
 - scaling the underlying compute infrastructure on the fly depending on the load constraints.
 
-For models from [other libraries](/docs/hub/libraries), the API uses [Starlette](https://www.starlette.io) and runs in [Docker containers](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community/docker_images). Each library defines the implementation of [different pipelines](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community/docker_images/sentence_transformers/app/pipelines).
+For models from [other libraries](/docs/hub/libraries), the API uses [Starlette](https://www.starlette.io) and runs in [Docker containers](https://github.com/huggingface/api-inference-community/tree/main/docker_images). Each library defines the implementation of [different pipelines](https://github.com/huggingface/api-inference-community/tree/main/docker_images/sentence_transformers/app/pipelines).
 
 
 ## How can I turn off the inference API for my model?

--- a/docs/hub/libraries.md
+++ b/docs/hub/libraries.md
@@ -9,7 +9,7 @@ title: Hugging Face Hub Libraries Docs
 
 No, the Hub supports other libraries and we're working on expanding this support! We're happy to welcome to the Hub a set of Open Source libraries that are pushing Machine Learning forward.
 
-The table below summarizes the supported libraries and how they are integrated. Find all our supported libraries [here](https://github.com/huggingface/huggingface_hub/blob/main/js/src/lib/interfaces/Libraries.ts)! 
+The table below summarizes the supported libraries and how they are integrated. Find all our supported libraries [here](https://github.com/huggingface/hub-docs/blob/main/js/src/lib/interfaces/Libraries.ts)! 
 
 | Library               | Description                                                                   | Inference API | Widgets | Download from Hub | Push to Hub |
 |-----------------------|-------------------------------------------------------------------------------|---------------|-------:|-------------------|-------------|

--- a/docs/hub/main.md
+++ b/docs/hub/main.md
@@ -69,7 +69,7 @@ You can always manually override your pipeline type with pipeline_tag: xxx in yo
 
 ## What are all the possible task/widget types?
 
-You can find all the supported tasks [here](https://github.com/huggingface/huggingface_hub/blob/main/js/src/lib/interfaces/Types.ts).
+You can find all the supported tasks [here](https://github.com/huggingface/hub-docs/blob/main/js/src/lib/interfaces/Types.ts).
 
 Here are some with links to examples:
 

--- a/docs/hub/model-repos.md
+++ b/docs/hub/model-repos.md
@@ -42,7 +42,7 @@ metrics:
 ---
 ```
 
-You can find the detailed specification [here](https://github.com/huggingface/huggingface_hub/blame/main/modelcard.md).
+You can find the detailed specification [here](https://github.com/huggingface/hub-docs/blame/main/modelcard.md).
 
 
 Some useful information on them:
@@ -50,7 +50,7 @@ Some useful information on them:
 * License identifiers are the keywords listed in the right column of [this table](#list-of-license-identifiers).
 * Dataset, metric, and language identifiers are those listed on the [Datasets](https://huggingface.co/datasets), [Metrics](https://huggingface.co/metrics) and [Languages](https://huggingface.co/languages) pages and in the [`datasets`](https://github.com/huggingface/datasets) repository.
 
-You can even specify your **model's eval results** in a structured way, which will allow the Hub to parse, display, and even link them to Papers With Code leaderboards. See how to format this data [in the metadata spec](https://github.com/huggingface/huggingface_hub/blame/main/modelcard.md).
+You can even specify your **model's eval results** in a structured way, which will allow the Hub to parse, display, and even link them to Papers With Code leaderboards. See how to format this data [in the metadata spec](https://github.com/huggingface/hub-docs/blame/main/modelcard.md).
 
 
 Here is a partial example (omitting the eval results part):
@@ -105,7 +105,7 @@ widget:
   example_title: "Reading comprehension"
 ```
 
-Moreover, you can specify non-text example inputs in the model card metadata. Refer [here](https://github.com/huggingface/huggingface_hub/blob/main/docs/hub/input-examples.md) for a complete list of example input formats for all widget types. For vision & audio widget types, provide example inputs with `src` rather than `text`. 
+Moreover, you can specify non-text example inputs in the model card metadata. Refer [here](https://github.com/huggingface/hub-docs/blob/main/docs/hub/input-examples.md) for a complete list of example input formats for all widget types. For vision & audio widget types, provide example inputs with `src` rather than `text`. 
 
 For example, allow users to choose from two sample audio files for automatic speech recognition tasks by:
 
@@ -126,7 +126,7 @@ widget:
   example_title: Custom Speech Sample 1
 ```
 
-We provide example inputs for some languages and most widget types in [the DefaultWidget.ts file](https://github.com/huggingface/huggingface_hub/blob/master/js/src/lib/interfaces/DefaultWidget.ts). If some examples are missing, we welcome PRs from the community to add them!
+We provide example inputs for some languages and most widget types in [the DefaultWidget.ts file](https://github.com/huggingface/hub-docs/blob/master/js/src/lib/interfaces/DefaultWidget.ts). If some examples are missing, we welcome PRs from the community to add them!
 
 ## How can I control my model's widget Inference API parameters?
 

--- a/docs/hub/security.md
+++ b/docs/hub/security.md
@@ -90,7 +90,7 @@ The Pro Git book is, as usual, a good resource about commit signing: [Pro Git: S
 
 The reasons we implemented GPG signing were:
 - To provide finer-grained security, especially as more and more Enterprise users rely on the Hub (in the future you'll be able to disallow non-signed commits)
-- Coupled with our model [eval results metadata](https://github.com/huggingface/huggingface_hub/blame/main/modelcard.md), GPG signing enables a cryptographically-secure trustable source of ML benchmarks. 🤯 
+- Coupled with our model [eval results metadata](https://github.com/huggingface/hub-docs/blame/main/modelcard.md), GPG signing enables a cryptographically-secure trustable source of ML benchmarks. 🤯 
 
 ### Setting up signed commits verification
 

--- a/docs/hub/tutorial-add-library.md
+++ b/docs/hub/tutorial-add-library.md
@@ -89,7 +89,7 @@ We recommend adding a code snippet to explain how a model should be used in your
 
 ![/docs/assets/hub/code_snippet.png](/docs/assets/hub/code_snippet.png)
 
-Add a code snippet by updating the [Libraries Typescript file](https://github.com/huggingface/huggingface_hub/blob/main/js/src/lib/interfaces/Libraries.ts) with instructions for your model. For example, the [Asteroid](https://huggingface.co/asteroid-team) integration includes a brief code snippet for how to load and use an Asteroid model:
+Add a code snippet by updating the [Libraries Typescript file](https://github.com/huggingface/hub-docs/blob/main/js/src/lib/interfaces/Libraries.ts) with instructions for your model. For example, the [Asteroid](https://huggingface.co/asteroid-team) integration includes a brief code snippet for how to load and use an Asteroid model:
 
 ```typescript
 const asteroid = (model: ModelData) =>
@@ -150,12 +150,12 @@ Lastly, it is important to add a model card, so users understand how to use your
 
 Our Inference API powers models uploaded to the Hub through your library.
 
-All third-party libraries are Dockerized, so you can install the dependencies you'll need for your library to work correctly. Add your library to the existing Docker images by navigating to the [Docker images folder](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community/docker_images).
+All third-party libraries are Dockerized, so you can install the dependencies you'll need for your library to work correctly. Add your library to the existing Docker images by navigating to the [Docker images folder](https://github.com/huggingface/api-inference-community/tree/main/docker_images).
 
 1. Copy the `common` folder and rename it with the name of your library (e.g. `docker/common` to `docker/your-awesome-library`).
 2. There are four files you need to edit:
     * List the packages required for your library to work in `requirements.txt`.
-    * Update `app/main.py` with the tasks supported by your model (see [here](https://github.com/huggingface/huggingface_hub/tree/main/api-inference-community) for a complete list of available tasks). Look out for the `IMPLEMENT_THIS` flag to add your supported task.
+    * Update `app/main.py` with the tasks supported by your model (see [here](https://github.com/huggingface/api-inference-community) for a complete list of available tasks). Look out for the `IMPLEMENT_THIS` flag to add your supported task.
 
        ```python
        ALLOWED_TASKS: Dict[str, Type[Pipeline]] = {
@@ -163,7 +163,7 @@ All third-party libraries are Dockerized, so you can install the dependencies yo
        }
        ```
 
-    * For each task your library supports, modify the `app/pipelines/task_name.py` files accordingly. We have also added an `IMPLEMENT_THIS` flag in the pipeline files to guide you. If there isn't a pipeline that supports your task, feel free to add one. Open an [issue](https://github.com/huggingface/huggingface_hub/issues/new) here, and we will be happy to help you.
+    * For each task your library supports, modify the `app/pipelines/task_name.py` files accordingly. We have also added an `IMPLEMENT_THIS` flag in the pipeline files to guide you. If there isn't a pipeline that supports your task, feel free to add one. Open an [issue](https://github.com/huggingface/hub-docs/issues/new) here, and we will be happy to help you.
     * Add your model and task to the `tests/test_api.py` file. For example, if you have a text generation model:
 
        ```python


### PR DESCRIPTION
I went through the tedious task of grepping `huggingface_hub` in this repo and moving the links to their respective now-correct repos 😅