### PR TITLE
Shorter anchor for adding files with terminal

### DIFF
--- a/docs/hub/repositories-getting-started.md
+++ b/docs/hub/repositories-getting-started.md
@@ -76,7 +76,7 @@ If you choose _Upload file_ you'll be able to choose a local file to upload, alo
 
 As with creating new files, you can select `Open as a pull request` to create a [Pull Request](./repositories-pull-requests-discussions) instead of adding your changes directly to the `main` branch of your repo.
 
-## Adding files to a repository (terminal)
+## Adding files to a repository (terminal)[[terminal]]
 
 ### Cloning repositories
 


### PR DESCRIPTION
There is a way to customize anchor links (read more [here](https://github.com/huggingface/doc-builder/pull/242/files))

Needed for [here](https://github.com/huggingface/moon-landing/pull/3132#discussion_r888085183)