### PR TITLE
Switch order of text-to-image models

### DIFF
--- a/tasks/src/text-to-image/data.ts
+++ b/tasks/src/text-to-image/data.ts
@@ -29,12 +29,12 @@ const taskData: TaskDataCustom = {
 	metrics: [],
 	models:  [
 		{
-			description: "A model that can be used to generate images based on text prompts. The DALL·E Mega model is the largest version of DALLE Mini.",
-			id:          "dalle-mini/dalle-mega",
-		},
-		{
 			description: "A latent text-to-image diffusion model capable of generating photo-realistic images given any text input.",
 			id:          "CompVis/stable-diffusion-v1-4",
+		},
+		{
+			description: "A model that can be used to generate images based on text prompts. The DALL·E Mega model is the largest version of DALLE Mini.",
+			id:          "dalle-mini/dalle-mega",
 		},
 	],
 	spaces:       [


### PR DESCRIPTION
# What does this PR do? 

This PR changes the order for the "models" on the task page since `dalle-mini` is not supported in `diffusers`.