### PR TITLE
Enable download Git-LFS files on sync

### DIFF
--- a/docs/hub/spaces-github-actions.md
+++ b/docs/hub/spaces-github-actions.md
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          lfs: true
       - name: Push to hub
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}


### PR DESCRIPTION
Following an user issue, enable LFS on [sync](https://github.com/actions/checkout#:~:text=Whether%20to%20download%20Git%2DLFS%20files)

