### PR TITLE
[docs] add cc-by-nc-nd-3.0 to licenses

### DIFF
--- a/docs/hub/repositories-licenses.md
+++ b/docs/hub/repositories-licenses.md
@@ -34,6 +34,7 @@ Creative Commons Attribution Non Commercial 2.0	| `cc-by-nc-2.0`
 Creative Commons Attribution Non Commercial 3.0	| `cc-by-nc-3.0`
 Creative Commons Attribution Non Commercial 4.0	| `cc-by-nc-4.0`
 Creative Commons Attribution No Derivatives 4.0	| `cc-by-nd-4.0`
+Creative Commons Attribution Non Commercial No Derivatives 3.0	| `cc-by-nc-nd-3.0`
 Creative Commons Attribution Non Commercial No Derivatives 4.0	| `cc-by-nc-nd-4.0`
 Creative Commons Attribution Non Commercial Share Alike 2.0	| `cc-by-nc-sa-2.0`
 Creative Commons Attribution Non Commercial Share Alike 3.0	| `cc-by-nc-sa-3.0`


### PR DESCRIPTION
Example of a dataset registered under cc-by-nc-nd-3.0: 

TED-LIUM
OpenSLR: https://www.openslr.org/51/
HuggingFace Hub: https://huggingface.co/datasets/LIUM/tedlium