### PR TITLE
Implement grouped input samples

### DIFF
--- a/js/src/lib/components/Icons/IconCaretDownV2.svelte
+++ b/js/src/lib/components/Icons/IconCaretDownV2.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	export let classNames = "";
+</script>
+
+<svg
+	class={classNames}
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 20 20"
+	fill="currentColor"
+	aria-hidden="true"
+>
+	<path
+		fill-rule="evenodd"
+		d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+		clip-rule="evenodd"
+	/>
+</svg>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetInputSamples/WidgetInputSamples.svelte
@@ -65,7 +65,7 @@
 	bind:this={containerEl}
 >
 	<div
-		class="no-hover:hidden inline-flex justify-between w-32 lg:w-44 rounded-md border border-gray-100 px-4 py-1"
+		class="no-hover:hidden inline-flex justify-between w-32 rounded-md border border-gray-100 px-4 py-1"
 		on:click={toggleOptionsVisibility}
 	>
 		<div class="text-sm truncate">{title}</div>
@@ -75,7 +75,7 @@
 		/>
 	</div>
 	<div
-		class="with-hover:hidden inline-flex justify-between w-32 lg:w-44 rounded-md border border-gray-100 px-4 py-1"
+		class="with-hover:hidden inline-flex justify-between w-32 rounded-md border border-gray-100 px-4 py-1"
 		on:click={toggleOptionsVisibility}
 	>
 		<div class="text-sm truncate">{title}</div>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetInputSamplesGroup/WidgetInputSamplesGroup.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetInputSamplesGroup/WidgetInputSamplesGroup.svelte
@@ -1,37 +1,21 @@
 <script lang="ts">
-	import type { WidgetInputSample } from "../../../../interfaces/Types";
 	import { slide } from "svelte/transition";
 	import IconCaretDownV2 from "../../../Icons/IconCaretDownV2.svelte";
 
 	export let classNames = "";
 	export let isLoading = false;
-	export let inputSamples: WidgetInputSample[];
-	export let applyInputSample: (sample: Record<string, any>) => void;
-	export let previewInputSample: (sample: Record<string, any>) => void;
+	export let inputGroups: string[];
+	export let selectedInputGroup: string;
 
 	let containerEl: HTMLElement;
 	let isOptionsVisible = false;
-	let title = "Examples";
+	let title = "Groups";
 
-	$: {
-		// reset title on inputSamples change (i.e. input group change)
-		inputSamples;
-		title = "Examples";
-	}
-
-	function _applyInputSample(idx: number) {
+	function chooseInputGroup(idx: number) {
 		hideOptions();
-		const sample = inputSamples[idx];
-		title = sample.example_title;
-		applyInputSample(sample);
-	}
-
-	function _previewInputSample(idx: number, isTouch = false) {
-		const sample = inputSamples[idx];
-		previewInputSample(sample);
-		if (isTouch) {
-			_applyInputSample(idx);
-		}
+		const inputGroup = inputGroups[idx];
+		title = inputGroup;
+		selectedInputGroup = inputGroup;
 	}
 
 	function toggleOptionsVisibility() {
@@ -91,20 +75,12 @@
 			transition:slide
 		>
 			<div class="py-1 bg-white rounded-md" role="none">
-				{#each inputSamples as { example_title }, i}
+				{#each inputGroups as inputGroup, i}
 					<div
-						class="no-hover:hidden px-4 py-2 text-sm truncate hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-						on:mouseover={() => _previewInputSample(i)}
-						on:click={() => _applyInputSample(i)}
+						class="px-4 py-2 text-sm truncate hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+						on:click={() => chooseInputGroup(i)}
 					>
-						{example_title}
-					</div>
-					<!-- Better UX for mobile/table through CSS breakpoints -->
-					<div
-						class="with-hover:hidden px-4 py-2 text-sm truncate hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-						on:click={() => _previewInputSample(i, true)}
-					>
-						{example_title}
+						{inputGroup}
 					</div>
 				{/each}
 			</div>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetInputSamplesGroup/WidgetInputSamplesGroup.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetInputSamplesGroup/WidgetInputSamplesGroup.svelte
@@ -49,7 +49,7 @@
 	bind:this={containerEl}
 >
 	<div
-		class="no-hover:hidden inline-flex justify-between w-32 lg:w-44 rounded-md border border-gray-100 px-4 py-1"
+		class="no-hover:hidden inline-flex justify-between w-32 rounded-md border border-gray-100 px-4 py-1"
 		on:click={toggleOptionsVisibility}
 	>
 		<div class="text-sm truncate">{title}</div>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import type { WidgetProps, LoadingStatus } from "../types";
+	import type { WidgetInputSample } from "../../../../interfaces/Types";
 
 	import { onMount } from "svelte";
 	import IconCross from "../../../Icons/IconCross.svelte";
 	import WidgetInputSamples from "../WidgetInputSamples/WidgetInputSamples.svelte";
+	import WidgetInputSamplesGroup from "../WidgetInputSamplesGroup/WidgetInputSamplesGroup.svelte";
 	import WidgetFooter from "../WidgetFooter/WidgetFooter.svelte";
 	import WidgetHeader from "../WidgetHeader/WidgetHeader.svelte";
 	import WidgetInfo from "../WidgetInfo/WidgetInfo.svelte";
@@ -28,14 +30,37 @@
 
 	let isMaximized = false;
 	let modelStatus: LoadingStatus = "unknown";
+	let selectedInputGroup: string;
 
-	const inputSamples: Record<string, any>[] = (model?.widgetData ?? [])
+	const inputSamples: WidgetInputSample[] = (model?.widgetData ?? [])
 		.sort(
 			(sample1, sample2) =>
 				(sample2.example_title ? 1 : 0) - (sample1.example_title ? 1 : 0)
 		)
-		.map((sample, idx) => ({ example_title: `Example ${++idx}`, ...sample }))
-		.slice(0, 5);
+		.map((sample, idx) => ({
+			example_title: `Example ${++idx}`,
+			group: "Group 1",
+			...sample,
+		}));
+
+	const inputGroups: { group: string; inputSamples: WidgetInputSample[] }[] =
+		[];
+	for (const inputSample of inputSamples) {
+		const isExist = inputGroups.find(
+			({ group }) => group === inputSample.group
+		);
+		if (!isExist) {
+			inputGroups.push({ group: inputSample.group, inputSamples: [] });
+		}
+		inputGroups
+			.find(({ group }) => group === inputSample.group)
+			?.inputSamples.push(inputSample);
+	}
+
+	$: selectedInputSamples =
+		inputGroups.length === 1
+			? inputGroups[0]
+			: inputGroups.find(({ group }) => group === selectedInputGroup);
 
 	onMount(() => {
 		getModelStatus(apiUrl, model.id).then((status) => {
@@ -58,14 +83,26 @@
 		</button>
 	{/if}
 	<WidgetHeader {noTitle} pipeline={model.pipeline_tag}>
-		{#if inputSamples.length}
-			<!-- Show samples selector when there are more than one sample -->
-			<WidgetInputSamples
-				{isLoading}
-				{inputSamples}
-				{applyInputSample}
-				{previewInputSample}
-			/>
+		{#if !!inputGroups.length}
+			<div class="ml-auto flex gap-x-1">
+				<!-- Show samples selector when there are more than one sample -->
+				{#if inputGroups.length > 1}
+					<WidgetInputSamplesGroup
+						bind:selectedInputGroup
+						{isLoading}
+						inputGroups={inputGroups.map(({ group }) => group)}
+					/>
+				{/if}
+				<WidgetInputSamples
+					classNames={!selectedInputSamples
+						? "opacity-70 pointer-events-none"
+						: ""}
+					{isLoading}
+					inputSamples={selectedInputSamples?.inputSamples ?? []}
+					{applyInputSample}
+					{previewInputSample}
+				/>
+			</div>
 		{/if}
 	</WidgetHeader>
 	<slot name="top" />

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -95,7 +95,7 @@
 				{/if}
 				<WidgetInputSamples
 					classNames={!selectedInputSamples
-						? "opacity-70 pointer-events-none"
+						? "opacity-50 pointer-events-none"
 						: ""}
 					{isLoading}
 					inputSamples={selectedInputSamples?.inputSamples ?? []}

--- a/js/src/lib/interfaces/Types.ts
+++ b/js/src/lib/interfaces/Types.ts
@@ -625,6 +625,7 @@ export const PIPELINE_TAGS_DISPLAY_ORDER: Array<PipelineType> = [
 	"time-series-forecasting",
 ];
 
+export type WidgetInputSample = Record<string | "example_title" | "group", string>;
 
 /**
  * Public interface for model metadata
@@ -668,7 +669,7 @@ export interface ModelData {
 	 * can be set in the model card metadata (under `widget`),
 	 * or by default in `DefaultWidget.ts`
 	 */
-	widgetData?: Record<string, any>[] | undefined;
+	widgetData?: WidgetInputSample[] | undefined;
 	/**
 	 * Parameters that will be used by the widget when calling Inference API
 	 * https://api-inference.huggingface.co/docs/python/html/detailed_parameters.html

--- a/js/src/routes/index.svelte
+++ b/js/src/routes/index.svelte
@@ -5,6 +5,18 @@
 
 	const models: ModelData[] = [
 		{
+			id: "roberta-large-mnli",
+			pipeline_tag: "text-classification",
+			widgetData: [
+				{ text: "I like you. I love you.", group: "Contradiction" },
+				{ text: "This is good. This is bad.", group: "Contradiction" },
+				{ text: "He runs fast. He runs slow", group: "Contradiction" },
+				{ text: "I like you", group: "Neutral" },
+				{ text: "This is good", group: "Neutral" },
+				{ text: "He runs fast", group: "Neutral" },
+			],
+		},
+		{
 			id: "edbeeching/decision-transformer-gym-hopper-medium-replay",
 			pipeline_tag: "reinforcement-learning",
 		},
@@ -29,11 +41,6 @@
 			id: "sentence-transformers/distilbert-base-nli-stsb-mean-tokens",
 			pipeline_tag: "feature-extraction",
 			widgetData: [{ text: "Hello, world" }],
-		},
-		{
-			id: "roberta-large-mnli",
-			pipeline_tag: "text-classification",
-			widgetData: [{ text: "I like you. </s></s> I love you." }],
 		},
 		{
 			id: "dbmdz/bert-large-cased-finetuned-conll03-english",


### PR DESCRIPTION
ModelCard will look like:
```
widget:
- text: My name is XYZ and I
  example_title: Logic Puzzle
  group: Some group 1
- text: My name is YZX and I
  example_title: Reading Comprehenesion
  group: Some group 1
- text: My name is ZXY and I
  example_title: Trunslation
  group: Some group 2
```

Results will look like this: [demo try first widget from this netlify](https://62c7f669614c746aedd988b4--huggingface-widgets.netlify.app/)

when there are multiple groups:

https://user-images.githubusercontent.com/11827707/177960486-729140b2-2990-4a9a-af9e-0a8f4d040c41.mov

when there is only one group or groups fields are unspecified, show only examples dropdown:

<img width="648" alt="Screenshot 2022-07-08 at 11 17 44" src="https://user-images.githubusercontent.com/11827707/177960596-84523e42-b30e-46f8-9f4a-47e005d654b4.png">

cc: @TevenLeScao 