### PR TITLE
Update paddlenlp snippet to use `transformersInfo`

### DIFF
--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -167,7 +167,13 @@ const paddlenlp = (model: ModelData) => {
 			`model = ${architecture}.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
 		].join("\n");
 	} else {
-		return `# ⚠️ Type of model unknown`;
+		return [
+			`# ⚠️ Type of model unknown`,
+			`from paddlenlp.transformers import AutoTokenizer, AutoModel`,
+			"",
+			`tokenizer = AutoTokenizer.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
+			`model = AutoModel.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
+		].join("\n");
 	}
 };
 

--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -158,7 +158,7 @@ model = from_pretrained_keras("${model.id}")
 `;
 
 const paddlenlp = (model: ModelData) => {
-	if (model.config && model.config.architectures && model.config.architectures[0]) {
+	if (model.config?.architectures?.[0]) {
 		const architecture = model.config.architectures[0];
 		return [
 			`from paddlenlp.transformers import AutoTokenizer, ${architecture}`,

--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -158,9 +158,7 @@ model = from_pretrained_keras("${model.id}")
 `;
 
 const paddlenlp = (model: ModelData) => {
-	if (!(model.config && model.config.architectures)) {
-		return `# ⚠️ Type of model unknown`;
-	} else {
+	if (model.config && model.config.architectures && model.config.architectures[0]) {
 		const architecture = model.config.architectures[0];
 		return [
 			`from paddlenlp.transformers import AutoTokenizer, ${architecture}`,
@@ -168,6 +166,8 @@ const paddlenlp = (model: ModelData) => {
 			`tokenizer = AutoTokenizer.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
 			`model = ${architecture}.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
 		].join("\n");
+	} else {
+		return `# ⚠️ Type of model unknown`;
 	}
 };
 

--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -158,7 +158,7 @@ model = from_pretrained_keras("${model.id}")
 `;
 
 const paddlenlp = (model: ModelData) => {
-	if (!model.config) {
+	if (!(model.config && model.config.architectures)) {
 		return `# ⚠️ Type of model unknown`;
 	} else {
 		const architecture = model.config.architectures[0];

--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -158,10 +158,10 @@ model = from_pretrained_keras("${model.id}")
 `;
 
 const paddlenlp = (model: ModelData) => {
-	const architecture = model.config.architectures[0];
-	if (!architecture) {
+	if (!model.config) {
 		return `# ⚠️ Type of model unknown`;
 	} else {
+		const architecture = model.config.architectures[0];
 		return [
 			`from paddlenlp.transformers import AutoTokenizer, ${architecture}`,
 			"",

--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -158,12 +158,17 @@ model = from_pretrained_keras("${model.id}")
 `;
 
 const paddlenlp = (model: ModelData) => {
-	return [
-	  `from paddlenlp.transformers import AutoModel, AutoTokenizer`,
-	  "",
-	  `tokenizer = AutoTokenizer.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
-	  `model = AutoModel.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
-	].join("\n");
+	const info = model.transformersInfo;
+	if (!info) {
+		return `# ⚠️ Type of model unknown`;
+	} else {
+		return [
+			`from transformers import AutoTokenizer, ${info.auto_model}`,
+			"",
+			`tokenizer = AutoTokenizer.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
+			`model = AutoModel.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
+		].join("\n");
+	}
 };
 
 const pyannote_audio_pipeline = (model: ModelData) =>

--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -158,15 +158,15 @@ model = from_pretrained_keras("${model.id}")
 `;
 
 const paddlenlp = (model: ModelData) => {
-	const info = model.transformersInfo;
-	if (!info) {
+	const architecture = model.config.architectures[0];
+	if (!architecture) {
 		return `# ⚠️ Type of model unknown`;
 	} else {
 		return [
-			`from paddlenlp.transformers import AutoTokenizer, ${info.auto_model}`,
+			`from paddlenlp.transformers import AutoTokenizer, ${architecture}`,
 			"",
 			`tokenizer = AutoTokenizer.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
-			`model = ${info.auto_model}.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
+			`model = ${architecture}.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
 		].join("\n");
 	}
 };

--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -163,10 +163,10 @@ const paddlenlp = (model: ModelData) => {
 		return `# ⚠️ Type of model unknown`;
 	} else {
 		return [
-			`from transformers import AutoTokenizer, ${info.auto_model}`,
+			`from paddlenlp.transformers import AutoTokenizer, ${info.auto_model}`,
 			"",
 			`tokenizer = AutoTokenizer.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
-			`model = AutoModel.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
+			`model = ${info.auto_model}.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
 		].join("\n");
 	}
 };


### PR DESCRIPTION
`PaddleNLP` has upgraded to re-use the same config system as `transformers`. Updating the paddlenlp snippet to produce a more accurate snippet by using the `transformersInfo`