### PR TITLE
Generalize `inference snippets`

### DIFF
--- a/js/src/lib/inferenceSnippets/inputs.ts
+++ b/js/src/lib/inferenceSnippets/inputs.ts
@@ -65,6 +65,8 @@ const inputsSentenceSimilarity = () =>
 const inputsFeatureExtraction = () =>
 	`"Today is a sunny day and I'll get some ice cream."`;
 
+const inputsImageClassification = () => `"cats.jpg"`;
+
 const modelInputSnippets: {
 	[key in PipelineType]?: (model: ModelData) => string;
 } = {
@@ -81,16 +83,24 @@ const modelInputSnippets: {
 	"token-classification":     inputsTokenClassification,
 	"translation":              inputsTranslation,
 	"zero-shot-classification": inputsZeroShotClassification,
+	"image-classification":     inputsImageClassification,
 };
 
 // Use noWrap to put the whole snippet on a single line (removing new lines and tabulations)
-export function getModelInputSnippet(model: ModelData, noWrap = false): string {
+// Use noQuotes to strip quotes from start & end (example: "abc" -> abc)
+export function getModelInputSnippet(model: ModelData, noWrap = false, noQuotes = false): string {
+	const REGEX_QUOTES = /^"(.+)"$/s;
 	if (model.pipeline_tag) {
 		const inputs = modelInputSnippets[model.pipeline_tag];
 		if (inputs) {
-			return noWrap
-				? inputs(model).replace(/(?:(?:\r?\n|\r)\t*)|\t+/g, " ")
-				: inputs(model);
+			let result = inputs(model);
+			if (noWrap) {
+				result = result.replace(/(?:(?:\r?\n|\r)\t*)|\t+/g, " ");
+			}
+			if (noQuotes && result.match(REGEX_QUOTES)) {
+				result = result.match(REGEX_QUOTES)[1];
+			}
+			return result;
 		}
 	}
 	return "No input example has been defined for this model task.";

--- a/js/src/lib/inferenceSnippets/inputs.ts
+++ b/js/src/lib/inferenceSnippets/inputs.ts
@@ -89,7 +89,6 @@ const modelInputSnippets: {
 // Use noWrap to put the whole snippet on a single line (removing new lines and tabulations)
 // Use noQuotes to strip quotes from start & end (example: "abc" -> abc)
 export function getModelInputSnippet(model: ModelData, noWrap = false, noQuotes = false): string {
-	const REGEX_QUOTES = /^"(.+)"$/s;
 	if (model.pipeline_tag) {
 		const inputs = modelInputSnippets[model.pipeline_tag];
 		if (inputs) {
@@ -97,8 +96,10 @@ export function getModelInputSnippet(model: ModelData, noWrap = false, noQuotes 
 			if (noWrap) {
 				result = result.replace(/(?:(?:\r?\n|\r)\t*)|\t+/g, " ");
 			}
-			if (noQuotes && result.match(REGEX_QUOTES)) {
-				result = result.match(REGEX_QUOTES)[1];
+			if (noQuotes) {
+				const REGEX_QUOTES = /^"(.+)"$/s;
+				const match = result.match(REGEX_QUOTES);
+				result = match ? match[1] : result;
 			}
 			return result;
 		}

--- a/js/src/lib/inferenceSnippets/inputs.ts
+++ b/js/src/lib/inferenceSnippets/inputs.ts
@@ -73,6 +73,7 @@ const modelInputSnippets: {
 	"conversational":           inputsConversational,
 	"feature-extraction":       inputsFeatureExtraction,
 	"fill-mask":                inputsFillMask,
+	"image-classification":     inputsImageClassification,
 	"question-answering":       inputsQuestionAnswering,
 	"sentence-similarity":      inputsSentenceSimilarity,
 	"summarization":            inputsSummarization,
@@ -83,7 +84,6 @@ const modelInputSnippets: {
 	"token-classification":     inputsTokenClassification,
 	"translation":              inputsTranslation,
 	"zero-shot-classification": inputsZeroShotClassification,
-	"image-classification":     inputsImageClassification,
 };
 
 // Use noWrap to put the whole snippet on a single line (removing new lines and tabulations)

--- a/js/src/lib/inferenceSnippets/serveCurl.ts
+++ b/js/src/lib/inferenceSnippets/serveCurl.ts
@@ -22,7 +22,7 @@ export const snippetFile = (model: ModelData, accessToken: string): string =>
 	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"
 `;
 
-export const curlSnippetBodies:
+export const curlSnippets:
 	Partial<Record<PipelineType, (model: ModelData, accessToken: string) => string>> =
 {
 	// Same order as in js/src/lib/interfaces/Types.ts
@@ -43,11 +43,11 @@ export const curlSnippetBodies:
 };
 
 export function getCurlInferenceSnippet(model: ModelData, accessToken: string): string {
-	return model.pipeline_tag && model.pipeline_tag in curlSnippetBodies
-		? curlSnippetBodies[model.pipeline_tag]?.(model, accessToken) ?? ""
+	return model.pipeline_tag && model.pipeline_tag in curlSnippets
+		? curlSnippets[model.pipeline_tag]?.(model, accessToken) ?? ""
 		: "";
 }
 
 export function hasCurlInferenceSnippet(model: ModelData): boolean {
-	return !!model.pipeline_tag && model.pipeline_tag in curlSnippetBodies;
+	return !!model.pipeline_tag && model.pipeline_tag in curlSnippets;
 }

--- a/js/src/lib/inferenceSnippets/serveCurl.ts
+++ b/js/src/lib/inferenceSnippets/serveCurl.ts
@@ -1,41 +1,51 @@
 import type { PipelineType, ModelData } from "../interfaces/Types";
 import { getModelInputSnippet } from "./inputs";
 
-export const bodyBasic = (model: ModelData): string =>
-	`-d '{"inputs": ${getModelInputSnippet(model, true)}}'`;
+export const snippetBasic = (model: ModelData, accessToken: string): string =>
+	`curl https://api-inference.huggingface.co/models/${model.id} \\
+	-X POST \\
+	-d '{"inputs": ${getModelInputSnippet(model, true)}}' \\
+	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"
+`;
 
-export const bodyZeroShotClassification = (model: ModelData): string =>
-	`-d '{"inputs": ${getModelInputSnippet(model, true)}, "parameters": {"candidate_labels": ["refund", "legal", "faq"]}}'`;
+export const snippetZeroShotClassification = (model: ModelData, accessToken: string): string =>
+	`curl https://api-inference.huggingface.co/models/${model.id} \\
+	-X POST \\
+	-d '{"inputs": ${getModelInputSnippet(model, true)}, "parameters": {"candidate_labels": ["refund", "legal", "faq"]}}' \\
+	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"
+`;
+
+export const snippetFile = (model: ModelData, accessToken: string): string =>
+	`curl https://api-inference.huggingface.co/models/${model.id} \\
+	-X POST \\
+	--data-binary '@${getModelInputSnippet(model, true, true)}' \\
+	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"
+`;
 
 export const curlSnippetBodies:
-	Partial<Record<PipelineType, (model: ModelData) => string>> =
+	Partial<Record<PipelineType, (model: ModelData, accessToken: string) => string>> =
 {
 	// Same order as in js/src/lib/interfaces/Types.ts
-	"text-classification":      bodyBasic,
-	"token-classification":     bodyBasic,
-	"table-question-answering": bodyBasic,
-	"question-answering":       bodyBasic,
-	"zero-shot-classification": bodyZeroShotClassification,
-	"translation":              bodyBasic,
-	"summarization":            bodyBasic,
-	"conversational":           bodyBasic,
-	"feature-extraction":       bodyBasic,
-	"text-generation":          bodyBasic,
-	"text2text-generation":     bodyBasic,
-	"fill-mask":                bodyBasic,
-	"sentence-similarity":      bodyBasic,
+	"text-classification":      snippetBasic,
+	"token-classification":     snippetBasic,
+	"table-question-answering": snippetBasic,
+	"question-answering":       snippetBasic,
+	"zero-shot-classification": snippetZeroShotClassification,
+	"translation":              snippetBasic,
+	"summarization":            snippetBasic,
+	"conversational":           snippetBasic,
+	"feature-extraction":       snippetBasic,
+	"text-generation":          snippetBasic,
+	"text2text-generation":     snippetBasic,
+	"fill-mask":                snippetBasic,
+	"sentence-similarity":      snippetBasic,
+	"image-classification":     snippetFile,
 };
 
 export function getCurlInferenceSnippet(model: ModelData, accessToken: string): string {
-	const body = model.pipeline_tag && model.pipeline_tag in curlSnippetBodies
-		? curlSnippetBodies[model.pipeline_tag]?.(model) ?? ""
+	return model.pipeline_tag && model.pipeline_tag in curlSnippetBodies
+		? curlSnippetBodies[model.pipeline_tag]?.(model, accessToken) ?? ""
 		: "";
-		
-	return `curl https://api-inference.huggingface.co/models/${model.id} \\
-	-X POST \\
-	${body} \\
-	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"
-`;
 }
 
 export function hasCurlInferenceSnippet(model: ModelData): boolean {

--- a/js/src/lib/inferenceSnippets/serveJs.ts
+++ b/js/src/lib/inferenceSnippets/serveJs.ts
@@ -56,7 +56,7 @@ query(${getModelInputSnippet(model)}).then((response) => {
 	console.log(JSON.stringify(response));
 });`;
 
-export const jsSnippetBodies:
+export const jsSnippets:
 	Partial<Record<PipelineType, (model: ModelData, accessToken: string) => string>> =
 {
 	// Same order as in js/src/lib/interfaces/Types.ts
@@ -77,11 +77,11 @@ export const jsSnippetBodies:
 };
 
 export function getJsInferenceSnippet(model: ModelData, accessToken: string): string {
-	return model.pipeline_tag && model.pipeline_tag in jsSnippetBodies
-		? jsSnippetBodies[model.pipeline_tag]?.(model, accessToken) ?? ""
+	return model.pipeline_tag && model.pipeline_tag in jsSnippets
+		? jsSnippets[model.pipeline_tag]?.(model, accessToken) ?? ""
 		: "";
 }
 
 export function hasJsInferenceSnippet(model: ModelData): boolean {
-	return !!model.pipeline_tag && model.pipeline_tag in jsSnippetBodies;
+	return !!model.pipeline_tag && model.pipeline_tag in jsSnippets;
 }

--- a/js/src/lib/inferenceSnippets/serveJs.ts
+++ b/js/src/lib/inferenceSnippets/serveJs.ts
@@ -1,37 +1,8 @@
 import type { PipelineType, ModelData } from "../interfaces/Types";
 import { getModelInputSnippet } from "./inputs";
 
-export const bodyBasic = (model: ModelData): string =>
-	`{"inputs": ${getModelInputSnippet(model)}}`;
-
-export const bodyZeroShotClassification = (model: ModelData): string =>
-	`{"inputs": ${getModelInputSnippet(model)}, "parameters": {"candidate_labels": ["refund", "legal", "faq"]}}`;
-
-export const jsSnippetBodies:
-	Partial<Record<PipelineType, (model: ModelData) => string>> =
-{
-	// Same order as in js/src/lib/interfaces/Types.ts
-	"text-classification":      bodyBasic,
-	"token-classification":     bodyBasic,
-	"table-question-answering": bodyBasic,
-	"question-answering":       bodyBasic,
-	"zero-shot-classification": bodyZeroShotClassification,
-	"translation":              bodyBasic,
-	"summarization":            bodyBasic,
-	"conversational":           bodyBasic,
-	"feature-extraction":       bodyBasic,
-	"text-generation":          bodyBasic,
-	"text2text-generation":     bodyBasic,
-	"fill-mask":                bodyBasic,
-	"sentence-similarity":      bodyBasic,
-};
-
-export function getJsInferenceSnippet(model: ModelData, accessToken: string): string {
-	const body = model.pipeline_tag && model.pipeline_tag in jsSnippetBodies
-		? jsSnippetBodies[model.pipeline_tag]?.(model) ?? ""
-		: "";
-	
-	return `async function query(data) {
+export const snippetBasic = (model: ModelData, accessToken: string): string =>
+	`async function query(data) {
 	const response = await fetch(
 		"https://api-inference.huggingface.co/models/${model.id}",
 		{
@@ -44,9 +15,71 @@ export function getJsInferenceSnippet(model: ModelData, accessToken: string): st
 	return result;
 }
 
-query(${body}).then((response) => {
+query({"inputs": ${getModelInputSnippet(model)}}).then((response) => {
 	console.log(JSON.stringify(response));
 });`;
+
+export const snippetZeroShotClassification = (model: ModelData, accessToken: string): string =>
+	`async function query(data) {
+	const response = await fetch(
+		"https://api-inference.huggingface.co/models/${model.id}",
+		{
+			headers: { Authorization: "Bearer ${accessToken || `{API_TOKEN}`}" },
+			method: "POST",
+			body: JSON.stringify(data),
+		}
+	);
+	const result = await response.json();
+	return result;
+}
+
+query({"inputs": ${getModelInputSnippet(model)}, "parameters": {"candidate_labels": ["refund", "legal", "faq"]}}).then((response) => {
+	console.log(JSON.stringify(response));
+});`;
+
+export const snippetFile = (model: ModelData, accessToken: string): string =>
+	`async function query(filename) {
+	const data = fs.readFileSync(filename);
+	const response = await fetch(
+		"https://api-inference.huggingface.co/models/${model.id}",
+		{
+			headers: { Authorization: "Bearer ${accessToken || `{API_TOKEN}`}" },
+			method: "POST",
+			body: data,
+		}
+	);
+	const result = await response.json();
+	return result;
+}
+
+query(${getModelInputSnippet(model)}).then((response) => {
+	console.log(JSON.stringify(response));
+});`;
+
+export const jsSnippetBodies:
+	Partial<Record<PipelineType, (model: ModelData, accessToken: string) => string>> =
+{
+	// Same order as in js/src/lib/interfaces/Types.ts
+	"text-classification":      snippetBasic,
+	"token-classification":     snippetBasic,
+	"table-question-answering": snippetBasic,
+	"question-answering":       snippetBasic,
+	"zero-shot-classification": snippetZeroShotClassification,
+	"translation":              snippetBasic,
+	"summarization":            snippetBasic,
+	"conversational":           snippetBasic,
+	"feature-extraction":       snippetBasic,
+	"text-generation":          snippetBasic,
+	"text2text-generation":     snippetBasic,
+	"fill-mask":                snippetBasic,
+	"sentence-similarity":      snippetBasic,
+	"image-classification":     snippetFile,
+};
+
+export function getJsInferenceSnippet(model: ModelData, accessToken: string): string {
+	return model.pipeline_tag && model.pipeline_tag in jsSnippetBodies
+		? jsSnippetBodies[model.pipeline_tag]?.(model, accessToken) ?? ""
+		: "";
 }
 
 export function hasJsInferenceSnippet(model: ModelData): boolean {

--- a/js/src/lib/inferenceSnippets/servePython.ts
+++ b/js/src/lib/inferenceSnippets/servePython.ts
@@ -29,7 +29,7 @@ export const snippetFile = (model: ModelData): string =>
 
 output = query(${getModelInputSnippet(model)})`;
 
-export const pythonSnippetBodies:
+export const pythonSnippets:
 	Partial<Record<PipelineType, (model: ModelData) => string>> =
 {
 	// Same order as in js/src/lib/interfaces/Types.ts
@@ -50,8 +50,8 @@ export const pythonSnippetBodies:
 };
 
 export function getPythonInferenceSnippet(model: ModelData, accessToken: string): string {
-	const body = model.pipeline_tag && model.pipeline_tag in pythonSnippetBodies
-		? pythonSnippetBodies[model.pipeline_tag]?.(model) ?? ""
+	const body = model.pipeline_tag && model.pipeline_tag in pythonSnippets
+		? pythonSnippets[model.pipeline_tag]?.(model) ?? ""
 		: "";
 
 	return `import requests
@@ -63,5 +63,5 @@ ${body}`;
 }
 
 export function hasPythonInferenceSnippet(model: ModelData): boolean {
-	return !!model.pipeline_tag && model.pipeline_tag in pythonSnippetBodies;
+	return !!model.pipeline_tag && model.pipeline_tag in pythonSnippets;
 }


### PR DESCRIPTION
This PR:
1. Generalizes snippets so that they can support tasks that send file as an input
2. As an example, I've added snippets for img-cls task
3. If this PR gets approved, I'll add remaining tasks (such as obj-det, aud-cls, etc.) & it should close https://github.com/huggingface/hub-docs/issues/50 [read more here](https://huggingface.slack.com/archives/C02GLJ5S0E9/p1649684595263329?thread_ts=1649684240.633949&cid=C02GLJ5S0E9)

Example screenshots of img-cls task (please check whether the snippets look correct: @Narsil @osanseviero ):
<img width="500" alt="Screenshot 2022-04-19 at 13 03 53" src="https://user-images.githubusercontent.com/11827707/163998062-da18bf52-0887-4488-b854-aa8f202ed6cf.png">
<img width="500" alt="Screenshot 2022-04-19 at 13 03 55" src="https://user-images.githubusercontent.com/11827707/163998056-f0cffe09-2265-480c-92ac-d8db479db455.png">
<img width="500" alt="Screenshot 2022-04-19 at 13 03 57" src="https://user-images.githubusercontent.com/11827707/163998048-81be22ad-4b27-4be9-82ac-3b2c6efda7d9.png">
