### PR TITLE
Add code snippet for fastai

### DIFF
--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -219,12 +219,9 @@ model = joblib.load(
 )`;
 
 const fastai = (model: ModelData) =>
-	`from huggingface_hub import hf_hub_download
-from fastai.learner import load_learner
+	`from huggingface_hub import from_pretrained_fastai
 
-model = load_learner(
-    hf_hub_download("${model.id}", "model.pkl")
-)`;
+learn = from_pretrained_fastai("${model.id}")`;
 
 const sentenceTransformers = (model: ModelData) =>
 	`from sentence_transformers import SentenceTransformer


### PR DESCRIPTION
[Do not merge until the next `huggingface_hub` release]

Add `from_pretrained_fastai` ([link](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/fastai_utils.py#L308)) in the "Use in fastai" functionality:

![image](https://user-images.githubusercontent.com/4755430/166261208-eeef4449-32f2-43dc-8602-71157acc18d8.png)
