### PR TITLE
[Spaces] Configuration reference newlines

### DIFF
--- a/docs/hub/spaces-config-reference.md
+++ b/docs/hub/spaces-config-reference.md
@@ -2,41 +2,41 @@
 
 Spaces are configured through the `YAML` block at the top of the **README.md** file at the root of the repository. All the accepted parameters are listed below.
 
-**`title`** : _string_
-Display title for the Space.
+**`title`** : _string_  
+Display title for the Space.  
 
-**`emoji`** : _string_
-Space emoji (emoji-only character allowed).
+**`emoji`** : _string_  
+Space emoji (emoji-only character allowed).  
 
-**`colorFrom`** : _string_
-Color for Thumbnail gradient (red, yellow, green, blue, indigo, purple, pink, gray).
+**`colorFrom`** : _string_  
+Color for Thumbnail gradient (red, yellow, green, blue, indigo, purple, pink, gray).  
 
-**`colorTo`** : _string_
-Color for Thumbnail gradient (red, yellow, green, blue, indigo, purple, pink, gray).
+**`colorTo`** : _string_  
+Color for Thumbnail gradient (red, yellow, green, blue, indigo, purple, pink, gray).  
 
-**`sdk`** : _string_
-Can be either `gradio`, `streamlit` or `static`.
+**`sdk`** : _string_  
+Can be either `gradio`, `streamlit` or `static`.  
 
-**`python_version`**: _string_
-Any valid Python `3.x` or `3.x.x` version.
-Defaults to `3.8.9`.
+**`python_version`**: _string_  
+Any valid Python `3.x` or `3.x.x` version.  
+Defaults to `3.8.9`.  
 
-**`sdk_version`** : _string_
-Specify the version of the selected SDK (Streamlit or Gradio).
-All versions of Gradio are supported.
-Streamlit versions are supported from `0.79.0` to `1.2.0`.
+**`sdk_version`** : _string_  
+Specify the version of the selected SDK (Streamlit or Gradio).  
+All versions of Gradio are supported.  
+Streamlit versions are supported from `0.79.0` to `1.2.0`.  
 
-**`app_file`** : _string_
-Path to your main application file (which contains either `gradio` or `streamlit` Python code, or `static` html code).
-Path is relative to the root of the repository.
+**`app_file`** : _string_  
+Path to your main application file (which contains either `gradio` or `streamlit` Python code, or `static` html code).  
+Path is relative to the root of the repository.  
 
-**`models`** : _List[string]_
-HF model IDs (like `gpt2` or `deepset/roberta-base-squad2`) used in the Space.
-Will be parsed automatically from your code if not specified here.
+**`models`** : _List[string]_  
+HF model IDs (like `gpt2` or `deepset/roberta-base-squad2`) used in the Space.  
+Will be parsed automatically from your code if not specified here.  
 
-**`datasets`** : _List[string]_
-HF dataset IDs (like `common_voice` or `oscar-corpus/OSCAR-2109`) used in the Space.
-Will be parsed automatically from your code if not specified here.
+**`datasets`** : _List[string]_  
+HF dataset IDs (like `common_voice` or `oscar-corpus/OSCAR-2109`) used in the Space.  
+Will be parsed automatically from your code if not specified here.  
 
-**`pinned`** : _boolean_
-Whether the Space stays on top of your profile. Can be useful if you have a lot of Spaces so you and others can quickly see your best Space.
+**`pinned`** : _boolean_  
+Whether the Space stays on top of your profile. Can be useful if you have a lot of Spaces so you and others can quickly see your best Space.  


### PR DESCRIPTION
Actually render new lines in the hub documentation

Before :
<img width="938" alt="Screenshot 2022-06-05 at 18 53 09" src="https://user-images.githubusercontent.com/11795593/172061464-1926e32d-2925-4e08-b2f2-030c505b38a8.png">

After :
<img width="940" alt="Screenshot 2022-06-05 at 18 52 37" src="https://user-images.githubusercontent.com/11795593/172061452-b07e2ff9-d6b7-4e57-b883-bf9400a2d39a.png">