### PR TITLE
Bring back PR advanced guide

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -10,6 +10,9 @@
     title: Repository Settings
   - local: repositories-pull-requests-discussions
     title: Pull Requests & Discussions
+    sections:
+    - local: repositories-pull-requests-advanced
+      title: Advanced Usage
   - local: repositories-next-steps
     title: Next Steps    
   - local: repositories-licenses

--- a/docs/hub/repositories-getting-started.md
+++ b/docs/hub/repositories-getting-started.md
@@ -76,7 +76,7 @@ If you choose _Upload file_ you'll be able to choose a local file to upload, alo
 
 As with creating new files, you can select `Open as a pull request` to create a [Pull Request](./repositories-pull-requests-discussions) instead of adding your changes directly to the `main` branch of your repo.
 
-## Adding files to a repository (terminal)
+## Adding files to a repository (terminal)[[terminal]]
 
 ### Cloning repositories
 

--- a/docs/hub/repositories-pull-requests-advanced.md
+++ b/docs/hub/repositories-pull-requests-advanced.md
@@ -1,0 +1,48 @@
+# Pull requests advanced usage
+
+## Advanced: for Pull requests, where in the git repo are changes stored?
+
+Our Pull requests do not use forks and branches, but instead custom "branches" called `refs` that are stored directly on the source repo.
+
+[Git References](https://git-scm.com/book/en/v2/Git-Internals-Git-References) are the internal machinery of git which already stores tags and branches.
+
+The advantage of using custom refs (like `refs/pr/42` for instance) instead of branches is that they're not fetched (by default) by people (including the repo "owner") cloning the repo, but they can still be fetched on demand.
+
+## Advanced: how do I locally check out a Pull request then?
+
+Let's assume your PR number is 42:
+
+```bash
+git fetch origin refs/pr/42:pr/42
+git checkout pr/42
+git push origin pr/42:refs/pr/42
+```
+
+## Even more advanced: for git magicians 🧙‍♀️
+
+You can tweak your local **refspec** to fetch all Pull requests:
+
+1. Add this refspec to your .git/config:
+
+```bash
+[remote "origin"]
+	fetch = +refs/pr/*:refs/remotes/origin/pr/*
+```
+
+2. Fetch
+
+```bash
+git fetch
+```
+
+3. create a local branch tracking the ref
+
+```bash
+git co pr/:num
+```
+
+4. IF you make local changes, to push to the PR ref:
+
+```bash
+git push origin pr/42:refs/pr/42
+```


### PR DESCRIPTION
https://huggingface.co/docs/hub/repositories-pull-requests-advanced was removed accidentally?

Bringing it back at https://moon-ci-docs.huggingface.co/docs/hub/pr_188/en/repositories-pull-requests-advanced