### PR TITLE
Add Sample Factory to Hub Docs

### DIFF
--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -15,6 +15,7 @@ export enum ModelLibrary {
 	"keras"                  = "Keras",
 	"nemo"                   = "NeMo",
 	"pyannote-audio"         = "pyannote.audio",
+	"sample-factory"         = "Sample Factory",
 	"sentence-transformers"  = "Sentence Transformers",
 	"sklearn"                = "Scikit-learn",
 	"spacy"                  = "spaCy",
@@ -244,6 +245,12 @@ const fastai = (model: ModelData) =>
 	`from huggingface_hub import from_pretrained_fastai
 
 learn = from_pretrained_fastai("${model.id}")`;
+
+const sample-factory = (model: ModelData) =>
+	`python -m sample_factory.huggingface.load_from_hub -r ${model.id} -d <train_dir_path>`
+
+const mlAgents = (model: ModelData) =>
+	`mlagents-load-from-hf --repo-id="${model.id}" --local-dir="./downloads"`;
 
 const sentenceTransformers = (model: ModelData) =>
 	`from sentence_transformers import SentenceTransformer

--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -247,10 +247,7 @@ const fastai = (model: ModelData) =>
 learn = from_pretrained_fastai("${model.id}")`;
 
 const sample-factory = (model: ModelData) =>
-	`python -m sample_factory.huggingface.load_from_hub -r ${model.id} -d <train_dir_path>`
-
-const mlAgents = (model: ModelData) =>
-	`mlagents-load-from-hf --repo-id="${model.id}" --local-dir="./downloads"`;
+	`python -m sample_factory.huggingface.load_from_hub -r ${model.id} -d <train_dir_path>`;
 
 const sentenceTransformers = (model: ModelData) =>
 	`from sentence_transformers import SentenceTransformer

--- a/tasks/src/const.ts
+++ b/tasks/src/const.ts
@@ -21,7 +21,7 @@ export const TASKS_MODEL_LIBRARIES: Record<PipelineType, Array<keyof typeof Mode
 	"other":                          [],
 	"question-answering":             ["adapter-transformers", "allennlp", "transformers"],
 	"robotics":                       [],
-	"reinforcement-learning":         ["transformers", "stable-baselines3", "ml-agents"],
+	"reinforcement-learning":         ["transformers", "stable-baselines3", "ml-agents", "sample-factory"],
 	"sentence-similarity":            ["sentence-transformers", "spacy"],
 	"summarization":                  ["transformers"],
 	"table-question-answering":       ["transformers"],


### PR DESCRIPTION
Adding Sample Factory to Hub Docs and Moon-landing. cc @edbeeching 

TODO (Thomas):
✔️ Adding the widget "how to use the lib"
🔲 Add track in Elastic.ts in moon-landing
🔲 Create the library doc
