### PR TITLE
Widgets call inference run `onMount`

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/helpers.ts
+++ b/js/src/lib/components/InferenceWidget/shared/helpers.ts
@@ -63,6 +63,7 @@ async function callApi(
 	waitForModel = false, // If true, the server will only respond once the model has been loaded on the inference API,
 	useCache = true,
 	includeCredentials = false,
+	isOnLoadCall = false,
 ): Promise<Response> {	
 	const contentType = 'file' in requestBody && 'type' in requestBody['file']
 		? requestBody['file']['type']  
@@ -78,6 +79,9 @@ async function callApi(
 	}
 	if (useCache === false) {
 		headers.set('X-Use-Cache', "false");
+	}
+	if (isOnLoadCall) {
+		headers.set('X-Load-Model', "0");
 	}
 	
 	const body: File | string = 'file' in requestBody
@@ -103,6 +107,7 @@ export async function getResponse<T>(
 	outputParsingFn: (x: unknown) =>  T,
 	waitForModel = false, // If true, the server will only respond once the model has been loaded on the inference API,
 	includeCredentials = false,
+	isOnLoadCall = false, // If true, the server will try to answer from cache and not do anything if not
 	useCache = true,
 ): Promise<{
 	computeTime: string,
@@ -126,6 +131,7 @@ export async function getResponse<T>(
 		waitForModel,
 		useCache,
 		includeCredentials,
+		isOnLoadCall,
 	);
 
 	if (response.ok) {

--- a/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
@@ -64,7 +64,7 @@
 		}
 	}
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		if (!file && !selectedSampleUrl) {
 			error = "You must select or record an audio file";
 			output = [];
@@ -87,7 +87,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;
@@ -156,7 +157,7 @@
 			filename = example_title ?? "";
 			fileUrl = src;
 			selectedSampleUrl = src;
-			getOutput();
+			getOutput(false, true);
 		}
 	});
 </script>

--- a/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
@@ -1,16 +1,22 @@
 <script lang="ts">
 	import type { WidgetProps } from "../../shared/types";
 
+	import { onMount } from "svelte";
 	import WidgetAudioTrack from "../../shared/WidgetAudioTrack/WidgetAudioTrack.svelte";
 	import WidgetFileInput from "../../shared/WidgetFileInput/WidgetFileInput.svelte";
 	import WidgetOutputChart from "../../shared/WidgetOutputChart/WidgetOutputChart.svelte";
 	import WidgetRecorder from "../../shared/WidgetRecorder/WidgetRecorder.svelte";
 	import WidgetSubmitBtn from "../../shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
-	import { getResponse, getBlobFromUrl } from "../../shared/helpers";
+	import {
+		getResponse,
+		getBlobFromUrl,
+		getDemoInputs,
+	} from "../../shared/helpers";
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -143,6 +149,16 @@
 		output = [];
 		outputJson = "";
 	}
+
+	onMount(() => {
+		const [example_title, src] = getDemoInputs(model, ["example_title", "src"]);
+		if (callApiOnMount && src) {
+			filename = example_title ?? "";
+			fileUrl = src;
+			selectedSampleUrl = src;
+			getOutput();
+		}
+	});
 </script>
 
 <WidgetWrapper

--- a/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -6,10 +6,16 @@
 	import WidgetRecorder from "../../shared/WidgetRecorder/WidgetRecorder.svelte";
 	import WidgetSubmitBtn from "../../shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
-	import { getResponse, getBlobFromUrl } from "../../shared/helpers";
+	import {
+		getResponse,
+		getBlobFromUrl,
+		getDemoInputs,
+	} from "../../shared/helpers";
+	import { onMount } from "svelte";
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -144,6 +150,16 @@
 		output = [];
 		outputJson = "";
 	}
+
+	onMount(() => {
+		const [example_title, src] = getDemoInputs(model, ["example_title", "src"]);
+		if (callApiOnMount && src) {
+			filename = example_title ?? "";
+			fileUrl = src;
+			selectedSampleUrl = src;
+			getOutput();
+		}
+	});
 </script>
 
 <WidgetWrapper

--- a/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -68,7 +68,7 @@
 		}
 	}
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		if (!file && !selectedSampleUrl) {
 			error = "You must select or record an audio file";
 			return;
@@ -88,7 +88,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 		isLoading = false;
 		// Reset values
@@ -157,7 +158,7 @@
 			filename = example_title ?? "";
 			fileUrl = src;
 			selectedSampleUrl = src;
-			getOutput();
+			getOutput(false, true);
 		}
 	});
 </script>

--- a/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -8,10 +8,16 @@
 	import WidgetRealtimeRecorder from "../../shared/WidgetRealtimeRecorder/WidgetRealtimeRecorder.svelte";
 	import WidgetSubmitBtn from "../../shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
-	import { getResponse, getBlobFromUrl } from "../../shared/helpers";
+	import {
+		getResponse,
+		getBlobFromUrl,
+		getDemoInputs,
+	} from "../../shared/helpers";
+	import { onMount } from "svelte";
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -138,6 +144,16 @@
 	function updateModelLoading(isLoading: boolean, estimatedTime: number = 0) {
 		modelLoading = { isLoading, estimatedTime };
 	}
+
+	onMount(() => {
+		const [example_title, src] = getDemoInputs(model, ["example_title", "src"]);
+		if (callApiOnMount && src) {
+			filename = example_title ?? "";
+			fileUrl = src;
+			selectedSampleUrl = src;
+			getOutput();
+		}
+	});
 </script>
 
 <WidgetWrapper

--- a/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -66,7 +66,7 @@
 		}
 	}
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		if (!file && !selectedSampleUrl) {
 			error = "You must select or record an audio file";
 			output = "";
@@ -89,7 +89,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;
@@ -151,7 +152,7 @@
 			filename = example_title ?? "";
 			fileUrl = src;
 			selectedSampleUrl = src;
-			getOutput();
+			getOutput(false, true);
 		}
 	});
 </script>

--- a/js/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
@@ -62,12 +62,12 @@
 			const [demoText] = getDemoInputs(model, ["text"]);
 			text = (demoText as string) ?? "";
 			if (text && callApiOnMount) {
-				getOutput();
+				getOutput(false, true);
 			}
 		}
 	});
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		const trimmedText = text.trim();
 
 		if (!trimmedText) {
@@ -96,7 +96,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;

--- a/js/src/lib/components/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
@@ -41,12 +41,12 @@
 			const [demoText] = getDemoInputs(model, ["text"]);
 			text = (demoText as string) ?? "";
 			if (text && callApiOnMount) {
-				getOutput();
+				getOutput(false, true);
 			}
 		}
 	});
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		const trimmedText = text.trim();
 
 		if (!trimmedText) {
@@ -72,7 +72,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;

--- a/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
@@ -43,12 +43,12 @@
 			const [demoText] = getDemoInputs(model, ["text"]);
 			setTextAreaValue(demoText ?? "");
 			if (text && callApiOnMount) {
-				getOutput();
+				getOutput(false, true);
 			}
 		}
 	});
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		const trimmedText = text.trim();
 
 		if (!trimmedText) {
@@ -74,7 +74,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;

--- a/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -36,7 +36,11 @@
 		getOutput(file);
 	}
 
-	async function getOutput(file: File | Blob, withModelLoading = false) {
+	async function getOutput(
+		file: File | Blob,
+		withModelLoading = false,
+		isOnLoadCall = false
+	) {
 		if (!file) {
 			return;
 		}
@@ -59,7 +63,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;
@@ -119,7 +124,7 @@
 			if (callApiOnMount && src) {
 				imgSrc = src;
 				const blob = await getBlobFromUrl(imgSrc);
-				getOutput(blob);
+				getOutput(blob, false, true);
 			}
 		})();
 	});

--- a/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -114,14 +114,14 @@
 	}
 
 	onMount(() => {
-		async () => {
+		(async () => {
 			const [src] = getDemoInputs(model, ["src"]);
 			if (callApiOnMount && src) {
 				imgSrc = src;
 				const blob = await getBlobFromUrl(imgSrc);
 				getOutput(blob);
 			}
-		};
+		})();
 	});
 </script>
 

--- a/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -113,13 +113,15 @@
 		outputJson = "";
 	}
 
-	onMount(async () => {
-		const [src] = getDemoInputs(model, ["src"]);
-		if (callApiOnMount && src) {
-			imgSrc = src;
-			const blob = await getBlobFromUrl(imgSrc);
-			getOutput(blob);
-		}
+	onMount(() => {
+		async () => {
+			const [src] = getDemoInputs(model, ["src"]);
+			if (callApiOnMount && src) {
+				imgSrc = src;
+				const blob = await getBlobFromUrl(imgSrc);
+				getOutput(blob);
+			}
+		};
 	});
 </script>
 

--- a/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -5,10 +5,16 @@
 	import WidgetDropzone from "../../shared/WidgetDropzone/WidgetDropzone.svelte";
 	import WidgetOutputChart from "../../shared/WidgetOutputChart/WidgetOutputChart.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
-	import { getResponse, getBlobFromUrl } from "../../shared/helpers";
+	import {
+		getResponse,
+		getBlobFromUrl,
+		getDemoInputs,
+	} from "../../shared/helpers";
+	import { onMount } from "svelte";
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -106,6 +112,15 @@
 		output = [];
 		outputJson = "";
 	}
+
+	onMount(async () => {
+		const [src] = getDemoInputs(model, ["src"]);
+		if (callApiOnMount && src) {
+			imgSrc = src;
+			const blob = await getBlobFromUrl(imgSrc);
+			getOutput(blob);
+		}
+	});
 </script>
 
 <WidgetWrapper

--- a/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
@@ -3,7 +3,11 @@
 	import { onMount } from "svelte";
 	import { COLORS } from "../../shared/consts";
 	import { clamp, mod, hexToRgb } from "../../../../utils/ViewUtils";
-	import { getResponse, getBlobFromUrl } from "../../shared/helpers";
+	import {
+		getResponse,
+		getBlobFromUrl,
+		getDemoInputs,
+	} from "../../shared/helpers";
 
 	import Canvas from "./Canvas.svelte";
 	import WidgetFileInput from "../../shared/WidgetFileInput/WidgetFileInput.svelte";
@@ -13,6 +17,7 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -223,9 +228,16 @@
 		outputJson = "";
 	}
 
-	onMount(() => {
+	onMount(async () => {
 		if (typeof createImageBitmap === "undefined") {
 			polyfillCreateImageBitmap();
+		}
+
+		const [src] = getDemoInputs(model, ["src"]);
+		if (callApiOnMount && src) {
+			imgSrc = src;
+			const blob = await getBlobFromUrl(imgSrc);
+			getOutput(blob);
 		}
 	});
 </script>

--- a/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
@@ -228,17 +228,19 @@
 		outputJson = "";
 	}
 
-	onMount(async () => {
+	onMount(() => {
 		if (typeof createImageBitmap === "undefined") {
 			polyfillCreateImageBitmap();
 		}
 
-		const [src] = getDemoInputs(model, ["src"]);
-		if (callApiOnMount && src) {
-			imgSrc = src;
-			const blob = await getBlobFromUrl(imgSrc);
-			getOutput(blob);
-		}
+		(async () => {
+			const [src] = getDemoInputs(model, ["src"]);
+			if (callApiOnMount && src) {
+				imgSrc = src;
+				const blob = await getBlobFromUrl(imgSrc);
+				getOutput(blob);
+			}
+		})();
 	});
 </script>
 

--- a/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
@@ -50,7 +50,11 @@
 		getOutput(file);
 	}
 
-	async function getOutput(file: File | Blob, withModelLoading = false) {
+	async function getOutput(
+		file: File | Blob,
+		withModelLoading = false,
+		isOnLoadCall = false
+	) {
 		if (!file) {
 			return;
 		}
@@ -73,7 +77,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;
@@ -238,7 +243,7 @@
 			if (callApiOnMount && src) {
 				imgSrc = src;
 				const blob = await getBlobFromUrl(imgSrc);
-				getOutput(blob);
+				getOutput(blob, false, true);
 			}
 		})();
 	});

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
@@ -5,10 +5,16 @@
 	import WidgetDropzone from "../../shared/WidgetDropzone/WidgetDropzone.svelte";
 	import WidgetOutputText from "../../shared/WidgetOutputText/WidgetOutputText.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
-	import { getResponse, getBlobFromUrl } from "../../shared/helpers";
+	import {
+		getResponse,
+		getBlobFromUrl,
+		getDemoInputs,
+	} from "../../shared/helpers";
+	import { onMount } from "svelte";
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -98,6 +104,17 @@
 		output = "";
 		outputJson = "";
 	}
+
+	onMount(() => {
+		(async () => {
+			const [src] = getDemoInputs(model, ["src"]);
+			if (callApiOnMount && src) {
+				imgSrc = src;
+				const blob = await getBlobFromUrl(imgSrc);
+				getOutput(blob);
+			}
+		})();
+	});
 </script>
 
 <WidgetWrapper

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
@@ -36,7 +36,11 @@
 		getOutput(file);
 	}
 
-	async function getOutput(file: File | Blob, withModelLoading = false) {
+	async function getOutput(
+		file: File | Blob,
+		withModelLoading = false,
+		isOnLoadCall = false
+	) {
 		if (!file) {
 			return;
 		}
@@ -59,7 +63,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;
@@ -111,7 +116,7 @@
 			if (callApiOnMount && src) {
 				imgSrc = src;
 				const blob = await getBlobFromUrl(imgSrc);
-				getOutput(blob);
+				getOutput(blob, false, true);
 			}
 		})();
 	});

--- a/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
@@ -3,15 +3,21 @@
 	import { COLORS } from "../../shared/consts";
 	import { mod } from "../../../../utils/ViewUtils";
 
+	import { onMount } from "svelte";
 	import BoundingBoxes from "./SvgBoundingBoxes.svelte";
 	import WidgetFileInput from "../../shared/WidgetFileInput/WidgetFileInput.svelte";
 	import WidgetDropzone from "../../shared/WidgetDropzone/WidgetDropzone.svelte";
 	import WidgetOutputChart from "../../shared/WidgetOutputChart/WidgetOutputChart.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
-	import { getResponse, getBlobFromUrl } from "../../shared/helpers";
+	import {
+		getResponse,
+		getBlobFromUrl,
+		getDemoInputs,
+	} from "../../shared/helpers";
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -131,6 +137,15 @@
 		output = [];
 		outputJson = "";
 	}
+
+	onMount(async () => {
+		const [src] = getDemoInputs(model, ["src"]);
+		if (callApiOnMount && src) {
+			imgSrc = src;
+			const blob = await getBlobFromUrl(imgSrc);
+			getOutput(blob);
+		}
+	});
 </script>
 
 <WidgetWrapper

--- a/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
@@ -138,13 +138,15 @@
 		outputJson = "";
 	}
 
-	onMount(async () => {
-		const [src] = getDemoInputs(model, ["src"]);
-		if (callApiOnMount && src) {
-			imgSrc = src;
-			const blob = await getBlobFromUrl(imgSrc);
-			getOutput(blob);
-		}
+	onMount(() => {
+		async () => {
+			const [src] = getDemoInputs(model, ["src"]);
+			if (callApiOnMount && src) {
+				imgSrc = src;
+				const blob = await getBlobFromUrl(imgSrc);
+				getOutput(blob);
+			}
+		};
 	});
 </script>
 

--- a/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
@@ -144,14 +144,14 @@
 	}
 
 	onMount(() => {
-		async () => {
+		(async () => {
 			const [src] = getDemoInputs(model, ["src"]);
 			if (callApiOnMount && src) {
 				imgSrc = src;
 				const blob = await getBlobFromUrl(imgSrc);
 				getOutput(blob, false, true);
 			}
-		};
+		})();
 	});
 </script>
 

--- a/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
@@ -40,7 +40,11 @@
 		getOutput(file);
 	}
 
-	async function getOutput(file: File | Blob, withModelLoading = false) {
+	async function getOutput(
+		file: File | Blob,
+		withModelLoading = false,
+		isOnLoadCall = false
+	) {
 		if (!file) {
 			return;
 		}
@@ -63,7 +67,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;
@@ -144,7 +149,7 @@
 			if (callApiOnMount && src) {
 				imgSrc = src;
 				const blob = await getBlobFromUrl(imgSrc);
-				getOutput(blob);
+				getOutput(blob, false, true);
 			}
 		};
 	});

--- a/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
@@ -51,12 +51,12 @@
 			question = (demoQuestion as string) ?? "";
 			setTextAreaValue(demoContext ?? "");
 			if (context && question && callApiOnMount) {
-				getOutput();
+				getOutput(false, true);
 			}
 		}
 	});
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		const trimmedQuestion = question.trim();
 		const trimmedContext = context.trim();
 
@@ -92,7 +92,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;

--- a/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
@@ -15,6 +15,7 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -32,16 +33,6 @@
 	};
 	let output: Array<{ label: string; score: number }> = [];
 	let outputJson: string;
-
-	onMount(() => {
-		const [demoSourcesentence, demoComparisonSentence] = getDemoInputs(model, [
-			"source_sentence",
-			"sentences",
-		]);
-		sourceSentence = (demoSourcesentence as string) ?? "";
-		comparisonSentences = demoComparisonSentence ?? [""];
-		nComparisonSentences = comparisonSentences.length;
-	});
 
 	async function getOutput(withModelLoading = false) {
 		const trimmedSourceSentence = sourceSentence.trim();
@@ -140,6 +131,19 @@
 		nComparisonSentences = comparisonSentences.length;
 		getOutput();
 	}
+
+	onMount(() => {
+		const [demoSourcesentence, demoComparisonSentence] = getDemoInputs(model, [
+			"source_sentence",
+			"sentences",
+		]);
+		if (callApiOnMount && demoSourcesentence && comparisonSentences?.length) {
+			sourceSentence = (demoSourcesentence as string) ?? "";
+			comparisonSentences = demoComparisonSentence ?? [""];
+			nComparisonSentences = comparisonSentences.length;
+			getOutput();
+		}
+	});
 </script>
 
 <WidgetWrapper

--- a/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
@@ -34,7 +34,7 @@
 	let output: Array<{ label: string; score: number }> = [];
 	let outputJson: string;
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		const trimmedSourceSentence = sourceSentence.trim();
 		if (!trimmedSourceSentence) {
 			error = "You need to input some text";
@@ -82,7 +82,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;
@@ -141,7 +142,7 @@
 			sourceSentence = (demoSourcesentence as string) ?? "";
 			comparisonSentences = demoComparisonSentence ?? [""];
 			nComparisonSentences = comparisonSentences.length;
-			getOutput();
+			getOutput(false, true);
 		}
 	});
 </script>

--- a/js/src/lib/components/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
@@ -43,12 +43,12 @@
 			const [demoText] = getDemoInputs(model, ["text"]);
 			setTextAreaValue(demoText ?? "");
 			if (text && callApiOnMount) {
-				getOutput();
+				getOutput(false, true);
 			}
 		}
 	});
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		const trimmedValue = text.trim();
 
 		if (!trimmedValue) {
@@ -74,7 +74,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;

--- a/js/src/lib/components/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
@@ -68,7 +68,7 @@
 			query = (demoQuery as string) ?? "";
 			table = convertDataToTable(demoTable as TableData);
 			if (query && table && callApiOnMount) {
-				getOutput();
+				getOutput(false, true);
 			}
 		}
 	});
@@ -77,7 +77,7 @@
 		table = updatedTable;
 	}
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		const trimmedQuery = query.trim();
 
 		if (!trimmedQuery) {
@@ -111,7 +111,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;

--- a/js/src/lib/components/InferenceWidget/widgets/TabularDataWidget/TabularDataWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TabularDataWidget/TabularDataWidget.svelte
@@ -77,7 +77,7 @@
 			const [demoTable] = getDemoInputs(model, ["structuredData"]);
 			table = convertDataToTable((demoTable as TableData) ?? {});
 			if (table && callApiOnMount) {
-				getOutput();
+				getOutput(false, true);
 			}
 		}
 	});
@@ -87,7 +87,7 @@
 		output = [];
 	}
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		for (let [i, row] of table.entries()) {
 			for (const [j, cell] of row.entries()) {
 				if (!String(cell)) {
@@ -126,7 +126,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;

--- a/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -61,12 +61,12 @@
 			const [demoText] = getDemoInputs(model, ["text"]);
 			setTextAreaValue(demoText ?? "");
 			if (text && callApiOnMount) {
-				getOutput();
+				getOutput(false, true);
 			}
 		}
 	});
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		if (isBloomLoginRequired) {
 			return;
 		}
@@ -115,6 +115,7 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
+			isOnLoadCall,
 			useCache
 		);
 

--- a/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
@@ -40,12 +40,12 @@
 			const [demoText] = getDemoInputs(model, ["text"]);
 			text = (demoText as string) ?? "";
 			if (text && callApiOnMount) {
-				getOutput();
+				getOutput(false, true);
 			}
 		}
 	});
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		const trimmedText = text.trim();
 
 		if (!trimmedText) {
@@ -70,7 +70,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;

--- a/js/src/lib/components/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
@@ -43,12 +43,12 @@
 			const [demoText] = getDemoInputs(model, ["text"]);
 			setTextAreaValue(demoText ?? "");
 			if (text && callApiOnMount) {
-				getOutput();
+				getOutput(false, true);
 			}
 		}
 	});
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		const trimmedText = text.trim();
 
 		if (!trimmedText) {
@@ -73,7 +73,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;

--- a/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
@@ -60,12 +60,12 @@
 			const [demoText] = getDemoInputs(model, ["text"]);
 			setTextAreaValue(demoText ?? "");
 			if (text && callApiOnMount) {
-				getOutput();
+				getOutput(false, true);
 			}
 		}
 	});
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		const trimmedText = text.trim();
 
 		if (!trimmedText) {
@@ -91,7 +91,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -150,7 +150,7 @@
 	}
 
 	onMount(() => {
-		async () => {
+		(async () => {
 			const [text, src] = getDemoInputs(model, ["text", "src"]);
 			if (callApiOnMount && text && src) {
 				question = text;
@@ -160,7 +160,7 @@
 				await updateImageBase64(blob);
 				getOutput(false, true);
 			}
-		};
+		})();
 	});
 </script>
 

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -148,16 +148,18 @@
 		}
 	}
 
-	onMount(async () => {
-		const [text, src] = getDemoInputs(model, ["text", "src"]);
-		if (callApiOnMount && text && src) {
-			question = text;
-			imgSrc = src;
-			const res = await fetch(imgSrc);
-			const blob = await res.blob();
-			await updateImageBase64(blob);
-			getOutput();
-		}
+	onMount(() => {
+		async () => {
+			const [text, src] = getDemoInputs(model, ["text", "src"]);
+			if (callApiOnMount && text && src) {
+				question = text;
+				imgSrc = src;
+				const res = await fetch(imgSrc);
+				const blob = await res.blob();
+				await updateImageBase64(blob);
+				getOutput();
+			}
+		};
 	});
 </script>
 

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -91,7 +91,7 @@
 		getOutput();
 	}
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		const trimmedQuestion = question.trim();
 
 		if (!trimmedQuestion) {
@@ -122,7 +122,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;
@@ -157,7 +158,7 @@
 				const res = await fetch(imgSrc);
 				const blob = await res.blob();
 				await updateImageBase64(blob);
-				getOutput();
+				getOutput(false, true);
 			}
 		};
 	});

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -6,10 +6,16 @@
 	import WidgetQuickInput from "../../shared/WidgetQuickInput/WidgetQuickInput.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
 	import WidgetOutputChart from "../../shared/WidgetOutputChart/WidgetOutputChart.svelte";
-	import { addInferenceParameters, getResponse } from "../../shared/helpers";
+	import {
+		addInferenceParameters,
+		getDemoInputs,
+		getResponse,
+	} from "../../shared/helpers";
+	import { onMount } from "svelte";
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -141,6 +147,18 @@
 			error = res.error;
 		}
 	}
+
+	onMount(async () => {
+		const [text, src] = getDemoInputs(model, ["text", "src"]);
+		if (callApiOnMount && text && src) {
+			question = text;
+			imgSrc = src;
+			const res = await fetch(imgSrc);
+			const blob = await res.blob();
+			await updateImageBase64(blob);
+			getOutput();
+		}
+	});
 </script>
 
 <WidgetWrapper

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
@@ -90,7 +90,7 @@
 		getOutput();
 	}
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		const trimmedCandidateLabels = candidateLabels.trim().split(",").join(",");
 
 		if (!trimmedCandidateLabels) {
@@ -124,7 +124,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;
@@ -162,7 +163,7 @@
 				const res = await fetch(imgSrc);
 				const blob = await res.blob();
 				await updateImageBase64(blob);
-				getOutput();
+				getOutput(false, true);
 			}
 		})();
 	});

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
@@ -157,7 +157,7 @@
 				"src",
 				"candidate_labels",
 			]);
-			if (callApiOnMount && src) {
+			if (callApiOnMount && src && candidate_labels) {
 				candidateLabels = candidate_labels;
 				imgSrc = src;
 				const res = await fetch(imgSrc);

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
@@ -7,10 +7,16 @@
 	import WidgetSubmitBtn from "../../shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte";
 	import WidgetWrapper from "../../shared/WidgetWrapper/WidgetWrapper.svelte";
 	import WidgetOutputChart from "../../shared/WidgetOutputChart/WidgetOutputChart.svelte";
-	import { addInferenceParameters, getResponse } from "../../shared/helpers";
+	import {
+		addInferenceParameters,
+		getResponse,
+		getDemoInputs,
+	} from "../../shared/helpers";
+	import { onMount } from "svelte";
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -143,6 +149,23 @@
 			error = res.error;
 		}
 	}
+
+	onMount(() => {
+		(async () => {
+			const [src, candidate_labels] = getDemoInputs(model, [
+				"src",
+				"candidate_labels",
+			]);
+			if (callApiOnMount && src) {
+				candidateLabels = candidate_labels;
+				imgSrc = src;
+				const res = await fetch(imgSrc);
+				const blob = await res.blob();
+				await updateImageBase64(blob);
+				getOutput();
+			}
+		})();
+	});
 </script>
 
 <WidgetWrapper

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
@@ -59,12 +59,12 @@
 			multiClass = demoMultiClass === "true";
 			setTextAreaValue(demoText ?? "");
 			if (candidateLabels && text && callApiOnMount) {
-				getOutput();
+				getOutput(false, true);
 			}
 		}
 	});
 
-	async function getOutput(withModelLoading = false) {
+	async function getOutput(withModelLoading = false, isOnLoadCall = false) {
 		const trimmedText = text.trim();
 		const trimmedCandidateLabels = candidateLabels.trim().split(",").join(",");
 
@@ -108,7 +108,8 @@
 			apiToken,
 			parseOutput,
 			withModelLoading,
-			includeCredentials
+			includeCredentials,
+			isOnLoadCall
 		);
 
 		isLoading = false;


### PR DESCRIPTION
TLDR: call inference run on widgets using `callApiOnMount` prop & flag [X-Load-Model = 0](https://github.com/huggingface/hub-docs/blob/4cb0e4dae893d905bf7a3a780afef231f897ce6f/js/src/lib/components/InferenceWidget/shared/helpers.ts#L83-L85)

`callApiOnMount` prop already exists on most widgets like [TextGenerationWidget](https://github.com/huggingface/hub-docs/blob/21965aab98c78c5b6971371bde0b8f17853fab40/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte) & this PR adds `callApiOnMount ` prop to remaining widgets like [ImageSegmentationWidget](https://github.com/huggingface/hub-docs/blob/7bda9b6965e26a57dbd9cee805577d6f0c84feee/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte)

when set to `true`, `callApiOnMount` makes the widget load example input & call the api. And since commonly used models have cached output, users should receive output instantly