### PR TITLE
Text2Img widget `useCache = false`

### DIFF
--- a/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
@@ -62,6 +62,7 @@
 		addInferenceParameters(requestBody, model);
 
 		isLoading = true;
+		const useCache = false;
 
 		const res = await getResponse(
 			apiUrl,
@@ -71,7 +72,8 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			useCache
 		);
 
 		isLoading = false;


### PR DESCRIPTION
`useCache = false` when calling inference on Text2Img widgets so that different images can be generated with same prompt on subsequent clicks