### PR TITLE
Fix #714

### DIFF
--- a/tasks/src/tasksData.ts
+++ b/tasks/src/tasksData.ts
@@ -72,7 +72,7 @@ export const TASKS_DATA: Record<PipelineType, TaskData | undefined> = {
 	"text-retrieval":                 undefined,
 	"text-to-image":                  getData("text-to-image", textToImage),
 	"text-to-speech":                 getData("text-to-speech", textToSpeech),
-	"text-to-video ":                 undefined,
+	"text-to-video":                  undefined,
 	"text2text-generation":           undefined,
 	"time-series-forecasting":        undefined,
 	"token-classification":           getData("token-classification", tokenClassification),


### PR DESCRIPTION
@osanseviero it wasn't caught because the CI only checks the files in `js/src/lib/interfaces`, and the faulty file is in `tasks/src`