### PR TITLE
Fix nit in Sentence Transformers section

### DIFF
--- a/docs/hub/sentence-transformers.md
+++ b/docs/hub/sentence-transformers.md
@@ -1,7 +1,3 @@
----
-title: Sentence Transformers
----
-
 # Using Sentence Transformers at Hugging Face
 
 `sentence-transformers` is a library that provides easy methods to compute embeddings (dense vector representations) for sentences, paragraphs and images. Texts are embedded in a vector space such that similar text is close, which enables applications such as semantic search, clustering, and retrieval. 


### PR DESCRIPTION
## Description
Eliminate `title: Sentence Transformers` from the top of the `md` (see image below).

<img width="964" alt="image" src="https://user-images.githubusercontent.com/4755430/172028700-015b41c9-d357-4b7f-b8ef-2ffa8485abae.png">
