### PR TITLE
Run inference on cmd+Enter click on all widgets

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/WidgetShortcutRunLabel/WidgetShortcutRunLabel.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetShortcutRunLabel/WidgetShortcutRunLabel.svelte
@@ -2,7 +2,6 @@
 	import { onMount } from "svelte";
 
 	export let isLoading: boolean;
-	export let getOutput: () => void;
 
 	let shortcutLabel = "";
 
@@ -10,19 +9,7 @@
 		const isMac = navigator.platform.includes("Mac");
 		shortcutLabel = isMac ? "⌘+Enter" : "ctrl+Enter";
 	});
-
-	function onKeyDown(e: KeyboardEvent) {
-		if (isLoading) {
-			return;
-		}
-		if (e.code === "Enter" && (e.metaKey || e.ctrlKey)) {
-			e.preventDefault();
-			getOutput();
-		}
-	}
 </script>
-
-<svelte:window on:keydown={onKeyDown} />
 
 <kbd
 	class="no-hover:hidden text-xs bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 py-0.5 px-1.5 rounded leading-none border border-gray-200 {isLoading

--- a/js/src/lib/components/InferenceWidget/shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte
@@ -5,8 +5,21 @@
 	export let isDisabled = false;
 	export let isLoading: boolean;
 	export let label = "Compute";
-	export let onClick: (e: MouseEvent) => void;
+	export let onClick: () => void;
+
+	function onKeyDown(e: KeyboardEvent) {
+		if (isLoading) {
+			return;
+		}
+		// run inference on cmd+Enter
+		if (e.code === "Enter" && (e.metaKey || e.ctrlKey)) {
+			e.preventDefault();
+			onClick();
+		}
+	}
 </script>
+
+<svelte:window on:keydown={onKeyDown} />
 
 <button
 	class="btn-widget w-24 h-10 px-5 {classNames}"

--- a/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -222,7 +222,7 @@
 						getOutput();
 					}}
 				/>
-				<WidgetShortcutRunLabel {isLoading} {getOutput} />
+				<WidgetShortcutRunLabel {isLoading} />
 				<div class="ml-auto self-start">
 					<WidgetTimer bind:this={inferenceTimer} />
 				</div>


### PR DESCRIPTION
#### TLDR: run widget inference on `cmd+enter` click

Implementation: (almost) every widget has [WidgetSumbitBtn](https://github.com/huggingface/hub-docs/blob/2032eb1161001200a1f2b5526cea58a1a095e21c/js/src/lib/components/InferenceWidget/shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte), therefore, implemented the cmd+enter run mechanism in this component 
https://github.com/huggingface/hub-docs/blob/2032eb1161001200a1f2b5526cea58a1a095e21c/js/src/lib/components/InferenceWidget/shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte#L14-L18