### PR TITLE
Use span `innerText` -> `textContent`

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -59,7 +59,7 @@
 			const spanEl = document.createElement("span");
 			spanEl.contentEditable = "true";
 			spanEl.className = classNamesInput;
-			spanEl.innerText = copiedTxt;
+			spanEl.textContent = copiedTxt;
 			range.insertNode(spanEl);
 		}
 		window.getSelection().collapseToEnd();


### PR DESCRIPTION
Setting `<span>. innerText ` val on Chrome replaces `\n` char with `<br>` element.
However, setting `<span>. textContent ` val on Chrome preserves `\n`.

Issue was mentioned by: @thomasw21 
```
In my case it seems to remove all \n now when I copy paste and run:
34+10=44
54+20=
```