### PR TITLE
✨ Better typing for LIBRARY_TASK_MAPPING_EXCLUDING_TRANSFORMERS

### DIFF
--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -32,7 +32,8 @@ export enum ModelLibrary {
 	"pythae"                 = "Pythae",
 }
 
-export const ALL_MODEL_LIBRARY_KEYS = Object.keys(ModelLibrary) as (keyof typeof ModelLibrary)[];
+export type ModelLibraryKey = ModelLibraryKey;
+export const ALL_MODEL_LIBRARY_KEYS = Object.keys(ModelLibrary) as ModelLibraryKey[];
 
 
 /**
@@ -390,7 +391,7 @@ model = AutoModel.load_from_hf_hub("${model.id}")`;
 
 
 
-export const MODEL_LIBRARIES_UI_ELEMENTS: { [key in keyof typeof ModelLibrary]?: LibraryUiElement } = {
+export const MODEL_LIBRARIES_UI_ELEMENTS: { [key in ModelLibraryKey]?: LibraryUiElement } = {
 	// ^^ TODO(remove the optional ? marker when Stanza snippet is available)
 	"adapter-transformers": {
 		btnLabel: "Adapter Transformers",

--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -32,7 +32,7 @@ export enum ModelLibrary {
 	"pythae"                 = "Pythae",
 }
 
-export type ModelLibraryKey = ModelLibraryKey;
+export type ModelLibraryKey = keyof typeof ModelLibrary;
 export const ALL_MODEL_LIBRARY_KEYS = Object.keys(ModelLibrary) as ModelLibraryKey[];
 
 

--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -9,10 +9,12 @@ export enum ModelLibrary {
 	"allennlp"               = "allenNLP",
 	"asteroid"               = "Asteroid",
 	"diffusers"              = "Diffusers",
+	"doctr"                  = "docTR",
 	"espnet"                 = "ESPnet",
 	"fairseq"                = "Fairseq",
 	"flair"                  = "Flair",
 	"keras"                  = "Keras",
+	"k2"                     = "K2",
 	"nemo"                   = "NeMo",
 	"paddlenlp"              = "PaddleNLP",
 	"pyannote-audio"         = "pyannote.audio",
@@ -34,6 +36,10 @@ export enum ModelLibrary {
 
 export type ModelLibraryKey = keyof typeof ModelLibrary;
 export const ALL_MODEL_LIBRARY_KEYS = Object.keys(ModelLibrary) as ModelLibraryKey[];
+
+const EXCLUDE_THOSE_LIBRARIES_FROM_DISPLAY: ModelLibraryKey[] = ["doctr", "k2"];
+
+export const ALL_DISPLAY_MODEL_LIBRARY_KEYS = ALL_MODEL_LIBRARY_KEYS.filter(k => !EXCLUDE_THOSE_LIBRARIES_FROM_DISPLAY.includes(k));
 
 
 /**

--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -397,7 +397,7 @@ model = AutoModel.load_from_hf_hub("${model.id}")`;
 
 
 
-export const MODEL_LIBRARIES_UI_ELEMENTS: { [key in ModelLibraryKey]?: LibraryUiElement } = {
+export const MODEL_LIBRARIES_UI_ELEMENTS: Partial<Record<ModelLibraryKey, LibraryUiElement>> = {
 	// ^^ TODO(remove the optional ? marker when Stanza snippet is available)
 	"adapter-transformers": {
 		btnLabel: "Adapter Transformers",

--- a/js/src/lib/interfaces/Types.ts
+++ b/js/src/lib/interfaces/Types.ts
@@ -1,4 +1,4 @@
-import type { ModelLibrary } from "./Libraries";
+import type { ModelLibraryKey } from "./Libraries";
 
 // Warning: order of modalities here determine how they are listed on the /tasks page
 export const MODALITIES = [
@@ -760,7 +760,7 @@ export interface TransformersInfo {
  * This mapping is generated automatically by "python-api-export-tasks" action in huggingface/api-inference-community repo upon merge.
  * Ref: https://github.com/huggingface/api-inference-community/pull/158
  */
-export const LIBRARY_TASK_MAPPING_EXCLUDING_TRANSFORMERS: Partial<Record<keyof typeof ModelLibrary, PipelineType[]>> = {
+export const LIBRARY_TASK_MAPPING_EXCLUDING_TRANSFORMERS: Partial<Record<ModelLibraryKey, PipelineType[]>> = {
 	"adapter-transformers": [
 		"question-answering",
 		"text-classification",

--- a/js/src/lib/interfaces/Types.ts
+++ b/js/src/lib/interfaces/Types.ts
@@ -776,9 +776,9 @@ export const LIBRARY_TASK_MAPPING_EXCLUDING_TRANSFORMERS: Partial<Record<ModelLi
 	"diffusers": [
 		"text-to-image",
 	],
-	// "doctr": [
-	// 	"object-detection",
-	// ],
+	"doctr": [
+		"object-detection",
+	],
 	"espnet": [
 		"text-to-speech",
 		"automatic-speech-recognition",
@@ -797,9 +797,9 @@ export const LIBRARY_TASK_MAPPING_EXCLUDING_TRANSFORMERS: Partial<Record<ModelLi
 	"flair": [
 		"token-classification",
 	],
-	// "k2_sherpa": [
-	// 	"automatic-speech-recognition",
-	// ],
+	"k2": [
+		"automatic-speech-recognition",
+	],
 	"keras": [
 		"image-classification",
 	],
@@ -837,10 +837,6 @@ export const LIBRARY_TASK_MAPPING_EXCLUDING_TRANSFORMERS: Partial<Record<ModelLi
 	"stanza": [
 		"token-classification",
 	],
-	// "superb": [
-	// 	"automatic-speech-recognition",
-	// 	"speech-segmentation",
-	// ],
 	"timm": [
 		"image-classification",
 	],

--- a/js/src/lib/interfaces/Types.ts
+++ b/js/src/lib/interfaces/Types.ts
@@ -1,3 +1,5 @@
+import type { ModelLibrary } from "./Libraries";
+
 // Warning: order of modalities here determine how they are listed on the /tasks page
 export const MODALITIES = [
 	"cv",
@@ -758,88 +760,88 @@ export interface TransformersInfo {
  * This mapping is generated automatically by "python-api-export-tasks" action in huggingface/api-inference-community repo upon merge.
  * Ref: https://github.com/huggingface/api-inference-community/pull/158
  */
-export const LIBRARY_TASK_MAPPING_EXCLUDING_TRANSFORMERS: Record<string, Array<string>> = {
-	"adapter_transformers": [
+export const LIBRARY_TASK_MAPPING_EXCLUDING_TRANSFORMERS: Partial<Record<keyof typeof ModelLibrary, PipelineType[]>> = {
+	"adapter-transformers": [
 		"question-answering",
 		"text-classification",
-		"token-classification"
+		"token-classification",
 	],
 	"allennlp": [
-		"question-answering"
+		"question-answering",
 	],
 	"asteroid": [
-		"audio-source-separation",
-		"audio-to-audio"
+		// "audio-source-separation",
+		"audio-to-audio",
 	],
 	"diffusers": [
-		"text-to-image"
+		"text-to-image",
 	],
-	"doctr": [
-		"object-detection"
-	],
+	// "doctr": [
+	// 	"object-detection",
+	// ],
 	"espnet": [
 		"text-to-speech",
-		"automatic-speech-recognition"
+		"automatic-speech-recognition",
 	],
 	"fairseq": [
 		"text-to-speech",
-		"audio-to-audio"
+		"audio-to-audio",
 	],
 	"fastai": [
-		"image-classification"
+		"image-classification",
 	],
 	"fasttext": [
 		"feature-extraction",
-		"text-classification"
+		"text-classification",
 	],
 	"flair": [
-		"token-classification"
+		"token-classification",
 	],
-	"k2_sherpa": [
-		"automatic-speech-recognition"
-	],
+	// "k2_sherpa": [
+	// 	"automatic-speech-recognition",
+	// ],
 	"keras": [
-		"image-classification"
+		"image-classification",
 	],
 	"nemo": [
-		"automatic-speech-recognition"
+		"automatic-speech-recognition",
 	],
 	"paddlenlp": [
 		"conversational",
-		"fill-mask"
+		"fill-mask",
 	],
-	"pyannote_audio": [
-		"automatic-speech-recognition"
+	"pyannote-audio": [
+		"automatic-speech-recognition",
 	],
-	"sentence_transformers": [
+	"sentence-transformers": [
 		"feature-extraction",
-		"sentence-similarity"
+		"sentence-similarity",
 	],
 	"sklearn": [
 		"tabular-classification",
 		"tabular-regression",
-		"text-classification"
+		"text-classification",
 	],
 	"spacy": [
 		"token-classification",
 		"text-classification",
-		"sentence-similarity"
+		"sentence-similarity",
 	],
 	"speechbrain": [
 		"audio-classification",
 		"audio-to-audio",
 		"automatic-speech-recognition",
 		"text-to-speech",
-		"text2text-generation"
+		"text2text-generation",
 	],
 	"stanza": [
-		"token-classification"
+		"token-classification",
 	],
-	"superb": [
-		"automatic-speech-recognition",
-		"speech-segmentation"
-	],
+	// "superb": [
+	// 	"automatic-speech-recognition",
+	// 	"speech-segmentation",
+	// ],
 	"timm": [
-		"image-classification"
-	]
-}
+		"image-classification",
+	],
+};

--- a/tasks/src/Types.ts
+++ b/tasks/src/Types.ts
@@ -1,4 +1,4 @@
-import type { ModelLibrary } from "../../js/src/lib/interfaces/Libraries";
+import type { ModelLibraryKey } from "../../js/src/lib/interfaces/Libraries";
 import type { PipelineType } from "../../js/src/lib/interfaces/Types";
 
 export interface ExampleRepo {
@@ -46,7 +46,7 @@ export interface TaskData {
 	id: PipelineType;
 	isPlaceholder?: boolean;
 	label: string;
-	libraries: Array<keyof typeof ModelLibrary>;
+	libraries: ModelLibraryKey[];
 	metrics: ExampleRepo[];
 	models: ExampleRepo[];
 	summary: string;

--- a/tasks/src/const.ts
+++ b/tasks/src/const.ts
@@ -1,10 +1,10 @@
-import type { ModelLibrary } from "../../js/src/lib/interfaces/Libraries";
+import type { ModelLibraryKey } from "../../js/src/lib/interfaces/Libraries";
 import type { PipelineType } from "../../js/src/lib/interfaces/Types";
 
 /*
  * Model libraries compatible with each ML task
  */
-export const TASKS_MODEL_LIBRARIES: Record<PipelineType, Array<keyof typeof ModelLibrary>> = {
+export const TASKS_MODEL_LIBRARIES: Record<PipelineType, ModelLibraryKey[]> = {
 	"audio-classification":           ["speechbrain", "transformers"],
 	"audio-to-audio":                 ["asteroid", "speechbrain"],
 	"automatic-speech-recognition":   ["espnet", "nemo", "speechbrain", "transformers"],


### PR DESCRIPTION
Following #549 
Better / stricter typing, allowing only valid ModelLibrary tags and valid PipelineType