### PR TITLE
Adjust link to TF notebook on Question Answering

### DIFF
--- a/tasks/src/question-answering/about.md
+++ b/tasks/src/question-answering/about.md
@@ -43,7 +43,7 @@ Would you like to learn more about QA? Awesome! Here are some curated resources 
 ### Notebooks
 
 - [PyTorch](https://github.com/huggingface/notebooks/blob/master/examples/question_answering.ipynb)
-- [TensorFlow](https://github.com/huggingface/notebooks/blob/master/examples/token_classification-tf.ipynb)
+- [TensorFlow](https://github.com/huggingface/notebooks/blob/main/examples/question_answering-tf.ipynb)
 
 ### Scripts for training
 


### PR DESCRIPTION
A link in the Question Answering task page points to an incorrect notebook. This PR fixes that link.

Note: All links that point to `huggingface/notebooks/blob/master/...` already redirect to `huggingface/notebooks/blob/main/...`, but I can change all `master` to `main` while I'm working through the revamp.