### PR TITLE
Fix translation widget output

### DIFF
--- a/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -244,7 +244,8 @@
 		</form>
 	</svelte:fragment>
 	<svelte:fragment slot="bottom">
-		{#if model?.pipeline_tag === "text2text-generation"}
+		{#if model?.pipeline_tag !== "text-generation"}
+			<!-- for pipelines: text2text-generation & translation -->
 			<WidgetOutputText classNames="mt-4" {output} />
 		{/if}
 	</svelte:fragment>


### PR DESCRIPTION
Fix `translation` widget output display. 
`text-geenration` widget is used `translation` as well, and `translation` needed a modification to handle `translation` output correctly

demo: https://62fdda6c76a6b9654894eb3a--huggingface-widgets.netlify.app/t5-base