### PR TITLE
Implement VisualQA widget

### DIFF
--- a/docs/hub/models-widgets-examples.md
+++ b/docs/hub/models-widgets-examples.md
@@ -248,6 +248,16 @@ widget:
   example_title: "Dog"
 ```
 
+### Visual Question Answering
+
+```yaml
+widget:
+- text: "What animal is it?"
+  src: "https://huggingface.co/datasets/mishig/sample_images/resolve/main/tiger.jpg"
+- text: "Where is it?"
+  src: "https://huggingface.co/datasets/mishig/sample_images/resolve/main/palace.jpg"
+```
+
 ## Other
 
 ### Structured Data Classification

--- a/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
@@ -13,6 +13,7 @@
 	import ImageSegmentationWidget from "./widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte";
 	import ObjectDetectionWidget from "./widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte";
 	import QuestionAnsweringWidget from "./widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte";
+	import VisualQuestionAnsweringWidget from "./widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte";
 	import SentenceSimilarityWidget from "./widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte";
 	import SummarizationWidget from "./widgets/SummarizationWidget/SummarizationWidget.svelte";
 	import TableQuestionAnsweringWidget from "./widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte";
@@ -63,6 +64,7 @@
 		translation: TextGenerationWidget,
 		"tabular-classification": TabularDataWidget,
 		"tabular-regression": TabularDataWidget,
+		"visual-question-answering": VisualQuestionAnsweringWidget,
 		"reinforcement-learning": ReinforcementLearningWidget,
 		"zero-shot-classification": ZeroShotClassificationWidget,
 	};

--- a/js/src/lib/components/InferenceWidget/shared/WidgetOutputChart/WidgetOutputChart.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetOutputChart/WidgetOutputChart.svelte
@@ -13,8 +13,12 @@ from-yellow-400 to-yellow-200 dark:from-yellow-400 dark:to-yellow-600
 <script lang="ts">
 	export let classNames = "";
 	export let defaultBarColor = "purple";
-	export let output: Array<{ label: string; score: number; color?: string }> =
-		[];
+	type LabelField = "label" | "answer";
+	export let labelField: LabelField = "label";
+	export let output: Array<
+		| { label: string; score: number; color?: string }
+		| { answer: string; score: number; color?: string }
+	> = [];
 	export let highlightIndex = -1;
 	export let mouseover: (index: number) => void = () => {};
 	export let mouseout: () => void = () => {};
@@ -28,7 +32,7 @@ from-yellow-400 to-yellow-200 dark:from-yellow-400 dark:to-yellow-600
 {#if output.length}
 	<div class="space-y-3.5 {classNames}">
 		<!-- NB: We sadly can't do color = defaultBarColor as the Svelte compiler will throw an unused-export-let warning (bug  on their side) ... -->
-		{#each output as { label, score, color }, index}
+		{#each output as { score, color }, index}
 			<div
 				class="flex items-start justify-between font-mono text-xs leading-none
 					animate__animated animate__fadeIn transition duration-200 ease-in-out
@@ -49,7 +53,7 @@ from-yellow-400 to-yellow-200 dark:from-yellow-400 dark:to-yellow-600
 							dark:to-{color ?? defaultBarColor}-600"
 						style={`width: ${Math.ceil((score / scoreMax) * 100 * 0.8)}%;`}
 					/>
-					<span class="leading-snug">{label}</span>
+					<span class="leading-snug">{output[index][labelField]}</span>
 				</div>
 				<span class="pl-2">{score.toFixed(3)}</span>
 			</div>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetQuickInput/WidgetQuickInput.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetQuickInput/WidgetQuickInput.svelte
@@ -18,6 +18,7 @@
 		{placeholder}
 		required={true}
 		type="text"
+		disabled={isLoading}
 	/>
 	<WidgetSubmitBtn
 		classNames="rounded-l-none border-l-0 {flatTop ? 'rounded-t-none' : ''}"

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -20,7 +20,7 @@
 		isLoading: false,
 		estimatedTime: 0,
 	};
-	let output: { answer: string; score: number } | null = null;
+	let output: Array<{ label: string; score: number }> = [];
 	let outputJson: string;
 	let question = "";
 	let imgSrc = "";
@@ -40,6 +40,38 @@
 		};
 		isLoading = true;
 		fileReader.readAsDataURL(file);
+	}
+
+	function isValidOutput(arg: any): arg is { label: string; score: number }[] {
+		return (
+			Array.isArray(arg) &&
+			arg.every(
+				(x) => typeof x.label === "string" && typeof x.score === "number"
+			)
+		);
+	}
+
+	function parseOutput(body: unknown): Array<{ label: string; score: number }> {
+		if (isValidOutput(body)) {
+			return body;
+		}
+		throw new TypeError(
+			"Invalid output: output must be of type Array<label: string, score:number>"
+		);
+	}
+
+	function previewInputSample(sample: Record<string, any>) {
+		question = sample.text;
+		imgSrc = sample.img;
+	}
+
+	async function applyInputSample(sample: Record<string, any>) {
+		question = sample.text;
+		imgSrc = sample.src;
+		const res = await fetch(imgSrc);
+		const blob = await res.blob();
+		updateImageBase64(blob);
+		getOutput();
 	}
 
 	async function getOutput(withModelLoading = false) {
@@ -97,34 +129,6 @@
 		} else if (res.status === "error") {
 			error = res.error;
 		}
-	}
-
-	function parseOutput(body: unknown): { answer: string; score: number } {
-		if (
-			body &&
-			typeof body === "object" &&
-			"answer" in body &&
-			"score" in body
-		) {
-			return { answer: body["answer"], score: body["score"] };
-		}
-		throw new TypeError(
-			"Invalid output: output must be of type <answer:string; score:number>"
-		);
-	}
-
-	function previewInputSample(sample: Record<string, any>) {
-		question = sample.text;
-		imgSrc = sample.img;
-	}
-
-	async function applyInputSample(sample: Record<string, any>) {
-		question = sample.text;
-		imgSrc = sample.src;
-		const res = await fetch(imgSrc);
-		const blob = await res.blob();
-		updateImageBase64(blob);
-		getOutput();
 	}
 </script>
 

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+	import type { WidgetProps } from "../../shared/types";
+
+	import WidgetFileInput from "../../shared/WidgetFileInput/WidgetFileInput.svelte";
+	import WidgetDropzone from "../../shared/WidgetDropzone/WidgetDropzone.svelte";
+	import WidgetQuickInput from "../../shared/WidgetQuickInput/WidgetQuickInput.svelte";
+	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
+	import { addInferenceParameters, getResponse } from "../../shared/helpers";
+
+	export let apiToken: WidgetProps["apiToken"];
+	export let apiUrl: WidgetProps["apiUrl"];
+	export let model: WidgetProps["model"];
+	export let noTitle: WidgetProps["noTitle"];
+	export let includeCredentials: WidgetProps["includeCredentials"];
+
+	let computeTime = "";
+	let error: string = "";
+	let isLoading = false;
+	let modelLoading = {
+		isLoading: false,
+		estimatedTime: 0,
+	};
+	let output: { answer: string; score: number } | null = null;
+	let outputJson: string;
+	let question = "";
+	let imgSrc = "";
+	let imageBase64 = "";
+
+	function onSelectFile(file: File | Blob) {
+		imgSrc = URL.createObjectURL(file);
+		updateImageBase64(file);
+	}
+
+	function updateImageBase64(file: File | Blob) {
+		let fileReader: FileReader = new FileReader();
+		fileReader.onload = () => {
+			const imageBase64WithPrefix: string = fileReader.result as string;
+			imageBase64 = imageBase64WithPrefix.split(",")[1]; // remove prefix
+			isLoading = false;
+		};
+		isLoading = true;
+		fileReader.readAsDataURL(file);
+	}
+
+	async function getOutput(withModelLoading = false) {
+		const trimmedQuestion = question.trim();
+
+		if (!trimmedQuestion) {
+			error = "You need to input a question";
+			output = null;
+			outputJson = "";
+			return;
+		}
+
+		if (!imageBase64) {
+			error = "You need to upload an image";
+			output = null;
+			outputJson = "";
+			return;
+		}
+
+		const requestBody = {
+			inputs: { question: trimmedQuestion, image: imageBase64 },
+		};
+		addInferenceParameters(requestBody, model);
+
+		isLoading = true;
+
+		const res = await getResponse(
+			apiUrl,
+			model.id,
+			requestBody,
+			apiToken,
+			parseOutput,
+			withModelLoading,
+			includeCredentials
+		);
+
+		isLoading = false;
+		// Reset values
+		computeTime = "";
+		error = "";
+		modelLoading = { isLoading: false, estimatedTime: 0 };
+		output = null;
+		outputJson = "";
+
+		if (res.status === "success") {
+			computeTime = res.computeTime;
+			output = res.output;
+			outputJson = res.outputJson;
+		} else if (res.status === "loading-model") {
+			modelLoading = {
+				isLoading: true,
+				estimatedTime: res.estimatedTime,
+			};
+			getOutput(true);
+		} else if (res.status === "error") {
+			error = res.error;
+		}
+	}
+
+	function parseOutput(body: unknown): { answer: string; score: number } {
+		if (
+			body &&
+			typeof body === "object" &&
+			"answer" in body &&
+			"score" in body
+		) {
+			return { answer: body["answer"], score: body["score"] };
+		}
+		throw new TypeError(
+			"Invalid output: output must be of type <answer:string; score:number>"
+		);
+	}
+
+	function previewInputSample(sample: Record<string, any>) {
+		question = sample.text;
+		imgSrc = sample.img;
+	}
+
+	async function applyInputSample(sample: Record<string, any>) {
+		question = sample.text;
+		imgSrc = sample.src;
+		const res = await fetch(imgSrc);
+		const blob = await res.blob();
+		updateImageBase64(blob);
+		getOutput();
+	}
+</script>
+
+<WidgetWrapper
+	{apiUrl}
+	{applyInputSample}
+	{computeTime}
+	{error}
+	{isLoading}
+	{model}
+	{modelLoading}
+	{noTitle}
+	{outputJson}
+	{previewInputSample}
+>
+	<svelte:fragment slot="top">
+		<form class="space-y-2">
+			<WidgetDropzone
+				classNames="no-hover:hidden"
+				{isLoading}
+				{imgSrc}
+				{onSelectFile}
+				onError={(e) => (error = e)}
+			>
+				{#if imgSrc}
+					<img
+						src={imgSrc}
+						class="pointer-events-none shadow mx-auto max-h-44"
+						alt=""
+					/>
+				{/if}
+			</WidgetDropzone>
+			<!-- Better UX for mobile/table through CSS breakpoints -->
+			{#if imgSrc}
+				{#if imgSrc}
+					<div
+						class="mb-2 flex justify-center bg-gray-50 dark:bg-gray-900 with-hover:hidden"
+					>
+						<img src={imgSrc} class="pointer-events-none max-h-44" alt="" />
+					</div>
+				{/if}
+			{/if}
+			<WidgetFileInput
+				accept="image/*"
+				classNames="mr-2 with-hover:hidden"
+				{isLoading}
+				label="Browse for image"
+				{onSelectFile}
+			/>
+			<WidgetQuickInput
+				bind:value={question}
+				{isLoading}
+				onClickSubmitBtn={() => {
+					getOutput();
+				}}
+			/>
+		</form>
+	</svelte:fragment>
+	<svelte:fragment slot="bottom">
+		{#if output}
+			<div class="mt-4 alert alert-success flex items-baseline">
+				<span>{output.answer}</span>
+				<span class="font-mono text-xs ml-auto">{output.score.toFixed(3)}</span>
+			</div>
+		{/if}
+	</svelte:fragment>
+</WidgetWrapper>

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -5,6 +5,7 @@
 	import WidgetDropzone from "../../shared/WidgetDropzone/WidgetDropzone.svelte";
 	import WidgetQuickInput from "../../shared/WidgetQuickInput/WidgetQuickInput.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
+	import WidgetOutputChart from "../../shared/WidgetOutputChart/WidgetOutputChart.svelte";
 	import { addInferenceParameters, getResponse } from "../../shared/helpers";
 
 	export let apiToken: WidgetProps["apiToken"];
@@ -188,11 +189,6 @@
 		</form>
 	</svelte:fragment>
 	<svelte:fragment slot="bottom">
-		{#if output}
-			<div class="mt-4 alert alert-success flex items-baseline">
-				<span>{output.answer}</span>
-				<span class="font-mono text-xs ml-auto">{output.score.toFixed(3)}</span>
-			</div>
-		{/if}
+		<WidgetOutputChart classNames="pt-4" {output} />
 	</svelte:fragment>
 </WidgetWrapper>

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -44,7 +44,6 @@
 	}
 
 	function isValidOutput(arg: any): arg is { answer: string; score: number }[] {
-		console.log(arg)
 		return (
 			Array.isArray(arg) &&
 			arg.every(
@@ -53,7 +52,9 @@
 		);
 	}
 
-	function parseOutput(body: unknown): Array<{ answer: string; score: number }> {
+	function parseOutput(
+		body: unknown
+	): Array<{ answer: string; score: number }> {
 		if (isValidOutput(body)) {
 			return body;
 		}
@@ -190,6 +191,6 @@
 		</form>
 	</svelte:fragment>
 	<svelte:fragment slot="bottom">
-		<WidgetOutputChart classNames="pt-4" {output} />
+		<WidgetOutputChart labelField="answer" classNames="pt-4" {output} />
 	</svelte:fragment>
 </WidgetWrapper>

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -21,7 +21,7 @@
 		isLoading: false,
 		estimatedTime: 0,
 	};
-	let output: Array<{ label: string; score: number }> = [];
+	let output: Array<{ answer: string; score: number }> = [];
 	let outputJson: string;
 	let question = "";
 	let imgSrc = "";
@@ -43,21 +43,22 @@
 		fileReader.readAsDataURL(file);
 	}
 
-	function isValidOutput(arg: any): arg is { label: string; score: number }[] {
+	function isValidOutput(arg: any): arg is { answer: string; score: number }[] {
+		console.log(arg)
 		return (
 			Array.isArray(arg) &&
 			arg.every(
-				(x) => typeof x.label === "string" && typeof x.score === "number"
+				(x) => typeof x.answer === "string" && typeof x.score === "number"
 			)
 		);
 	}
 
-	function parseOutput(body: unknown): Array<{ label: string; score: number }> {
+	function parseOutput(body: unknown): Array<{ answer: string; score: number }> {
 		if (isValidOutput(body)) {
 			return body;
 		}
 		throw new TypeError(
-			"Invalid output: output must be of type Array<label: string, score:number>"
+			"Invalid output: output must be of type Array<answer: string, score:number>"
 		);
 	}
 

--- a/js/src/routes/index.svelte
+++ b/js/src/routes/index.svelte
@@ -7,6 +7,16 @@
 		{
 			id: "dandelin/vilt-b32-finetuned-vqa",
 			pipeline_tag: "visual-question-answering",
+			widgetData: [
+				{
+					text: "What animal is it?",
+					src: "https://huggingface.co/datasets/mishig/sample_images/resolve/main/tiger.jpg",
+				},
+				{
+					text: "Where is it?",
+					src: "https://huggingface.co/datasets/mishig/sample_images/resolve/main/palace.jpg",
+				},
+			],
 		},
 		{
 			id: "roberta-large-mnli",

--- a/js/src/routes/index.svelte
+++ b/js/src/routes/index.svelte
@@ -5,6 +5,10 @@
 
 	const models: ModelData[] = [
 		{
+			id: "distilbert-base-uncased-distilled-squad",
+			pipeline_tag: "visual-question-answering",
+		},
+		{
 			id: "roberta-large-mnli",
 			pipeline_tag: "text-classification",
 			widgetData: [

--- a/js/src/routes/index.svelte
+++ b/js/src/routes/index.svelte
@@ -5,7 +5,7 @@
 
 	const models: ModelData[] = [
 		{
-			id: "distilbert-base-uncased-distilled-squad",
+			id: "dandelin/vilt-b32-finetuned-vqa",
 			pipeline_tag: "visual-question-answering",
 		},
 		{


### PR DESCRIPTION
### Implement VisualQuestionAnswering widget

demo: fist widget [here](https://62e138f1056cc019e97ad654--huggingface-widgets.netlify.app/)

input (similar to [QuestionAnsweringWidget](https://github.com/huggingface/hub-docs/blob/5686c85b0ddbb8e4b95d9718b4b2c6d626aa46c8/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte#L81-L83) instead of context , there is an image (base64 str) ):
```js
const requestBody = {
    inputs: { 
        question: string, 
        image: string, // base64 str of img 
    },
};
```

output1 (similar to [ImageClassificationWidget](https://github.com/huggingface/hub-docs/blob/d13a2a5bcf50a6431b74f972e1806c0fffccb5f6/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte#L80)):
```js
Array<{ label: string; score: number }>
```

<img width="300" alt="Screenshot 2022-07-27 at 15 02 20" src="https://user-images.githubusercontent.com/11827707/181253529-d15a1027-d19c-4539-9165-b2de1c269dcc.png">

todos:
- [x] test when api-inference vqa is up
- [x] test widget input samples
- [ ] document widget input sample


cc: @philschmid @NielsRogge 