### PR TITLE
Fix widgettextarea

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -3,8 +3,8 @@
 
 	import WidgetLabel from "../WidgetLabel/WidgetLabel.svelte";
 
-	export let label: string = "";
-	export let placeholder: string = "Your sentence here...";
+	export let label = "";
+	export let placeholder = "Your sentence here...";
 	export let value: string;
 
 	let textAreaEl: HTMLTextAreaElement;

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -1,43 +1,40 @@
-<script lang="ts">
+<script>
+	import { tick } from "svelte";
+
 	import WidgetLabel from "../WidgetLabel/WidgetLabel.svelte";
 
 	export let label: string = "";
 	export let placeholder: string = "Your sentence here...";
 	export let value: string;
 
-	// hack to handle FireFox contenteditable bug
-	let innterHTML: string;
-	let spanEl: HTMLSpanElement;
-	const REGEX_SPAN = /<span .+>(.*)<\/span>/gms;
-	$: {
-		if (spanEl && innterHTML && REGEX_SPAN.test(innterHTML)) {
-			innterHTML = innterHTML.replace(REGEX_SPAN, (_, txt) => {
-				return txt;
-			});
-			spanEl.blur();
+	let textAreaEl: HTMLTextAreaElement;
+
+	const HEIGHT_LIMIT = 500 as const;
+
+	async function resize() {
+		if (!!textAreaEl) {
+			textAreaEl.style.height = "0px";
+			await tick();
+			textAreaEl.style.height =
+				Math.min(textAreaEl.scrollHeight, HEIGHT_LIMIT) + "px";
 		}
+	}
+
+	$: {
+		value;
+		resize();
 	}
 </script>
 
 <WidgetLabel {label}>
 	<svelte:fragment slot="after">
-		<span
-			bind:textContent={value}
-			bind:innerHTML={innterHTML}
-			bind:this={spanEl}
+		<textarea
+			bind:this={textAreaEl}
+			bind:value
 			class="{label
 				? 'mt-1.5'
-				: ''} block overflow-auto resize-y py-2 px-3 w-full min-h-[42px] max-h-[500px] border border-gray-200 rounded-lg shadow-inner outline-none focus:ring-1 focus:ring-inset focus:ring-indigo-200 focus:shadow-inner dark:bg-gray-925"
-			role="textbox"
-			contenteditable
-			style="--placeholder: '{placeholder}'"
+				: ''} block w-full border border-gray-200 rounded-lg shadow-inner outline-none focus:ring-1 focus:ring-inset focus:ring-indigo-200 focus:shadow-inner dark:bg-gray-925"
+			{placeholder}
 		/>
 	</svelte:fragment>
 </WidgetLabel>
-
-<style>
-	span[contenteditable]:empty::before {
-		content: var(--placeholder);
-		color: rgba(156, 163, 175);
-	}
-</style>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -3,8 +3,8 @@
 
 	import WidgetLabel from "../WidgetLabel/WidgetLabel.svelte";
 
-	export let label = "";
-	export let placeholder = "Your sentence here...";
+	export let label: string = "";
+	export let placeholder: string = "Your sentence here...";
 	export let value: string;
 
 	let textAreaEl: HTMLTextAreaElement;

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { tick } from "svelte";
 
 	import WidgetLabel from "../WidgetLabel/WidgetLabel.svelte";


### PR DESCRIPTION
Copying changes from [huggingface_hub#625](https://github.com/huggingface/huggingface_hub/pull/625)

widget files were migrated to `hub-docs` repository on March 16, as can be seen [here](https://github.com/huggingface/hub-docs/commit/33b0b76b654c02a7755feeea837a9c2f05538615), which is after [huggingface_hub#625](https://github.com/huggingface/huggingface_hub/pull/625) was merged. Why [huggingface_hub#625](https://github.com/huggingface/huggingface_hub/pull/625) would not be present in `hub-docs` from the beginning, @LysandreJik @julien-c ?