### PR TITLE
Adjust paths, add widget examples page

### DIFF
--- a/.github/ISSUE_TEMPLATE/adding-a-new-task-.md
+++ b/.github/ISSUE_TEMPLATE/adding-a-new-task-.md
@@ -18,4 +18,4 @@ Note that you're not expected to do all of the following steps. This PR helps tr
 - [ ] Added basic UI elements (icon, order specification, etc)
 - [ ] Added a widget
 
-Integration guide: https://hf.co/docs/hub/adding-a-task
+Integration guide: https://hf.co/docs/hub/models-tasks

--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -58,6 +58,9 @@
         title: TensorBoard
   - local: models-widgets
     title: Model Widgets
+    sections:
+      - local: models-widgets-examples
+        title: Widget Examples
   - local: models-inference
     title: Inference API docs
   - local: models-faq

--- a/docs/hub/models-inference.md
+++ b/docs/hub/models-inference.md
@@ -12,7 +12,7 @@ On top of `Pipelines` and depending on the model type, there are several product
 - maintaining a Least Recently Used cache, ensuring that the most popular models are always loaded,
 - scaling the underlying compute infrastructure on the fly depending on the load constraints.
 
-For models from [other libraries](/docs/hub/libraries), the API uses [Starlette](https://www.starlette.io) and runs in [Docker containers](https://github.com/huggingface/api-inference-community/tree/main/docker_images). Each library defines the implementation of [different pipelines](https://github.com/huggingface/api-inference-community/tree/main/docker_images/sentence_transformers/app/pipelines).
+For models from [other libraries](./models-libraries), the API uses [Starlette](https://www.starlette.io) and runs in [Docker containers](https://github.com/huggingface/api-inference-community/tree/main/docker_images). Each library defines the implementation of [different pipelines](https://github.com/huggingface/api-inference-community/tree/main/docker_images/sentence_transformers/app/pipelines).
 
 
 ## How can I turn off the inference API for my model?

--- a/docs/hub/models-tasks.md
+++ b/docs/hub/models-tasks.md
@@ -25,7 +25,7 @@ To begin the process, open a new issue in the [huggingface_hub](https://github.c
 The first step is to upload a model for your proposed task. Once you have a model in the Hub for the new task, the next step is to enable it in the Inference API. There are three types of support that you can choose from:
 
 * 🤗 using a `transformers` model
-* 🐳 using a model from an [officially supported library](/docs/hub/libraries)
+* 🐳 using a model from an [officially supported library](./models-libraries)
 * 🖨️ using a model with custom inference code. This experimental option has downsides, so we recommend using one of the other approaches.
 
 Finally, you can add a couple of UI elements, such as the task icon and the widget, that complete the integration in the Hub. 📷 

--- a/docs/hub/models-uploading.md
+++ b/docs/hub/models-uploading.md
@@ -53,7 +53,7 @@ You can add metadata to your model card. You can specify:
 * license
 * a lot more!
 
-Read more about model tags [here](/docs/hub/model-repos#model-card-metadata).
+Read more about model tags [here](./models-cards#model-card-metadata).
 
 6. Add TensorBoard traces
 

--- a/docs/hub/models-widgets-examples.md
+++ b/docs/hub/models-widgets-examples.md
@@ -1,0 +1,303 @@
+# Widget Examples
+
+## Natural Language Processing
+
+### Fill-Mask
+
+```yaml
+widget:
+- text: "Paris is the <mask> of France."
+  example_title: "Capital"
+- text: "The goal of life is <mask>."
+  example_title: "Philosophy"
+```
+
+### Question Answering
+
+```yaml
+widget:
+- text: "What's my name?"
+  context: "My name is Clara and I live in Berkeley."
+  example_title: "Name"
+- text: "Where do I live?"
+  context: "My name is Sarah and I live in London"
+  example_title: "Location"
+```
+
+### Summarization
+
+```yaml
+widget:
+- text: "The tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building, and the tallest structure in Paris. Its base is square, measuring 125 metres (410 ft) on each side. During its construction, the Eiffel Tower surpassed the Washington Monument to become the tallest man-made structure in the world, a title it held for 41 years until the Chrysler Building in New York City was finished in 1930. It was the first structure to reach a height of 300 metres. Due to the addition of a broadcasting aerial at the top of the tower in 1957, it is now taller than the Chrysler Building by 5.2 metres (17 ft). Excluding transmitters, the Eiffel Tower is the second tallest free-standing structure in France after the Millau Viaduct."
+  example_title: "Eiffel Tower"
+- text: "Laika, a dog that was the first living creature to be launched into Earth orbit, on board the Soviet artificial satellite Sputnik 2, on November 3, 1957. It was always understood that Laika would not survive the mission, but her actual fate was misrepresented for decades. Laika was a small (13 pounds [6 kg]), even-tempered, mixed-breed dog about two years of age. She was one of a number of stray dogs that were taken into the Soviet spaceflight program after being rescued from the streets. Only female dogs were used because they were considered to be anatomically better suited than males for close confinement."
+  example_title: "First in Space"
+```
+
+### Table Question Answering
+
+```yaml
+widget:
+- text: "How many stars does the transformers repository have?"
+  table:
+    Repository:
+      - "Transformers"
+      - "Datasets"
+      - "Tokenizers"
+    Stars:
+      - 36542
+      - 4512
+      - 3934
+    Contributors:
+      - 651
+      - 77
+      - 34
+    Programming language:
+      - "Python"
+      - "Python"
+      - "Rust, Python and NodeJS"
+  example_title: "Github stars"
+```
+
+### Text Classification
+
+```yaml
+widget:
+- text: "I love football so much"
+  example_title: "Positive"
+- text: "I don't really like this type of food"
+  example_title: "Negative"
+```
+
+### Text Generation
+
+```yaml
+widget:
+- text: "My name is Julien and I like to"
+  example_title: "Julien"
+- text: "My name is Merve and my favorite"
+  example_title: "Merve"
+```
+
+### Text2Text Generation
+
+```yaml
+widget:
+- text: "My name is Julien and I like to"
+  example_title: "Julien"
+- text: "My name is Merve and my favorite"
+  example_title: "Merve"
+```
+
+### Token Classification
+
+```yaml
+widget:
+- text: "My name is Sylvain and I live in Paris"
+  example_title: "Parisian"
+- text: "My name is Sarah and I live in London"
+  example_title: "Londoner"
+```
+
+### Translation
+
+```yaml
+widget:
+- text: "My name is Sylvain and I live in Paris"
+  example_title: "Parisian"
+- text: "My name is Sarah and I live in London"
+  example_title: "Londoner"
+```
+
+### Zero-Shot Classification
+
+```yaml
+widget:
+- text: "I have a problem with my car that needs to be resolved asap!!"
+  candidate_labels: "urgent, not urgent, phone, tablet, computer"
+  multi_class: true
+  example_title: "Car problem"
+- text: "Last week I upgraded my iOS version and ever since then my phone has been overheating whenever I use your app."
+  candidate_labels: "mobile, website, billing, account access"
+  multi_class: false
+  example_title: "Phone issue"
+```
+### Sentence Similarity
+
+```yaml
+widget:
+- source_sentence: "That is a happy person"
+  sentences:
+    - "That is a happy dog"
+    - "That is a very happy person"
+    - "Today is a sunny day"
+  example_title: "Happy"
+```
+
+### Conversational
+
+```yaml
+widget:
+- text: "Hey my name is Julien! How are you?"
+  example_title: "Julien"
+- text: "Hey my name is Clara! How are you?"
+  example_title: "Clara"
+```
+
+### Feature Extraction
+
+```yaml
+widget:
+- text: "My name is Sylvain and I live in Paris"
+  example_title: "Parisian"
+- text: "My name is Sarah and I live in London"
+  example_title: "Londoner"
+```
+
+## Audio
+
+### Text-to-Speech
+
+```yaml
+widget:
+- text: "My name is Sylvain and I live in Paris"
+  example_title: "Parisian"
+- text: "My name is Sarah and I live in London"
+  example_title: "Londoner"
+```
+
+### Automatic Speech Recognition
+
+```yaml
+widget:
+- src: https://cdn-media.huggingface.co/speech_samples/sample1.flac
+  example_title: Librispeech sample 1
+- src: https://cdn-media.huggingface.co/speech_samples/sample2.flac
+  example_title: Librispeech sample 2
+```
+
+### Audio-to-Audio
+
+```yaml
+widget:
+- src: https://cdn-media.huggingface.co/speech_samples/sample1.flac
+  example_title: Librispeech sample 1
+- src: https://cdn-media.huggingface.co/speech_samples/sample2.flac
+  example_title: Librispeech sample 2
+```
+
+### Audio Classification
+
+```yaml
+widget:
+- src: https://cdn-media.huggingface.co/speech_samples/sample1.flac
+  example_title: Librispeech sample 1
+- src: https://cdn-media.huggingface.co/speech_samples/sample2.flac
+  example_title: Librispeech sample 2
+```
+
+### Voice Activity Detection
+
+```yaml
+widget:
+- src: https://cdn-media.huggingface.co/speech_samples/sample1.flac
+  example_title: Librispeech sample 1
+- src: https://cdn-media.huggingface.co/speech_samples/sample2.flac
+  example_title: Librispeech sample 2
+```
+
+## Computer Vision
+
+### Image Classification
+
+```yaml
+widget:
+- src: https://huggingface.co/datasets/mishig/sample_images/resolve/main/tiger.jpg
+  example_title: Tiger
+- src: https://huggingface.co/datasets/mishig/sample_images/resolve/main/teapot.jpg
+  example_title: Teapot
+```
+
+### Object Detection
+
+```yaml
+widget:
+- src: https://huggingface.co/datasets/mishig/sample_images/resolve/main/football-match.jpg
+  example_title: Football Match
+- src: https://huggingface.co/datasets/mishig/sample_images/resolve/main/airport.jpg
+  example_title: Airport
+```
+
+### Image Segmentation
+
+```yaml
+widget:
+- src: https://huggingface.co/datasets/mishig/sample_images/resolve/main/football-match.jpg
+  example_title: Football Match
+- src: https://huggingface.co/datasets/mishig/sample_images/resolve/main/airport.jpg
+  example_title: Airport
+```
+
+### Text-to-Image
+
+```yaml
+widget:
+- text: "A cat playing with a ball"
+  example_title: "Cat"
+- text: "A dog jumping over a fence"
+  example_title: "Dog"
+```
+
+## Other
+
+### Structured Data Classification
+
+```yaml
+widget:
+  structuredData:
+    fixed_acidity:
+      - 7.4
+      - 7.8
+      - 10.3
+    volatile_acidity:
+      - 0.7
+      - 0.88
+      - 0.32
+    citric_acid:
+      - 0
+      - 0
+      - 0.45
+    residual_sugar:
+      - 1.9
+      - 2.6
+      - 6.4
+    chlorides:
+      - 0.076
+      - 0.098
+      - 0.073
+    free_sulfur_dioxide:
+      - 11
+      - 25
+      - 5
+    total_sulfur_dioxide:
+      - 34
+      - 67
+      - 13
+    density:
+      - 0.9978
+      - 0.9968
+      - 0.9976
+    pH:
+      - 3.51
+      - 3.2
+      - 3.23
+    sulphates:
+      - 0.56
+      - 0.68
+      - 0.82
+    alcohol:
+      - 9.4
+      - 9.8
+      - 12.6
+  example_title: "Wine"
+```

--- a/docs/hub/models-widgets.md
+++ b/docs/hub/models-widgets.md
@@ -50,7 +50,7 @@ widget:
   example_title: "Reading comprehension"
 ```
 
-Moreover, you can specify non-text example inputs in the model card metadata. Refer [here](https://github.com/huggingface/hub-docs/blob/main/docs/hub/input-examples.md) for a complete list of sample input formats for all widget types. For vision & audio widget types, provide example inputs with `src` rather than `text`. 
+Moreover, you can specify non-text example inputs in the model card metadata. Refer [here](./models-widgets-examples) for a complete list of sample input formats for all widget types. For vision & audio widget types, provide example inputs with `src` rather than `text`. 
 
 For example, allow users to choose from two sample audio files for automatic speech recognition tasks by:
 

--- a/docs/hub/models.md
+++ b/docs/hub/models.md
@@ -11,6 +11,7 @@ The Hugging Face Hub hosts many models for a [variety of machine learning tasks]
 - [Uploading Models](./models-uploading)
 - [Downloading Models](./models-downloading)
 - [Widgets](./models-widgets)
+  - [Widget Examples](./models-widgets-examples)
 - [Inference API](./models-inference)
 - [Frequently Asked Questions](./models-faq)
 - [Advanced Topics](./models-advanced)

--- a/modelcard.md
+++ b/modelcard.md
@@ -2,7 +2,7 @@
 language:
 - {lang_0}  # Example: fr
 - {lang_1}  # Example: en
-license: {license}  # Example: apache-2.0 or any license from https://hf.co/docs/hub/model-repos#list-of-license-identifiers
+license: {license}  # Example: apache-2.0 or any license from https://hf.co/docs/hub/repositories-licenses
 library_name: {library_name}  # Optional. Example: keras or any library from https://github.com/huggingface/huggingface_hub/blob/main/js/src/lib/interfaces/Libraries.ts
 tags:
 - {tag_0}  # Example: audio
@@ -41,4 +41,4 @@ model-index:
 ---
 
 This markdown file contains the spec for the modelcard metadata regarding evaluation parameters. When present, and only then, 'model-index', 'datasets' and 'license' contents will be verified when git pushing changes to your README.md file.
-Valid license identifiers can be found in [our docs](https://huggingface.co/docs/hub/model-repos#list-of-license-identifiers)
+Valid license identifiers can be found in [our docs](https://huggingface.co/docs/hub/repositories-licenses)


### PR DESCRIPTION
Some paths needed to be updated, due to the revamp. Also, the Widget Examples page had been omitted from the revamp by mistake.