### PR TITLE
Rm redundancy: `push` already runs on every `pull`

### DIFF
--- a/.github/workflows/js-interfaces-tests.yml
+++ b/.github/workflows/js-interfaces-tests.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - "js/**"
       - "js/src/lib/interfaces/**"
-  pull_request:
-    paths:
-      - "js/**"
-      - "js/src/lib/interfaces/**"
 
 
 jobs:


### PR DESCRIPTION
I looked over the changes in https://github.com/huggingface/hub-docs/pull/96 & everything lgtm except this small nit