### PR TITLE
Fix snippet for zero-shot-classification for lang zh

### DIFF
--- a/js/src/lib/interfaces/DefaultWidget.ts
+++ b/js/src/lib/interfaces/DefaultWidget.ts
@@ -165,7 +165,7 @@ const MAPPING_ZH: PerLanguageMapping = new Map([
 	[ "zero-shot-classification", [
 		{
 			text: "房间干净明亮，非常不错",
-			candidate_labels: ["这是一条差评", "这是一条好评"],
+			candidate_labels: "这是一条差评, 这是一条好评",
 		}
 	] ],
 	[ "summarization", [


### PR DESCRIPTION
Value for `candidate_labels` field needs to be string, not string[] as written [here](https://huggingface.co/docs/hub/models-widgets-examples#zeroshot-classification).
It should fix the issue for running widget on https://huggingface.co/PaddlePaddle/utc-large

cc: @sijunhe 