### PR TITLE
Update _toctree.yml

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -33,7 +33,7 @@
     title: Integrated Libraries
     sections:
       - local: spacy
-        title: SpaCy
+        title: spaCy
       - local: transformers
         title: transformers
       - local: adapter-transformers


### PR DESCRIPTION
It's spelt `spaCy` not `SpaCy`.