### PR TITLE
docs: add Zeno example to Docker Spaces examples

### DIFF
--- a/docs/hub/spaces-sdks-docker-examples.md
+++ b/docs/hub/spaces-sdks-docker-examples.md
@@ -10,3 +10,4 @@ We gathered some example demos in the [Docker Templates](https://huggingface.co/
 * Genie.jl app in Julia https://huggingface.co/spaces/nooji/GenieOnHuggingFaceSpaces
 * Argilla app for data labelling and curation: https://huggingface.co/spaces/argilla/live-demo and [write-up about hosting Argilla on Spaces](./spaces-sdks-docker-argilla) by [@dvilasuero](https://huggingface.co/dvilasuero) 🎉
 * JupyterLab: https://huggingface.co/spaces/camenduru/jupyter
+* Zeno app for interactive model evaluation: https://huggingface.co/spaces/zeno-ml/diffusiondb and [instructions for setup](https://zenoml.com/docs/deployment#hugging-face-spaces)


### PR DESCRIPTION
Add an entry to the Docker spaces examples for the Zeno evaluation framework: zenoml.com