### PR TITLE
Add an Example using Julia's Genie.jl framework

### DIFF
--- a/docs/hub/spaces-sdks-docker-examples.md
+++ b/docs/hub/spaces-sdks-docker-examples.md
@@ -7,3 +7,4 @@ We gathered some example demos in the [Docker Templates](https://huggingface.co/
 * Phoenix app for https://huggingface.co/spaces/DockerTemplates/single_file_phx_bumblebee_ml
 * HTTP endpoint in Go with query parameters https://huggingface.co/spaces/XciD/test-docker-go?q=Adrien
 * Shiny app written in Python https://huggingface.co/spaces/elonmuskceo/shiny-orbit-simulation
+* Genie.jl app in Julia https://huggingface.co/spaces/nooji/GenieOnHuggingFaceSpaces


### PR DESCRIPTION
I've created a demo using Julia lang's Genie.jl framework to build a webapp using Docker spaces! I would love to add this to the list of examples, as it is quite finicky to figure out how ports need to be exposed and how the default CMD is leveraged. I think this would be useful for those looking to grow the Julia ecosystem and support on the Huggingface platform :)