### PR TITLE
fix(hub): remove h5 and savedmodels from safe format list

### DIFF
--- a/docs/hub/security-pickle.md
+++ b/docs/hub/security-pickle.md
@@ -208,8 +208,6 @@ model = AutoModel.from_pretrained("bert-base-cased", from_flax=True)
 
 ### Use your own serialization format
 
-- [HDF5](https://github.com/HDFGroup/hdf5)
-- [SavedModel](https://www.tensorflow.org/guide/saved_model)
 - [MsgPack](https://msgpack.org/index.html)
 - [Protobuf](https://developers.google.com/protocol-buffers)
 - [Cap'n'proto](https://capnproto.org/)


### PR DESCRIPTION
Thanks to @mmaitre314 for spotting that H5/SavedModels is not a safe serialisation format, as specified on [this documentation](https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md#running-untrusted-models).