### PR TITLE
add code to languages list of datasets

### DIFF
--- a/js/src/lib/interfaces/Language.ts
+++ b/js/src/lib/interfaces/Language.ts
@@ -155,6 +155,11 @@ export const LANGUAGES: Record<string, Language> = {
 		name:       "Corsican",
 		nativeName: "corsu",
 	},
+	code: {
+		code:       "code",
+		name:       "Code",
+		nativeName: "code",
+	},
 	cr: {
 		code:       "cr",
 		name:       "Cree",


### PR DESCRIPTION
Add `code` to the list of languages displayed on the Hub for datasets.