### PR TITLE
Set embed mode of a Streamlit app example

### DIFF
--- a/docs/hub/spaces-sdks-streamlit.md
+++ b/docs/hub/spaces-sdks-streamlit.md
@@ -94,7 +94,7 @@ For example, the demo above can be embedded in these docs with the following tag
   sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"
 ></iframe>
 
-Please note that we have added `?embed=true` to the URL, which makes the Streamlit app rendered in embed mode, removing some non-essential parts such as the footer.
+Please note that we have added `?embed=true` to the URL, which activates the embed mode of the Streamlit app, removing some spacers and the footer for slim embeds.
 
 
 Additionally, you can checkout [our documentation](./spaces-embed).

--- a/docs/hub/spaces-sdks-streamlit.md
+++ b/docs/hub/spaces-sdks-streamlit.md
@@ -77,9 +77,23 @@ You can use the HTML `<iframe>` tag to embed a Streamlit Space as an inline fram
 For example, the demo above can be embedded in these docs with the following tag:
 
 ```
-<iframe src="https://NimaBoscarino-hotdog-streamlit.hf.space" title="My awesome Streamlit Space"></iframe>
+<iframe
+  src="https://NimaBoscarino-hotdog-streamlit.hf.space?embed=true"
+  title="My awesome Streamlit Space"
+></iframe>
 ```
 
-<iframe src="https://NimaBoscarino-hotdog-streamlit.hf.space" frameBorder="0" height="600" title="Streamlit app" class="container p-0 flex-grow space-iframe" allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; document-domain; encrypted-media; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; vr ; wake-lock; xr-spatial-tracking" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"></iframe>
+<iframe
+  src="https://NimaBoscarino-hotdog-streamlit.hf.space?embed=true"
+  frameborder="0"
+  height="364"  <!-- This height is calculated as 236 + 64 * 2. 236 is the inner content height measured with Chrome 108. 64 is padding-top of its container element. -->
+  title="Streamlit app"
+  class="container p-0 flex-grow space-iframe"
+  allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; document-domain; encrypted-media; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; vr ; wake-lock; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"
+></iframe>
+
+Please note that we have added `?embed=true` to the URL, which makes the Streamlit app rendered in embed mode, removing some non-essential parts such as the footer.
+
 
 Additionally, you can checkout [our documentation](./spaces-embed).

--- a/docs/hub/spaces-sdks-streamlit.md
+++ b/docs/hub/spaces-sdks-streamlit.md
@@ -83,10 +83,11 @@ For example, the demo above can be embedded in these docs with the following tag
 ></iframe>
 ```
 
+<!-- The height of this iframe has been calculated as 236 + 64 * 2. 236 is the inner content height measured with Chrome 108. 64 is padding-top of its container element. -->
 <iframe
   src="https://NimaBoscarino-hotdog-streamlit.hf.space?embed=true"
   frameborder="0"
-  height="364"  <!-- This height is calculated as 236 + 64 * 2. 236 is the inner content height measured with Chrome 108. 64 is padding-top of its container element. -->
+  height="364"
   title="Streamlit app"
   class="container p-0 flex-grow space-iframe"
   allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; document-domain; encrypted-media; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; vr ; wake-lock; xr-spatial-tracking"


### PR DESCRIPTION
~~This is just a suggestion, and I still haven't confirmed whether or not the embeddng mode is an officially supported API, so I leave this PR as a draft at this moment, before I get an answer to [this question](https://huggingface.slack.com/archives/C01A67JREBT/p1677056033767559).~~

This API is officially documented at https://docs.streamlit.io/streamlit-community-cloud/get-started/deploy-an-app#embed-apps while it's about Streamlit Cloud, and it is also referred to in some issues too such as: https://github.com/streamlit/streamlit/issues/911.

<table>
<tr>
<th>
Current ver.
</th>
<th>
This PR
</th>
</tr>
<tr>
<td>
<img width="1067" alt="CleanShot 2023-02-22 at 18 36 51@2x" src="https://user-images.githubusercontent.com/3135397/220580843-1a738041-fd2a-44d8-bc3b-644629e795f5.png">

</td>
<td>
<img width="995" alt="CleanShot 2023-02-22 at 18 35 52@2x" src="https://user-images.githubusercontent.com/3135397/220580709-2ef7652b-f468-4c6e-8e3b-3e34be77c25d.png">

</td>
</tr>
</table>