### PR TITLE
git co -> git checkout

### DIFF
--- a/docs/hub/repositories-pull-requests-discussions.md
+++ b/docs/hub/repositories-pull-requests-discussions.md
@@ -69,7 +69,7 @@ git fetch
 3. create a local branch tracking the ref
 
 ```bash
-git co pr/:num
+git checkout pr/:num
 ```
 
 4. IF you make local changes, to push to the PR ref:


### PR DESCRIPTION
`git co` is a shortcut not supported by everyone (eg default git on linux doesn't have it)