### PR TITLE
Text-to-image widget background

### DIFF
--- a/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
@@ -144,7 +144,7 @@
 	</svelte:fragment>
 	<svelte:fragment slot="bottom">
 		{#if output.length}
-			<div class="flex justify-center mt-4 bg-gray-50">
+			<div class="flex justify-center mt-4 bg-gray-50 dark:bg-gray-925">
 				<img class="max-w-sm object-contain" src={output} alt="" />
 			</div>
 		{/if}


### PR DESCRIPTION
The background was white before.

<img width="675" alt="image" src="https://user-images.githubusercontent.com/3841370/202765542-2ee95a11-f5a6-4eb0-94a2-90ed9340c984.png">
