### PR TITLE
Bump supported Streamlit versions

### DIFF
--- a/docs/hub/spaces-config-reference.md
+++ b/docs/hub/spaces-config-reference.md
@@ -26,7 +26,7 @@ Defaults to `3.8.9`.
 **`sdk_version`** : _string_  
 Specify the version of the selected SDK (Streamlit or Gradio).  
 All versions of Gradio are supported.  
-Streamlit versions are supported from `0.79.0` to `1.2.0`.  
+Streamlit versions are supported from `0.79.0` to `1.10.0`.  
 
 **`app_file`** : _string_  
 Path to your main application file (which contains either `gradio` or `streamlit` Python code, or `static` html code).  

--- a/docs/hub/spaces-sdks-streamlit.md
+++ b/docs/hub/spaces-sdks-streamlit.md
@@ -8,7 +8,7 @@ To use Streamlit in a Space, select **Streamlit** as the SDK when you create a S
 
 ```yaml
 sdk: streamlit
-sdk_version: 1.2.0 # The latest supported version
+sdk_version: 1.10.0 # The latest supported version
 ```
 
 You can edit the `sdk_version`, but note that issues may occur when you use an unsupported Streamlit version. Not all Streamlit versions are supported, so please refer to the [reference section](./spaces-config-reference) to see which versions are available.


### PR DESCRIPTION
This PR bumps the list of supported Streamlit versions to v1.10.0

* Tweet: https://twitter.com/charlesbben/status/1534944089803829248?s=20&t=FNqW3ZMWUvyRRs9A1cSb9Q
* Internal Slack thread: https://huggingface.slack.com/archives/C02136Y252P/p1654759216920019