### PR TITLE
[doc+snippets] No more `use_auth_token=True` needed

### DIFF
--- a/docs/hub/models-gated.md
+++ b/docs/hub/models-gated.md
@@ -15,7 +15,9 @@ from huggingface_hub import notebook_login
 notebook_login()
 ```
 
-Then, ensure that your library uses the token. For example, if using 🤗 Transformers [you'll need to pass `use_auth_token=True`](https://huggingface.co/docs/transformers/main/en/main_classes/model#transformers.PreTrainedModel.from_pretrained) when calling `.from_pretrained()`.  
+Then, ensure that your library uses the token. This is now the case by default in huggingface-maintained libraries.
+
+However, on older versions of libraries, for example if using 🤗 Transformers with a version of `huggingface_hub` older than `v0.10` [you'll need to pass `use_auth_token=True`](https://huggingface.co/docs/transformers/main/en/main_classes/model#transformers.PreTrainedModel.from_pretrained) when calling `.from_pretrained()`.  
 
 ## Modifying the prompt 
 

--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -26,7 +26,7 @@ export enum ModelLibrary {
 	"fasttext"               = "fastText",
 	"stable-baselines3"      = "Stable-Baselines3",
 	"ml-agents"              = "ML-Agents",
-	"pythae"                 = "Pythae"
+	"pythae"                 = "Pythae",
 }
 
 export const ALL_MODEL_LIBRARY_KEYS = Object.keys(ModelLibrary) as (keyof typeof ModelLibrary)[];
@@ -97,7 +97,7 @@ model = BaseModel.from_pretrained("${model.id}")`;
 const diffusers = (model: ModelData) =>
 	`from diffusers import DiffusionPipeline
 
-pipeline = DiffusionPipeline.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""})`;
+pipeline = DiffusionPipeline.from_pretrained("${model.id}")`;
 
 const espnetTTS = (model: ModelData) =>
 	`from espnet2.bin.tts_inference import Text2Speech
@@ -301,15 +301,15 @@ const transformers = (model: ModelData) => {
 		return [
 			`from transformers import ${info.processor}, ${info.auto_model}`,
 			"",
-			`${varName} = ${info.processor}.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""})`,
+			`${varName} = ${info.processor}.from_pretrained("${model.id}")`,
 			"",
-			`model = ${info.auto_model}.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""})`,
+			`model = ${info.auto_model}.from_pretrained("${model.id}")`,
 		].join("\n");
 	} else {
 		return [
 			`from transformers import ${info.auto_model}`,
 			"",
-			`model = ${info.auto_model}.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""})`,
+			`model = ${info.auto_model}.from_pretrained("${model.id}")`,
 		].join("\n");
 	}
 };
@@ -458,8 +458,8 @@ export const MODEL_LIBRARIES_UI_ELEMENTS: { [key in keyof typeof ModelLibrary]?:
 	"stanza": {
 		btnLabel: "Stanza",
 		repoName: "stanza",
-		repoUrl: "https://github.com/stanfordnlp/stanza",
-		snippet: stanza,
+		repoUrl:  "https://github.com/stanfordnlp/stanza",
+		snippet:  stanza,
 	},
 	"tensorflowtts": {
 		btnLabel: "TensorFlowTTS",


### PR DESCRIPTION
Keeping as draft until https://github.com/huggingface/huggingface_hub/pull/1064 lands in a release. (and subsequently in a transformers or diffusers release if those still pin a version of `huggingface_hub` – not sure right now)