### PR TITLE
docs(Spaces): Add details for custom Python Spaces

### DIFF
--- a/docs/hub/spaces.md
+++ b/docs/hub/spaces.md
@@ -177,7 +177,7 @@ Issues may occur when you use an unsupported Streamlit version. The Streamlit ve
 
 While not an official workflow, you are able to run your own Python + interface stack in Spaces by selecting Gradio as your SDK and serving a frontend on port `7680`. See the [templates](https://huggingface.co/templates#spaces) for examples.
 
-Spaces are served in iframes, which by default restrict links from opening in the parent page. The simplest solution is to open them a new window:
+Spaces are served in iframes, which by default restrict links from opening in the parent page. The simplest solution is to open them in a new window:
 
 ```HTML
 <a href="https://hf.space" rel="noopener" target="_blank">Spaces</a>

--- a/docs/hub/spaces.md
+++ b/docs/hub/spaces.md
@@ -183,7 +183,7 @@ Spaces are served in iframes, which by default restrict links from opening in th
 <a href="https://hf.space" rel="noopener" target="_blank">Spaces</a>
 ```
 
-Usually, the height of Spaces is adjusted automatically when using the Gradio library interface. If you provide your own frontend in the Gradio SDK however, and if your content height is larger than the viewport, you'll need to add an [iFrame Resizer script](https://cdnjs.com/libraries/iframe-resizer) so that content can scroll in the iframe:
+Usually, the height of Spaces is automatically adjusted when using the Gradio library interface. However, if you provide your own frontend in the Gradio SDK and the content height is larger than the viewport, you'll need to add an [iFrame Resizer script](https://cdnjs.com/libraries/iframe-resizer) so the content is scrollable in the iframe:
 
 ```HTML
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.min.js"></script>

--- a/docs/hub/spaces.md
+++ b/docs/hub/spaces.md
@@ -175,19 +175,21 @@ Issues may occur when you use an unsupported Streamlit version. The Streamlit ve
 
 ### Custom Python Spaces
 
-While not an official workflow yet, you are able to run your own Python + interface stack in Spaces by selecting Gradio as your SDK and serving a frontend on port `7680`. See the [templates](https://huggingface.co/templates#spaces) for examples.
+While not an official workflow, you are able to run your own Python + interface stack in Spaces by selecting Gradio as your SDK and serving a frontend on port `7680`. See the [templates](https://huggingface.co/templates#spaces) for examples.
 
-Because you are now responsible for the interface, you must add an [iFrame Resizer script](https://cdnjs.com/libraries/iframe-resizer) that is normally imported by the Gradio library:
+Spaces are served in iframes, which by default restrict links from opening in the parent page. The simplest solution is to open them a new window:
+
+```HTML
+<a href="https://hf.space" rel="noopener" target="_blank">Spaces</a>
+```
+
+Usually, the height of Spaces is adjusted automatically when using the Gradio library interface. If you provide your own frontend in the Gradio SDK however, you'll need to add an [iFrame Resizer script](https://cdnjs.com/libraries/iframe-resizer) so that content can scroll in the iframe:
 
 ```HTML
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.min.js"></script>
 ```
 
-Iframes by default are also restricted from opening links in the parent page, so you should open them in a new window:
 
-```HTML
-<a href="https://hf.space" rel="noopener" target="_blank">Spaces</a>
-```
 
 ## Contact
 

--- a/docs/hub/spaces.md
+++ b/docs/hub/spaces.md
@@ -169,7 +169,25 @@ jobs:
 
 ## Troubleshoot
 
+### Streamlit
+
 Issues may occur when you use an unsupported Streamlit version. The Streamlit version is not configured in the **requirements.txt** file but rather in the `YAML` settings through the `sdk_version` setting. Not all Streamlit versions are supported. Check that you are using a supported version of Streamlit. Refer to the [reference section](#reference) for more information about supported versions.
+
+### Custom Python Spaces
+
+While not an official workflow yet, you are able to run your own Python + interface stack in Spaces by selecting Gradio as your SDK and serving a frontend on port `7680`. See the [templates](https://huggingface.co/templates#spaces) for examples.
+
+Because you are now responsible for the interface, you must add an [iFrame Resizer script](https://cdnjs.com/libraries/iframe-resizer) that is normally imported by the Gradio library:
+
+```HTML
+<script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.min.js"></script>
+```
+
+Iframes by default are also restricted from opening links in the parent page, so you should open them in a new window:
+
+```HTML
+<a href="https://hf.space" rel="noopener" target="_blank">Spaces</a>
+```
 
 ## Contact
 

--- a/docs/hub/spaces.md
+++ b/docs/hub/spaces.md
@@ -183,7 +183,7 @@ Spaces are served in iframes, which by default restrict links from opening in th
 <a href="https://hf.space" rel="noopener" target="_blank">Spaces</a>
 ```
 
-Usually, the height of Spaces is adjusted automatically when using the Gradio library interface. If you provide your own frontend in the Gradio SDK however, you'll need to add an [iFrame Resizer script](https://cdnjs.com/libraries/iframe-resizer) so that content can scroll in the iframe:
+Usually, the height of Spaces is adjusted automatically when using the Gradio library interface. If you provide your own frontend in the Gradio SDK however, and if your content height is larger than the viewport, you'll need to add an [iFrame Resizer script](https://cdnjs.com/libraries/iframe-resizer) so that content can scroll in the iframe:
 
 ```HTML
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.min.js"></script>

--- a/docs/hub/spaces.md
+++ b/docs/hub/spaces.md
@@ -188,7 +188,9 @@ Usually, the height of Spaces is adjusted automatically when using the Gradio li
 ```HTML
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.min.js"></script>
 ```
-
+As an example, here is the same Space with and without the script:
+- https://huggingface.co/spaces/ronvolutional/http-server
+- https://huggingface.co/spaces/ronvolutional/iframe-test
 
 
 ## Contact


### PR DESCRIPTION
Without making a full section on custom Python Spaces as it's still only unofficially supported, point out the main issues that are not obvious.