### PR TITLE
Add Datasets Card spec

### DIFF
--- a/datasetcard.md
+++ b/datasetcard.md
@@ -20,13 +20,12 @@ language_details:
 license_details: {license_details}  # Example: content or link to a license not present in https://hf.co/docs/hub/repositories-licenses
 pretty_name: {pretty_name}  # Example: SQuAD
 size_categories:
-- {size_0}  # Example: n<1K
-- {size_0}  # Example: 100K<n<1M
+- {number_of_elements_in_dataset}  # Example: n<1K, 100K<n<1M, …
 source_datasets:
 - {source_dataset_0}  # Example: wikipedia
 - {source_dataset_1}  # Example: laion/laion-2b
 task_categories:  # Full list at https://github.com/huggingface/hub-docs/blob/main/js/src/lib/interfaces/Types.ts
-- {task_0}  # Example: question-ansering
+- {task_0}  # Example: question-answering
 - {task_1}  # Example: image-classification
 task_ids:
 - {subtask_0}  # Example: extractive-qa

--- a/datasetcard.md
+++ b/datasetcard.md
@@ -8,18 +8,12 @@ license: {license}  # Example: apache-2.0 or any license from https://hf.co/docs
 tags:
 - {tag_0}  # Example: audio
 - {tag_1}  # Example: bio
-- {tag_2}  # Example: natural language understanding
-- {tag_3}  # Example: birds classification
+- {tag_2}  # Example: natural-language-understanding
+- {tag_3}  # Example: birds-classification
 annotations_creators:
-- {creator_0}  # Example: crowdsourced
-- {creator_1}  # Example: found
-- {creator_3}  # Example: expert-generated
-- {creator_4}  # Example: machine-generated
+- {creator}  # Example: crowdsourced, found, expert-generated, machine-generated
 language_creators:
-- {creator_0}  # Example: crowdsourced
-- {creator_1}  # Example: found
-- {creator_3}  # Example: expert-generated
-- {creator_4}  # Example: machine-generated
+- {creator}  # Example: crowdsourced, ...
 language_details:
 - {bcp47_lang_0}  # Example: fr-FR
 - {bcp47_lang_1}  # Example: en-US
@@ -46,7 +40,7 @@ configs:  # Optional for datasets with multiple configurations like glue.
 dataset_info:
   features:
     - name: {feature_name_0}    # Example: id
-      dtype: {feature_dtyp_e0}  # Example: int32
+      dtype: {feature_dtype_0}  # Example: int32
     - name: {feature_name_1}    # Example: text
       dtype: {feature_dtype_1}  # Example: string
     - name: {feature_name_2}    # Example: image

--- a/datasetcard.md
+++ b/datasetcard.md
@@ -79,7 +79,7 @@ dataset_info:
 #       ...
 # ```
 
-# Optional. If you want your dataset to be protected behind a gate that users have to accept to access the dataset:
+# Optional. If you want your dataset to be protected behind a gate that users have to accept to access the dataset. More info at https://huggingface.co/docs/hub/datasets-gated
 extra_gated_fields:
 - {field_name_0}: {field_type_0}  # Example: Name: text
 - {field_name_1}: {field_type_1}  # Example: Affiliation: text
@@ -87,7 +87,7 @@ extra_gated_fields:
 - {field_name_3}: {field_type_3}  # Example for speech datasets: I agree to not attempt to determine the identity of speakers in this dataset: checkbox
 extra_gated_prompt: {extra_gated_prompt}  # Example for speech datasets: By clicking on “Access repository” below, you also agree to not attempt to determine the identity of speakers in the dataset.
 
-# Optional. Add this if you want to encode a train and evaluation info in a structured way for AutoTrain
+# Optional. Add this if you want to encode a train and evaluation info in a structured way for AutoTrain or Evaluation on the Hub
 train-eval-index:
   - config: {config_name}           # The dataset config name to use. Example for datasets without configs: default. Example for glue: sst2
     task: {task_name}               # The task category name (same as task_category). Example: question-answering

--- a/datasetcard.md
+++ b/datasetcard.md
@@ -1,0 +1,118 @@
+---
+# Example metadata to be added to a dataset card.  
+# Full dataset card template at https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/templates/datasetcard_template.md
+language:
+- {lang_0}  # Example: fr
+- {lang_1}  # Example: en
+license: {license}  # Example: apache-2.0 or any license from https://hf.co/docs/hub/repositories-licenses
+tags:
+- {tag_0}  # Example: audio
+- {tag_1}  # Example: bio
+- {tag_2}  # Example: natural language understanding
+- {tag_3}  # Example: birds classification
+annotations_creators:
+- {creator_0}  # Example: crowdsourced
+- {creator_1}  # Example: found
+- {creator_3}  # Example: expert-generated
+- {creator_4}  # Example: machine-generated
+language_creators:
+- {creator_0}  # Example: crowdsourced
+- {creator_1}  # Example: found
+- {creator_3}  # Example: expert-generated
+- {creator_4}  # Example: machine-generated
+language_details:
+- {bcp47_lang_0}  # Example: fr-FR
+- {bcp47_lang_1}  # Example: en-US
+license_details: {license_details}  # Example: content or link to a license not present in https://hf.co/docs/hub/repositories-licenses
+pretty_name: {pretty_name}  # Example: SQuAD
+size_categories:
+- {size_0}  # Example: n<1K
+- {size_0}  # Example: 100K<n<1M
+source_datasets:
+- {source_dataset_0}  # Example: wikipedia
+- {source_dataset_1}  # Example: laion/laion-2b
+task_categories:  # Full list at https://github.com/huggingface/hub-docs/blob/main/js/src/lib/interfaces/Types.ts
+- {task_0}  # Example: question-ansering
+- {task_1}  # Example: image-classification
+task_ids:
+- {subtask_0}  # Example: extractive-qa
+- {subtask_1}  # Example: multi-class-image-classification
+paperswithcode_id: {paperswithcode_id}  # Dataset id on PapersWithCode (from the URL). Example for SQuAD: squad
+configs:  # Optional for datasets with multiple configurations like glue.
+- {config_0}  # Example for glue: sst2
+- {config_1}  # Example for glue: cola
+
+# Optional. This part can be used to store the feature types and size of the dataset to be used in python. This can be automatically generated using the datasets-cli.
+dataset_info:
+  features:
+    - name: {feature_name_0}    # Example: id
+      dtype: {feature_dtyp_e0}  # Example: int32
+    - name: {feature_name_1}    # Example: text
+      dtype: {feature_dtype_1}  # Example: string
+    - name: {feature_name_2}    # Example: image
+      dtype: {feature_dtype_2}  # Example: image
+    # Example for SQuAD:
+    # - name: id
+    #   dtype: string
+    # - name: title
+    #   dtype: string
+    # - name: context
+    #   dtype: string
+    # - name: question
+    #   dtype: string
+    # - name: answers
+    #   sequence:
+    #     - name: text
+    #       dtype: string
+    #     - name: answer_start
+    #       dtype: int32
+  config_name: {config_name}  # Example for glue: sst2
+  splits:
+    - name: {split_name_0}                  # Example: train
+      num_bytes: {split_num_bytes_0}        # Example for SQuAD: 79317110
+      num_examples: {split_num_examples_0}  # Example for SQuAD: 87599
+  download_size: {dataset_download_size}   # Example for SQuAD: 35142551
+  dataset_size: {dataset_size}             # Example for SQuAD: 89789763
+
+# It can also be a list of multiple configurations:
+# ```yaml
+# dataset_info:
+#   - config_name: {config0}
+#     features:
+#       ...
+#   - config_name: {config1}
+#     features:
+#       ...
+# ```
+
+# Optional. If you want your dataset to be protected behind a gate that users have to accept to access the dataset:
+extra_gated_fields:
+- {field_name_0}: {field_type_0}  # Example: Name: text
+- {field_name_1}: {field_type_1}  # Example: Affiliation: text
+- {field_name_2}: {field_type_2}  # Example: Email: text
+- {field_name_3}: {field_type_3}  # Example for speech datasets: I agree to not attempt to determine the identity of speakers in this dataset: checkbox
+extra_gated_prompt: {extra_gated_prompt}  # Example for speech datasets: By clicking on “Access repository” below, you also agree to not attempt to determine the identity of speakers in the dataset.
+
+# Optional. Add this if you want to encode a train and evaluation info in a structured way for AutoTrain
+train-eval-index:
+  - config: {config_name}           # The dataset config name to use. Example for datasets without configs: default. Example for glue: sst2
+    task: {task_name}               # The task category name (same as task_category). Example: question-answering
+    task_id: {task_type}            # The AutoTrain task id. Example: extractive_question_answering
+    splits:
+      train_split: train            # The split to use for training. Example: train
+      eval_split: validation        # The split to use for evaluation. Example: test
+    col_mapping:                    # The columns mapping needed to configure the task_id.
+    # Example for extractive_question_answering:
+      # question: question
+      # context: context
+      # answers:
+      #   text: text
+      #   answer_start: answer_start
+    metrics:
+      - type: {metric_type}         # The metric id. Example: wer. Use metric id from https://hf.co/metrics
+        name: {metric_name}         # Tne metric name to be displayed. Example: Test WER
+---
+
+Valid license identifiers can be found in [our docs](https://huggingface.co/docs/hub/repositories-licenses).
+
+For the full dataset card template, see: [https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/templates/datasetcard_template.md](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/templates/datasetcard_template.md).

--- a/datasetcard.md
+++ b/datasetcard.md
@@ -5,6 +5,7 @@ language:
 - {lang_0}  # Example: fr
 - {lang_1}  # Example: en
 license: {license}  # Example: apache-2.0 or any license from https://hf.co/docs/hub/repositories-licenses
+license_details: {license_details}  # Example: content or link to a license not present in https://hf.co/docs/hub/repositories-licenses
 tags:
 - {tag_0}  # Example: audio
 - {tag_1}  # Example: bio
@@ -17,7 +18,6 @@ language_creators:
 language_details:
 - {bcp47_lang_0}  # Example: fr-FR
 - {bcp47_lang_1}  # Example: en-US
-license_details: {license_details}  # Example: content or link to a license not present in https://hf.co/docs/hub/repositories-licenses
 pretty_name: {pretty_name}  # Example: SQuAD
 size_categories:
 - {number_of_elements_in_dataset}  # Example: n<1K, 100K<n<1M, …

--- a/docs/hub/datasets-cards.md
+++ b/docs/hub/datasets-cards.md
@@ -1,28 +1,36 @@
 # Dataset Cards
 
+## What are Dataet Cards?
+
 Each dataset may be documented by the `README.md` file in the repository. This file is called a **dataset card**, and the Hugging Face Hub will render its contents on the dataset's main page. To inform users about how to responsibly use the data, it's a good idea to include information about any potential biases within the dataset. Generally, dataset cards help users understand the contents of the dataset and give context for how the dataset should be used.
 
-You can also add dataset metadata to your card. The metadata describes important information about a dataset such as its license, language, and size. It also contains tags to help users discover a dataset on the Hub. Tags are defined in a YAML metadata section at the top of the `README.md` file. Supported tags include:
+You can also add dataset metadata to your card. The metadata describes important information about a dataset such as its license, language, and size. It also contains tags to help users discover a dataset on the Hub. Tags are defined in a YAML metadata section at the top of the `README.md` file.
+
+## Dataset card metadata
+
+A dataset repo will render its README.md as a dataset card. To control how the Hub displays the card, you should create a YAML section in the README file to define some metadata. Start by adding three --- at the top, then include all of the relevant metadata, and close the section with another group of --- like the example below:
 
 ```yaml
-tags: List[str]
-annotations_creators: List[str]
-language_creators: List[str]
-language: List[str]
-language_details: Optional[str]
-license: Union[str, List[str]]
-license_details: str
-pretty_name: str
-size_categories: List[str]
-source_datasets: List[str]
-task_categories: List[str]
-task_ids: List[str]
-paperswithcode_id: Optional[str]
-train-eval-index: List[Dict]
-configs: List[str]
-extra_gated_fields: Dict
-extra_gated_prompt: str
+language: 
+- "List of ISO 639-1 code for your language"
+- lang1
+- lang2
+pretty_name: "Pretty Name of the Dataset"
+tags:
+- tag1
+- tag2
+license: "any valid license identifier"
+task_categories:
+- task1
+- task2
 ```
+
+The metadata that you add to the dataset card enables certain interactions on the Hub. For example:
+
+* Allow users to filter and discover datasets at https://huggingface.co/datasets.
+* If you choose a license using the keywords listed in the right column of [this table](./repositories-licenses), the license will be displayed on the dataset page.
+
+See the detailed dataset card metadata specification [here]((https://github.com/huggingface/hub-docs/blob/main/datasetcard.md?plain=1)).
 
 Use the [Dataset Metadata Creator](https://huggingface.co/spaces/huggingface/datasets-tagging) to help you generate the appropriate metadata. For a step-by-step guide on creating a dataset card, check out the [Create a dataset card](https://huggingface.co/docs/datasets/dataset_card) guide.
 


### PR DESCRIPTION
I added a datasetcard spec in the same format as the one for models at https://github.com/huggingface/hub-docs/blob/main/modelcard.md

This can also be helpful for https://github.com/huggingface/huggingface_hub/pull/1282 cc @julien-c 
If this gets merged I'll also link the `datasets` docs to it