### PR TITLE
Fix `WidgetTextArea`

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -9,8 +9,6 @@
 	export let isLoading = false;
 	export let size: "small" | "big" = "small";
 
-	let newValue = "";
-	let isOnFreshLine = true;
 	let containerSpanEl: HTMLSpanElement;
 	const typingEffectSpeedMs = 12;
 	const classNamesInput = "font-normal text-black dark:text-white";
@@ -64,42 +62,7 @@
 	}
 
 	function updateInnerTextValue() {
-		newValue = "";
-		isOnFreshLine = true;
-		parseChildNodesForValueAndLines(containerSpanEl.childNodes);
-		value = newValue;
-	}
-
-	// from https://stephenhaney.com/2020/get-contenteditable-plaintext-with-correct-linebreaks/
-	// Recursive function to navigate childNodes and build linebreaks with text
-	function parseChildNodesForValueAndLines(childNodes: NodeListOf<ChildNode>) {
-		for (let i = 0; i < childNodes.length; i++) {
-			const childNode = childNodes[i];
-
-			if (childNode.nodeName === "BR") {
-				// BRs are always line breaks which means the next loop is on a fresh line
-				newValue += "\n";
-				isOnFreshLine = true;
-				continue;
-			}
-
-			// We may or may not need to create a new line
-			if (childNode.nodeName === "DIV" && isOnFreshLine === false) {
-				// Divs create new lines for themselves if they aren't already on one
-				newValue += "\n";
-			}
-
-			// Whether we created a new line or not, we'll use it for this content so the next loop will not be on a fresh line:
-			isOnFreshLine = false;
-
-			// Add the text content if this is a text node:
-			if (childNode.nodeType === 3 && childNode.textContent) {
-				newValue += childNode.textContent;
-			}
-
-			// If this node has children, get into them as well:
-			parseChildNodesForValueAndLines(childNode.childNodes);
-		}
+		value = containerSpanEl?.textContent ?? "";
 	}
 
 	export function setValue(text: string) {
@@ -110,12 +73,13 @@
 
 <WidgetLabel {label}>
 	<svelte:fragment slot="after">
+		<!-- `whitespace-pre-wrap inline-block` are needed to get correct newlines from `el.textContent` on Chrome -->
 		<span
 			class="{isLoading ? 'pointer-events-none' : ''} {label
 				? 'mt-1.5'
 				: ''} block overflow-auto resize-y py-2 px-3 w-full {size === 'small'
 				? 'min-h-[42px]'
-				: 'min-h-[144px]'} max-h-[500px] whitespace-pre-wrap border border-gray-200 rounded-lg shadow-inner outline-none focus:ring focus:ring-blue-200 focus:shadow-inner dark:bg-gray-925"
+				: 'min-h-[144px]'} max-h-[500px] whitespace-pre-wrap inline-block border-gray-200 rounded-lg shadow-inner outline-none focus:ring focus:ring-blue-200 focus:shadow-inner dark:bg-gray-925"
 			role="textbox"
 			contenteditable
 			style="--placeholder: '{placeholder}'"
@@ -123,7 +87,7 @@
 			dir="auto"
 			bind:this={containerSpanEl}
 			on:paste|preventDefault={handlePaste}
-			on:keypress={updateInnerTextValue}
+			on:input={updateInnerTextValue}
 		/>
 	</svelte:fragment>
 </WidgetLabel>


### PR DESCRIPTION
Fixes 2 bugs found on `TextWidgetArea`:
1. `text content` of `contenteditable` span was excluding last char. for example: should be `abc`, was `ab`
2. `text content` of `contenteditable` span was wrong after: "once I have received the previous output, I deleted what has been generated but it was not taken out of what that have been sent to the API"

Luckily found a fix on https://stackoverflow.com/a/51702629:
`whitespace-pre-wrap inline-block` tailwind classes are needed to get correct newlines from `el.textContent` on Chrome where `el.contentEditable == true`, which eliminated the need to use custom `getTextContent` from [here](https://stephenhaney.com/2020/get-contenteditable-plaintext-with-correct-linebreaks/), which was causing the second bug mentioned above