### PR TITLE
Update GitHub action to account for Hub PRs

### DIFF
--- a/docs/hub/spaces.md
+++ b/docs/hub/spaces.md
@@ -139,10 +139,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Setup git
+        run: |
+          git config --global user.name "Your Name"
+          git config --global user.email "you@example.com"
       - name: Push to hub
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: git push https://HF_USERNAME:$HF_TOKEN@huggingface.co/spaces/FULL_SPACE_NAME main
+        run: |
+          git pull https://HF_USERNAME:$HF_TOKEN@huggingface.co/spaces/FULL_SPACE_NAME main --rebase 
+          git push https://HF_USERNAME:$HF_TOKEN@huggingface.co/spaces/FULL_SPACE_NAME main
 ```
 
 Finally, create an Action that automatically checks the file size of any new pull request:


### PR DESCRIPTION
This PR updates the GitHub workflow to rebase the GitHub repo before pushing to the HF Hub. It also configures Git to define a dummy username / email in order to allow the rebase to happen.

### Why does this?
The introduction of Hub PRs means that the repos on GitHub and the Hugging Face Hub can get out of sync. (Actually, this was always possible through manual Git commands, but now is easier through the UI.) This throws errors like:

```
To https://huggingface.co/spaces/autoevaluate/autoevaluate
 ! [rejected]        main -> main (fetch first)
error: failed to push some refs to 'https://huggingface.co/spaces/autoevaluate/autoevaluate'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.
```

With the new workflow, the above error is resolved.

**Question:** I'm not sure whether Hub PRs will break every Space that is currently using a sync with GitHub actions. 