### PR TITLE
Add `tags` to the Spaces configuration reference

### DIFF
--- a/docs/hub/spaces-config-reference.md
+++ b/docs/hub/spaces-config-reference.md
@@ -40,5 +40,8 @@ Will be parsed automatically from your code if not specified here.
 HF dataset IDs (like `common_voice` or `oscar-corpus/OSCAR-2109`) used in the Space.  
 Will be parsed automatically from your code if not specified here.  
 
+**`tags`** : _List[string]_  
+List of terms that describe your Space task or scope.  
+
 **`pinned`** : _boolean_  
 Whether the Space stays on top of your profile. Can be useful if you have a lot of Spaces so you and others can quickly see your best Space.  


### PR DESCRIPTION
I kept it simple rather than explaining that users can manually filter using a URL param.