### PR TITLE
Inference widget was using a value that was one keypress behind the current state

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -123,7 +123,7 @@
 			dir="auto"
 			bind:this={containerSpanEl}
 			on:paste|preventDefault={handlePaste}
-			on:keypress={updateInnerTextValue}
+			on:input={updateInnerTextValue}
 		/>
 	</svelte:fragment>
 </WidgetLabel>


### PR DESCRIPTION
The inference widget was submitting a value that was from one keypress before the last one. 

To reproduce:

* go to https://huggingface.co/gpt2 and type the text "123" at the end of the example text in the inference widget
* Submit
* Check the URL: you will see that it only submitted "12". 

This is because of how content editable events work; listening to the `input` event rather than the keypress fixes it.

I've tested this on Chrome and Safari on Mac but no other browsers.