### PR TITLE
Fix consistent style of radio/checkboxes with the hub

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/WidgetCheckbox/WidgetCheckbox.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetCheckbox/WidgetCheckbox.svelte
@@ -10,7 +10,7 @@
 	<svelte:fragment slot="before">
 		<input
 			bind:checked
-			class="rounded bg-gray-200 border-transparent focus:border-transparent text-blue-500 focus:ring-1 focus:ring-offset-2 focus:ring-gray-200 mr-2"
+			class="rounded bg-gray-200 dark:bg-gray-700 border-transparent text-blue-500 focus:ring-1 focus:ring-offset-2 focus:ring-blue-200 dark:focus:ring-gray-500 dark:focus:ring-offset-gray-925 cursor-pointer checked:bg-blue-500 dark:checked:bg-blue-500 mr-2"
 			type="checkbox"
 		/>
 	</svelte:fragment>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetRadio/WidgetRadio.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetRadio/WidgetRadio.svelte
@@ -12,7 +12,7 @@
 	<svelte:fragment slot="before">
 		<input
 			bind:group
-			class="bg-gray-200 dark:bg-gray-700 shadow-inner border-transparent focus:border-transparent text-blue-500 ring-1 ring-offset-2 ring-gray-200 dark:ring-gray-700 mr-2"
+			class="border-gray-300 dark:border-gray-700 focus:border-gray-300 hover:border-gray-300 focus:ring-1 focus:ring-offset-2 focus:ring-blue-200 dark:focus:ring-gray-500 dark:focus:ring-offset-gray-925 cursor-pointer checked:text-blue-500 mr-2"
 			on:change={onChange}
 			type="radio"
 			{value}


### PR DESCRIPTION
Ensure widget style is consistent for radio and checkboxes 

### Light theme
Without focus:
![image](https://user-images.githubusercontent.com/468620/191437735-dfe17dee-723a-4487-8139-d613ec6cd6b5.png)
![image](https://user-images.githubusercontent.com/468620/191437840-d76e50c8-4d7c-40c7-99a9-7518cee8433e.png)

With focus:
![image](https://user-images.githubusercontent.com/468620/191438104-006ba440-8cd9-4a77-a5b9-19ea8291154e.png)
![image](https://user-images.githubusercontent.com/468620/191438158-23ae371d-00d1-4269-a55f-3aee8de256f3.png)

### Dark theme
Without focus:
![image](https://user-images.githubusercontent.com/468620/191438352-4ab3f480-276f-4698-85b2-9ca1b782f8bf.png)

With focus:
![image](https://user-images.githubusercontent.com/468620/191438441-1742281c-0d56-4318-a307-f40f2660ebb6.png)
![image](https://user-images.githubusercontent.com/468620/191438483-c5daa0d6-548d-43f8-b0de-932c05be36b6.png)

