### PR TITLE
add capdec space in image-to-text

### DIFF
--- a/tasks/src/image-to-text/data.ts
+++ b/tasks/src/image-to-text/data.ts
@@ -63,7 +63,7 @@ const taskData: TaskDataCustom = {
 			id:          "Salesforce/BLIP",
 		},
 		{
-			description: "An image captioning application that demonstrates the effect of noise injections on captions.",
+			description: "An image captioning application that demonstrates the effect of noise on captions.",
 			id:          "johko/capdec-image-captioning",
 		},
 	],

--- a/tasks/src/image-to-text/data.ts
+++ b/tasks/src/image-to-text/data.ts
@@ -62,6 +62,10 @@ const taskData: TaskDataCustom = {
 			description: "An application that can caption images and answer questions about a given image.",
 			id:          "Salesforce/BLIP",
 		},
+		{
+			description: "An image captioning application that demonstrates the effect of noise injections on captions.",
+			id:          "johko/capdec-image-captioning",
+		},
 	],
 	summary:      "",
 	widgetModels: ["nlpconnect/vit-gpt2-image-captioning"],


### PR DESCRIPTION
I added the space for CapDec ([Text-Only Training for Image Captioning using Noise-Injected CLIP](https://arxiv.org/pdf/2211.00575.pdf)) on the Image-to-Text task page