### PR TITLE
We do not need `PIPELINE_TAGS_DISPLAY_ORDER` anymore

### DIFF
--- a/docs/hub/models-tasks.md
+++ b/docs/hub/models-tasks.md
@@ -72,7 +72,7 @@ The Hub allows users to filter models by a given task. To do this, you need to a
 In [interfaces/Types.ts](https://github.com/huggingface/hub-docs/blob/main/js/src/lib/interfaces/Types.ts), you need to do a couple of things
 
 * Add the type to `PIPELINE_DATA`. Note that pipeline types are sorted into different categories (NLP, Audio, Computer Vision, and others).
-* Specify the display order in `PIPELINE_TAGS_DISPLAY_ORDER`. It also needs minor changes in the following files:
+* You will also need to fill minor changes in the following files:
     1. [tasks/src/const.ts](https://github.com/huggingface/hub-docs/blob/main/tasks/src/const.ts)
     2. [tasks/src/tasksData.ts](https://github.com/huggingface/hub-docs/blob/main/tasks/src/tasksData.ts)
 

--- a/js/src/lib/interfaces/Types.ts
+++ b/js/src/lib/interfaces/Types.ts
@@ -619,51 +619,7 @@ export const ALL_SUBTASKS = Object.values(PIPELINE_DATA).flatMap(data => data.su
 export const ALL_SUBTASK_TYPES = ALL_SUBTASKS.map(s => s.type);
 export const ALL_SUBTASK_TYPES_SET = new Set(ALL_SUBTASK_TYPES);
 
-/*
- * Specification of pipeline tag display order.
- */
-export const PIPELINE_TAGS_DISPLAY_ORDER: Array<PipelineType> = [
-	"image-classification",
-	"translation",
-	"image-segmentation",
-	"fill-mask",
-	"automatic-speech-recognition",
-	"token-classification",
-	"sentence-similarity",
-	"audio-classification",
-	"question-answering",
-	"summarization",
-	"zero-shot-classification",
-	"table-to-text",
-	"feature-extraction",
-	"other",
-	"multiple-choice",
-	"text-classification",
-	"text-to-image",
-	"text2text-generation",
-	"zero-shot-image-classification",
-	"tabular-classification",
-	"tabular-regression",
-	"image-to-image",
-	"tabular-to-text",
-	"unconditional-image-generation",
-	"text-retrieval",
-	"text-to-speech",
-	"object-detection",
-	"video-classification",
-	"audio-to-audio",
-	"text-generation",
-	"conversational",
-	"table-question-answering",
-	"visual-question-answering",
-	"image-to-text",
-	"reinforcement-learning",
-	"robotics",
-	"voice-activity-detection",
-	"time-series-forecasting",
-	"document-question-answering",
-	"depth-estimation",
-];
+
 
 /**
  * Tags that are suggested inside the metadata GUI


### PR DESCRIPTION
We do not need PIPELINE_TAGS_DISPLAY_ORDER anymore now that we group by modalities on /models and /datasets