### PR TITLE
Document app_port in spaces config reference

### DIFF
--- a/docs/hub/spaces-config-reference.md
+++ b/docs/hub/spaces-config-reference.md
@@ -32,7 +32,7 @@ Streamlit versions are supported from `0.79.0` to `1.15.2`.
 Path to your main application file (which contains either `gradio` or `streamlit` Python code, or `static` html code).  
 Path is relative to the root of the repository.  
 
-**`app_port`** : _int_
+**`app_port`** : _int_  
 Port on which your application is running. Used only if `sdk` is `docker`. Default port is `7860`.
 
 **`fullWidth`**: _boolean_  

--- a/docs/hub/spaces-config-reference.md
+++ b/docs/hub/spaces-config-reference.md
@@ -32,6 +32,9 @@ Streamlit versions are supported from `0.79.0` to `1.15.2`.
 Path to your main application file (which contains either `gradio` or `streamlit` Python code, or `static` html code).  
 Path is relative to the root of the repository.  
 
+**`app_port`** : _int_
+Port on which your application is running. Used only if `sdk` is `docker`. Default port is `7860`.
+
 **`fullWidth`**: _boolean_  
 Whether your Space is rendered inside a full-width (when `true`) or fixed-width column (ie. "container" CSS) inside the iframe.
 Defaults to false in `gradio` and `streamlit`, and to true for other sdks.


### PR DESCRIPTION
**`app_port`** is not documented in https://huggingface.co/docs/hub/spaces-config-reference (only used for dockerfiles)


See https://moon-ci-docs.huggingface.co/docs/hub/pr_646/en/spaces-config-reference