### PR TITLE
Updated yaml file doc to use checkout@v3

### DIFF
--- a/docs/hub/spaces-github-actions.md
+++ b/docs/hub/spaces-github-actions.md
@@ -32,7 +32,7 @@ jobs:
   sync-to-hub:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Push to hub


### PR DESCRIPTION
Node 12 has been out of support since April 2022, as a result Github has started the deprecation process of Node 12 for GitHub Actions. More details below  https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Verified the fix with a local action file with v3 version seems to fix the error in Git Actions