### PR TITLE
Add Circassian language

### DIFF
--- a/js/src/lib/interfaces/Language.ts
+++ b/js/src/lib/interfaces/Language.ts
@@ -1213,5 +1213,15 @@ export const LANGUAGES: Record<string, Language> = {
 		code: "fon",
 		name: "Fon",
 	},
+	ady: {
+		code: "ady",
+		name: "Circassian Adyghean",
+		nativeName: "Адыгэбзэ Къэбэрдей",
+	},
+	kbd: {
+		code: "kbd",
+		name: "Circassian Kabardian",
+		nativeName: "Адыгэбзэ КIахэ",
+	},
 };
 


### PR DESCRIPTION
Add two standard variants/dialects of the Circassian language to the languages list:
• ady – "Circassian Adyghean"
• kbd – "Circassian Kabardian"