### PR TITLE
Add the diffusers library snippet

### DIFF
--- a/docs/hub/models-libraries.md
+++ b/docs/hub/models-libraries.md
@@ -4,25 +4,26 @@ The Hub has support for dozens of libraries in the Open Source ecosystem. Thanks
 
 The table below summarizes the supported libraries and their level of integration. Find all our supported libraries [here](https://github.com/huggingface/hub-docs/blob/main/js/src/lib/interfaces/Libraries.ts)! 
 
-| Library | Description | Inference API | Widgets | Download from Hub | Push to Hub |
-|---|---|---|---:|---|---|
-| [🤗 Transformers](https://github.com/huggingface/transformers) | State-of-the-art Natural Language Processing for Pytorch, TensorFlow, and JAX | ✅ | ✅ | ✅ | ✅ |
-| [Adapter Transformers](https://github.com/Adapter-Hub/adapter-transformers) | Extends 🤗Transformers with Adapters. | ❌ | ❌ | ✅ | ✅ |
-| [AllenNLP](https://github.com/allenai/allennlp) | An open-source NLP research library, built on PyTorch. | ✅ | ✅ | ✅ | ❌ |
-| [Asteroid](https://github.com/asteroid-team/asteroid) | Pytorch-based audio source separation toolkit | ✅ | ✅ | ✅ | ❌ |
-| [docTR](https://github.com/mindee/doctr) | Models and datasets for OCR-related tasks in PyTorch & TensorFlow | ✅ | ✅ | ✅ | ❌ |
-| [ESPnet](https://github.com/espnet/espnet) | End-to-end speech processing toolkit (e.g. TTS) | ✅ | ✅ | ✅ | ❌ |
-| [fastai](https://github.com/fastai/fastai) | Library to train fast and accurate models with state-of-the-art outputs. | ✅ | ✅ | ✅ | ✅ |
-| [Flair](https://github.com/flairNLP/flair) | Very simple framework for state-of-the-art NLP. | ✅ | ✅ | ✅ | ❌ |
-| [NeMo](https://github.com/NVIDIA/NeMo) | Conversational AI toolkit built for researchers | ✅ | ✅ | ✅ | ❌ |
-| [Pyannote](https://github.com/pyannote/pyannote-audio) | Neural building blocks for speaker diarization. | ❌ | ❌ | ✅ | ❌ |
-| [PyCTCDecode](https://github.com/kensho-technologies/pyctcdecode) | Language model supported CTC decoding for speech recognition | ❌ | ❌ | ✅ | ❌ |
-| [Sentence Transformers](https://github.com/UKPLab/sentence-transformers) | Compute dense vector representations for sentences, paragraphs, and images. | ✅ | ✅ | ✅ | ✅ |
-| [spaCy](https://github.com/explosion/spaCy) | Advanced Natural Language Processing in Python and Cython. | ✅ | ✅ | ✅ | ✅ |
-| [Speechbrain](https://speechbrain.github.io/) | A PyTorch Powered Speech Toolkit. | ✅ | ✅ | ✅ | ❌ |
-| [Stable-Baselines3](https://github.com/DLR-RM/stable-baselines3) | Set of reliable implementations of deep reinforcement learning algorithms in PyTorch | ❌ | ✅ | ✅ | ✅ |
-| [TensorFlowTTS](https://github.com/TensorSpeech/TensorFlowTTS) | Real-time state-of-the-art speech synthesis architectures. | ❌ | ❌ | ✅ | ❌ |
-| [Timm](https://github.com/rwightman/pytorch-image-models) | Collection of image models, scripts, pretrained weights, etc. | ❌ | ❌ | ✅ | ❌ |
+| Library                                                                     | Description                                                                          | Inference API | Widgets | Download from Hub | Push to Hub |
+|-----------------------------------------------------------------------------|--------------------------------------------------------------------------------------|---|---:|---|---|
+| [🤗 Transformers](https://github.com/huggingface/transformers)              | State-of-the-art Natural Language Processing for Pytorch, TensorFlow, and JAX        | ✅ | ✅ | ✅ | ✅ |
+| [🤗 Diffusers](https://github.com/huggingface/diffusers)                    | A modular toolbox for inference and training of diffusion models                     | ❌ | ❌ | ✅ | ✅ |
+| [Adapter Transformers](https://github.com/Adapter-Hub/adapter-transformers) | Extends 🤗Transformers with Adapters.                                                | ❌ | ❌ | ✅ | ✅ |
+| [AllenNLP](https://github.com/allenai/allennlp)                             | An open-source NLP research library, built on PyTorch.                               | ✅ | ✅ | ✅ | ❌ |
+| [Asteroid](https://github.com/asteroid-team/asteroid)                       | Pytorch-based audio source separation toolkit                                        | ✅ | ✅ | ✅ | ❌ |
+| [docTR](https://github.com/mindee/doctr)                                    | Models and datasets for OCR-related tasks in PyTorch & TensorFlow                    | ✅ | ✅ | ✅ | ❌ |
+| [ESPnet](https://github.com/espnet/espnet)                                  | End-to-end speech processing toolkit (e.g. TTS)                                      | ✅ | ✅ | ✅ | ❌ |
+| [fastai](https://github.com/fastai/fastai)                                  | Library to train fast and accurate models with state-of-the-art outputs.             | ✅ | ✅ | ✅ | ✅ |
+| [Flair](https://github.com/flairNLP/flair)                                  | Very simple framework for state-of-the-art NLP.                                      | ✅ | ✅ | ✅ | ❌ |
+| [NeMo](https://github.com/NVIDIA/NeMo)                                      | Conversational AI toolkit built for researchers                                      | ✅ | ✅ | ✅ | ❌ |
+| [Pyannote](https://github.com/pyannote/pyannote-audio)                      | Neural building blocks for speaker diarization.                                      | ❌ | ❌ | ✅ | ❌ |
+| [PyCTCDecode](https://github.com/kensho-technologies/pyctcdecode)           | Language model supported CTC decoding for speech recognition                         | ❌ | ❌ | ✅ | ❌ |
+| [Sentence Transformers](https://github.com/UKPLab/sentence-transformers)    | Compute dense vector representations for sentences, paragraphs, and images.          | ✅ | ✅ | ✅ | ✅ |
+| [spaCy](https://github.com/explosion/spaCy)                                 | Advanced Natural Language Processing in Python and Cython.                           | ✅ | ✅ | ✅ | ✅ |
+| [Speechbrain](https://speechbrain.github.io/)                               | A PyTorch Powered Speech Toolkit.                                                    | ✅ | ✅ | ✅ | ❌ |
+| [Stable-Baselines3](https://github.com/DLR-RM/stable-baselines3)            | Set of reliable implementations of deep reinforcement learning algorithms in PyTorch | ❌ | ✅ | ✅ | ✅ |
+| [TensorFlowTTS](https://github.com/TensorSpeech/TensorFlowTTS)              | Real-time state-of-the-art speech synthesis architectures.                           | ❌ | ❌ | ✅ | ❌ |
+| [Timm](https://github.com/rwightman/pytorch-image-models)                   | Collection of image models, scripts, pretrained weights, etc.                        | ❌ | ❌ | ✅ | ❌ |
 
 ### How can I add a new library to the Inference API?
 

--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -7,6 +7,7 @@ export enum ModelLibrary {
 	"adapter-transformers"   = "Adapter Transformers",
 	"allennlp"               = "allenNLP",
 	"asteroid"               = "Asteroid",
+	"diffusers"              = "Diffusers",
 	"espnet"                 = "ESPnet",
 	"fairseq"                = "Fairseq",
 	"flair"                  = "Flair",
@@ -90,6 +91,11 @@ const asteroid = (model: ModelData) =>
 	`from asteroid.models import BaseModel
 
 model = BaseModel.from_pretrained("${model.id}")`;
+
+const diffusers = (model: ModelData) =>
+	`from diffusers import DiffusionPipeline
+
+pipeline = DiffusionPipeline.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""})`;
 
 const espnetTTS = (model: ModelData) =>
 	`from espnet2.bin.tts_inference import Text2Speech
@@ -366,6 +372,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS: { [key in keyof typeof ModelLibrary]?:
 		repoName: "Asteroid",
 		repoUrl:  "https://github.com/asteroid-team/asteroid",
 		snippet:  asteroid,
+	},
+	"diffusers": {
+		btnLabel: "Diffusers",
+		repoName: "🤗/diffusers",
+		repoUrl:  "https://github.com/huggingface/diffusers",
+		snippet:  diffusers,
 	},
 	"espnet": {
 		btnLabel: "ESPnet",


### PR DESCRIPTION
This adds the [huggingafce/diffusers] library and snippet.

All current use cases are covered by the `DiffusionPipeline.from_pretrained()` line, here's an example: https://huggingface.co/fusing/glide-base#usage

cc @osanseviero @patrickvonplaten @patil-suraj
