### PR TITLE
Show realtime ASR on transformers only

### DIFF
--- a/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -169,18 +169,20 @@
 						onError={onRecordError}
 					/>
 				{/if}
-				{#if !isRealtimeRecording}
-					<span class="mt-1.5 mx-2">or</span>
+				{#if model?.library_name === "transformers"}
+					{#if !isRealtimeRecording}
+						<span class="mt-1.5 mx-2">or</span>
+					{/if}
+					<WidgetRealtimeRecorder
+						classNames="mt-1.5"
+						{apiToken}
+						{model}
+						{updateModelLoading}
+						onRecordStart={() => (isRealtimeRecording = true)}
+						onRecordStop={() => (isRealtimeRecording = false)}
+						onError={onRecordError}
+					/>
 				{/if}
-				<WidgetRealtimeRecorder
-					classNames="mt-1.5"
-					{apiToken}
-					{model}
-					{updateModelLoading}
-					onRecordStart={() => (isRealtimeRecording = true)}
-					onRecordStop={() => (isRealtimeRecording = false)}
-					onError={onRecordError}
-				/>
 			</div>
 			{#if !isRealtimeRecording}
 				{#if fileUrl}

--- a/js/src/lib/interfaces/Types.ts
+++ b/js/src/lib/interfaces/Types.ts
@@ -684,6 +684,11 @@ export interface ModelData {
 			parameters?: Record<string, any>;
 		};
 	};
+	/**
+	 * Library name
+	 * Example: transformers, SpeechBrain, Stanza, etc.
+	 */
+	library_name?: string;
 }
 
 


### PR DESCRIPTION
Currently, only transformers models are supported by realtime ASR.
Therefore, show realtime ASR btn only on transformers checkpoints

transformers checkpoint:
<img width="400" alt="Screenshot 2022-06-27 at 15 06 34" src="https://user-images.githubusercontent.com/11827707/175949292-ef964143-1587-4b50-b5f8-a36ef4638448.png">
non-transformers checkpoint:
<img width="400" alt="Screenshot 2022-06-27 at 15 06 16" src="https://user-images.githubusercontent.com/11827707/175949301-d3c8c4b6-3b14-413d-832d-6db30f445454.png">

