### PR TITLE
Show `Computation time on Intel Xeon 3rd Gen Scalable cpu`

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/WidgetInfo/WidgetInfo.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetInfo/WidgetInfo.svelte
@@ -34,6 +34,14 @@
 		}
 		return statuses[modelLoadInfo.status];
 	}
+
+	function getComputeTypeMsg(): string {
+		let compute_type = modelLoadInfo?.compute_type ?? "cpu";
+		if (compute_type === "cpu") {
+			return "Intel Xeon 3rd Gen Scalable cpu";
+		}
+		return compute_type;
+	}
 </script>
 
 <div class="mt-2">
@@ -56,7 +64,7 @@
 				</div>
 			</div>
 		{:else if computeTime}
-			Computation time on {modelLoadInfo?.compute_type ?? "cpu"}: {computeTime}
+			Computation time on {getComputeTypeMsg()}: {computeTime}
 		{:else}
 			{@html getStatusReport(modelLoadInfo, status)}
 		{/if}


### PR DESCRIPTION
<img width="493" alt="image" src="https://user-images.githubusercontent.com/11827707/208408589-d8c688ac-d45b-4f77-afde-c307bec45f83.png">

This is how it is gonna look. Two details are:
1. `cpu` is lowercase (i.e not `CPU`)
2. There is no link in ` Intel Xeon 3rd Gen`. It is just a text.

Does it look fine? @Michellehbn 😃 

[original issue here](https://github.com/huggingface/moon-landing/issues/3713#issuecomment-1330400976)
