### PR TITLE
Add Eastern Mari and Erzya to Language.ts

### DIFF
--- a/js/src/lib/interfaces/Language.ts
+++ b/js/src/lib/interfaces/Language.ts
@@ -1228,5 +1228,15 @@ export const LANGUAGES: Record<string, Language> = {
 		name: "Yakut",
 		nativeName: "саха тыла",
 	},
+	mhr: {
+		code: "mhr",
+		name: "Eastern Mari",
+		nativeName: "олык марий",
+	},
+	myv: {
+		code: "myv",
+		name: "Erzya",
+		nativeName: "эрзянь кель",
+	},
 };
 


### PR DESCRIPTION
Adds [Eastern Mari](https://en.wikipedia.org/wiki/Meadow_Mari_language) and [Erzya](https://en.wikipedia.org/wiki/Erzya_language) to `Language.ts`. 

Requested in https://github.com/huggingface/datasets/issues/5675.