### PR TITLE
Model card additions

### DIFF
--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -1,5 +1,6 @@
 # Model Cards
 
+  ### [  <u>New! Try our experimental Modal Card Creator App</u>](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool)
 ## What are Model Cards?
 
 Model cards are files that accompany the models and provide handy information. Under the hood, model cards are simple Markdown files with additional metadata. Model cards are essential for discoverability, reproducibility, and sharing! You can find a model card as the `README.md` file in any model repo.

--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -1,6 +1,10 @@
 # Model Cards
 
-  ### <Tip>[ New! Try our experimental Modal Card Creator App](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool)</Tip>
+<Tip>
+
+[New! Try our experimental Model Card Creator App](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool)
+
+</Tip>
 ## What are Model Cards?
 
 Model cards are files that accompany the models and provide handy information. Under the hood, model cards are simple Markdown files with additional metadata. Model cards are essential for discoverability, reproducibility, and sharing! You can find a model card as the `README.md` file in any model repo.

--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -1,6 +1,6 @@
 # Model Cards
 
-  ### [  <u>New! Try our experimental Modal Card Creator App</u>](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool)
+  ### [  <Tip>New! Try our experimental Modal Card Creator App</Tip>](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool)
 ## What are Model Cards?
 
 Model cards are files that accompany the models and provide handy information. Under the hood, model cards are simple Markdown files with additional metadata. Model cards are essential for discoverability, reproducibility, and sharing! You can find a model card as the `README.md` file in any model repo.

--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -1,6 +1,6 @@
 # Model Cards
 
-  ### [<Tip> New! Try our experimental Modal Card Creator App</Tip>](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool)
+  ### <Tip>[ New! Try our experimental Modal Card Creator App](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool)</Tip>
 ## What are Model Cards?
 
 Model cards are files that accompany the models and provide handy information. Under the hood, model cards are simple Markdown files with additional metadata. Model cards are essential for discoverability, reproducibility, and sharing! You can find a model card as the `README.md` file in any model repo.

--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -1,6 +1,6 @@
 # Model Cards
 
-  ### [  <Tip>New! Try our experimental Modal Card Creator App</Tip>](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool)
+  ### [<Tip> New! Try our experimental Modal Card Creator App</Tip>](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool)
 ## What are Model Cards?
 
 Model cards are files that accompany the models and provide handy information. Under the hood, model cards are simple Markdown files with additional metadata. Model cards are essential for discoverability, reproducibility, and sharing! You can find a model card as the `README.md` file in any model repo.


### PR DESCRIPTION
We want users to be able to more easily find the [model card creator tool](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool) when they’re making cards, so I’m linking the space within the model card document for when users are reading the model cards hub doc.