### PR TITLE
Implement img2text widget

### DIFF
--- a/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
@@ -10,6 +10,7 @@
 	import FeatureExtractionWidget from "./widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte";
 	import FillMaskWidget from "./widgets/FillMaskWidget/FillMaskWidget.svelte";
 	import ImageClassificationWidget from "./widgets/ImageClassificationWidget/ImageClassificationWidget.svelte";
+	import ImageToTextWidget from "./widgets/ImageToTextWidget/ImageToTextWidget.svelte";
 	import ImageSegmentationWidget from "./widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte";
 	import ObjectDetectionWidget from "./widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte";
 	import QuestionAnsweringWidget from "./widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte";
@@ -49,6 +50,7 @@
 		"feature-extraction": FeatureExtractionWidget,
 		"fill-mask": FillMaskWidget,
 		"image-classification": ImageClassificationWidget,
+		"image-to-text": ImageToTextWidget,
 		"image-segmentation": ImageSegmentationWidget,
 		"object-detection": ObjectDetectionWidget,
 		"question-answering": QuestionAnsweringWidget,

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+	import type { WidgetProps } from "../../shared/types";
+
+	import WidgetFileInput from "../../shared/WidgetFileInput/WidgetFileInput.svelte";
+	import WidgetDropzone from "../../shared/WidgetDropzone/WidgetDropzone.svelte";
+	import WidgetOutputText from "../../shared/WidgetOutputText/WidgetOutputText.svelte";
+	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
+	import { getResponse, getBlobFromUrl } from "../../shared/helpers";
+
+	export let apiToken: WidgetProps["apiToken"];
+	export let apiUrl: WidgetProps["apiUrl"];
+	export let model: WidgetProps["model"];
+	export let noTitle: WidgetProps["noTitle"];
+	export let includeCredentials: WidgetProps["includeCredentials"];
+
+	let computeTime = "";
+	let error: string = "";
+	let isLoading = false;
+	let imgSrc = "";
+	let modelLoading = {
+		isLoading: false,
+		estimatedTime: 0,
+	};
+	let output: string = "";
+	let outputJson: string;
+	let warning: string = "";
+
+	function onSelectFile(file: File | Blob) {
+		imgSrc = URL.createObjectURL(file);
+		getOutput(file);
+	}
+
+	async function getOutput(file: File | Blob, withModelLoading = false) {
+		if (!file) {
+			return;
+		}
+
+		// Reset values
+		computeTime = "";
+		error = "";
+		warning = "";
+		output = "";
+		outputJson = "";
+
+		const requestBody = { file };
+
+		isLoading = true;
+
+		const res = await getResponse(
+			apiUrl,
+			model.id,
+			requestBody,
+			apiToken,
+			parseOutput,
+			withModelLoading,
+			includeCredentials
+		);
+
+		isLoading = false;
+		modelLoading = { isLoading: false, estimatedTime: 0 };
+
+		if (res.status === "success") {
+			computeTime = res.computeTime;
+			output = res.output;
+			outputJson = res.outputJson;
+			if (output.length === 0) {
+				warning = "No classes were detected";
+			}
+		} else if (res.status === "loading-model") {
+			modelLoading = {
+				isLoading: true,
+				estimatedTime: res.estimatedTime,
+			};
+			getOutput(file, true);
+		} else if (res.status === "error") {
+			error = res.error;
+		}
+	}
+
+	function parseOutput(body: unknown): string {
+		if (Array.isArray(body) && body.length) {
+			return body[0]?.["generated_text"] ?? "";
+		}
+		throw new TypeError(
+			"Invalid output: output must be of type Array & non-empty"
+		);
+	}
+
+	async function applyInputSample(sample: Record<string, any>) {
+		imgSrc = sample.src;
+		const blob = await getBlobFromUrl(imgSrc);
+		getOutput(blob);
+	}
+
+	function previewInputSample(sample: Record<string, any>) {
+		imgSrc = sample.src;
+		output = "";
+		outputJson = "";
+	}
+</script>
+
+<WidgetWrapper
+	{apiUrl}
+	{applyInputSample}
+	{computeTime}
+	{error}
+	{isLoading}
+	{model}
+	{modelLoading}
+	{noTitle}
+	{outputJson}
+	{previewInputSample}
+>
+	<svelte:fragment slot="top">
+		<form>
+			<WidgetDropzone
+				classNames="no-hover:hidden"
+				{isLoading}
+				{imgSrc}
+				{onSelectFile}
+				onError={(e) => (error = e)}
+			>
+				{#if imgSrc}
+					<img
+						src={imgSrc}
+						class="pointer-events-none shadow mx-auto max-h-44"
+						alt=""
+					/>
+				{/if}
+			</WidgetDropzone>
+			<!-- Better UX for mobile/table through CSS breakpoints -->
+			{#if imgSrc}
+				{#if imgSrc}
+					<div
+						class="mb-2 flex justify-center bg-gray-50 dark:bg-gray-900 with-hover:hidden"
+					>
+						<img src={imgSrc} class="pointer-events-none max-h-44" alt="" />
+					</div>
+				{/if}
+			{/if}
+			<WidgetFileInput
+				accept="image/*"
+				classNames="mr-2 with-hover:hidden"
+				{isLoading}
+				label="Browse for image"
+				{onSelectFile}
+			/>
+			{#if warning}
+				<div class="alert alert-warning mt-2">{warning}</div>
+			{/if}
+		</form>
+	</svelte:fragment>
+	<svelte:fragment slot="bottom">
+		{#if model?.pipeline_tag !== "text-generation"}
+			<WidgetOutputText classNames="mt-4" {output} />
+		{/if}
+	</svelte:fragment>
+</WidgetWrapper>

--- a/js/src/routes/index.svelte
+++ b/js/src/routes/index.svelte
@@ -5,6 +5,10 @@
 
 	const models: ModelData[] = [
 		{
+			id: "microsoft/trocr-base-printed",
+			pipeline_tag: "image-to-text",
+		},
+		{
 			id: "skops/hf_hub_example-bdc26c1f-7e82-42eb-9657-0318315f2df0",
 			pipeline_tag: "tabular-classification",
 		},


### PR DESCRIPTION
### Implement Text-to-Image widget

https://github.com/huggingface/transformers/pull/18821#issuecomment-1234524309

input (identical to [ImageClassificationWidget](https://github.com/huggingface/hub-docs/blob/d13a2a5bcf50a6431b74f972e1806c0fffccb5f6/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte#L45)):
```js
const requestBody = { file }; // img file
```

output (identical to [TextGenerationWidget](https://github.com/huggingface/hub-docs/blob/21965aab98c78c5b6971371bde0b8f17853fab40/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte#L158)):
```js
Array<{ generated_text: string; }>
```
example:
```js
[
  {
    "generated_text": "Some text"
  }
]
```

### Note:

In transformers implementation, I see that the pipeline is called [image-to-text-generation](https://github.com/OlivierDehaene/transformers/blob/dc0cc5322f55901265f816b5eda45f73f77d473b/src/transformers/pipelines/image2text_generation.py#L29), while in the hub, we already defined it as [image-to-text](https://huggingface.co/models?pipeline_tag=image-to-text) without the **generation** part. Please let me know if it is an issue: @Narsil @osanseviero 

todos:
- [ ] test when api-inference is up @Narsil 
- [ ] document widget input sample
