### PR TITLE
Fix #645 breaking doc-builder

### DIFF
--- a/docs/hub/webhooks-guide-metadata-review.md
+++ b/docs/hub/webhooks-guide-metadata-review.md
@@ -156,7 +156,7 @@ Your webhook will look like this:
 ![webhook settings](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/webhooks-guides/003-metadata-review/webhook-settings.png)
 
 
-## Create a new "Bot" user profile
+## Create a new Bot user profile
 
 This guide creates a separate user account that will post the metadata reviews. 
 


### PR DESCRIPTION
see this comment: https://github.com/huggingface/hub-docs/pull/645#issuecomment-1410816047

see double escaping of Bot inside quotes here:

<img width="1328" alt="Screenshot 2023-02-01 at 22 11 20" src="https://user-images.githubusercontent.com/326577/216164224-94522283-6d0d-4259-a417-bdb4f7efc5f5.png">


cc @mishig25 @coyotte508 for doc-builder