### PR TITLE
Fix text2tex widget

### DIFF
--- a/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -8,6 +8,7 @@
 	import WidgetBloomDecoding from "../../shared/WidgetBloomDecoding/WidgetBloomDecoding.svelte";
 	import WidgetTextarea from "../../shared/WidgetTextarea/WidgetTextarea.svelte";
 	import WidgetTimer from "../../shared/WidgetTimer/WidgetTimer.svelte";
+	import WidgetOutputText from "../../shared/WidgetOutputText/WidgetOutputText.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
 	import {
 		addInferenceParameters,
@@ -131,7 +132,7 @@
 			outputJson = res.outputJson;
 			if (output.length === 0) {
 				warning = "No text was generated";
-			} else {
+			} else if (model?.pipeline_tag === "text-generation") {
 				const outputWithoutInput = output.slice(text.length);
 				inferenceTimer.stop();
 				await renderTypingEffect(outputWithoutInput);
@@ -241,5 +242,10 @@
 				</div>
 			{/if}
 		</form>
+	</svelte:fragment>
+	<svelte:fragment slot="bottom">
+		{#if model?.pipeline_tag === "text2text-generation"}
+			<WidgetOutputText classNames="mt-4" {output} />
+		{/if}
 	</svelte:fragment>
 </WidgetWrapper>


### PR DESCRIPTION
Two widgets: `text-gen` & `text2tex-gen` are closely related but not identical.

Therefore, unlike `text-gen` widget, `text2text-gen` widget should show output in a specific output text box, not as continuation.
![Screenshot from 2022-07-15 11-10-22](https://user-images.githubusercontent.com/11827707/179203664-bb493d2c-50ed-457b-820c-3f8581350a26.png)

issue was reported here https://discuss.huggingface.co/t/new-inference-api-for-text-to-text-no-longer-is-useful/20410
