### PR TITLE
changes to metrics

### DIFF
--- a/tasks/src/reinforcement-learning/data.ts
+++ b/tasks/src/reinforcement-learning/data.ts
@@ -12,9 +12,17 @@ const taskData: TaskDataCustom = {
 		outputs: [],
 	},
     metrics: [{
-        description: "Average return obtained after running the policy for a certain number of evaluation episodes ",
+		description: "Accumulated reward across all time steps discounted by a factor that ranges between 0 and 1 and determines how much the agent optimizes for future relative to immediate rewards. Measures how good is the policy ultimately found by a given algorithm considering uncertainty over the future.",
+		id:          "Discounted Total Reward",
+	},
+	{
+        description: "Average return obtained after running the policy for a certain number of evaluation episodes. As opposed to total reward, mean reward considers how much reward a given algorithm receives while learning.",
         id:          "Mean Reward",
-    }],
+    },
+	{
+		description: "Measures how good a given algorithm is after a predefined time. Some algorithms may be guaranteed to converge to optimal behavior across many time steps. However, an agent that reaches an acceptable level of optimality after a given time horizon may be preferable to one that ultimately reaches optimality but takes a long time.",
+		id:          "Level of Performance After Some Time",
+	}],
 	models: [
         {
 			description: "A Reinforcement Learning model trained on expert data from the Gym Hopper environment",


### PR DESCRIPTION
Addressing #357 

So sorry for the delay, @merveenoyan ! I've been crazy busy. I just suggested some edits to mean reward, which was already in data.ts and added two other metrics.

Two comments:

I noticed @RamAnanth had already contributed the D4RL dataset. I could also add [RL Unplugged](https://github.com/deepmind/deepmind-research/tree/master/rl_unplugged), [Robosuite](https://www.tensorflow.org/datasets/catalog/robosuite_panda_pick_place_can), [MuJoCo locomotion](https://www.tensorflow.org/datasets/catalog/locomotion), [MT Opt dataset](https://www.tensorflow.org/datasets/catalog/mt_opt), and [Mine RL Dataset](https://minerl.io/dataset/), but they don't seem to be hosted by Hugging Face.

Also, there's already three libraries in hub-docs/tasks/src/const.ts I could add [PyTorch](https://huggingface.co/edbeeching/decision-transformer-gym-hopper-medium) and [TensorBoard](https://huggingface.co/ThomasSimonini/MLAgents-Pyramids2), but neither is included in ModelLibrary on hub-docs/js/src/lib/interfaces/Libraries.ts