### PR TITLE
Fix type in function signature

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/helpers.ts
+++ b/js/src/lib/components/InferenceWidget/shared/helpers.ts
@@ -22,7 +22,7 @@ export function getDemoInputs(model: ModelData, keys: (number | string)[]): any[
 }
 
 // Update current url search params, keeping existing keys intact.
-export function updateUrl(obj: Record<string, string>) {
+export function updateUrl(obj: Record<string, string | undefined>) {
 	if (!window) {
 		return;
 	}


### PR DESCRIPTION
Allowing undefined values helps remove a query parameter from the URL. It's already working, but the type in the signature needs to be corrected.