### PR TITLE
Bump streamlit version

### DIFF
--- a/docs/hub/spaces-config-reference.md
+++ b/docs/hub/spaces-config-reference.md
@@ -26,7 +26,7 @@ Defaults to `3.8.9`.
 **`sdk_version`** : _string_  
 Specify the version of the selected SDK (Streamlit or Gradio).  
 All versions of Gradio are supported.  
-Streamlit versions are supported from `0.79.0` to `1.15.2`.  
+Streamlit versions are supported from `0.79.0` to `1.17.0`.  
 
 **`app_file`** : _string_  
 Path to your main application file (which contains either `gradio` or `streamlit` Python code, or `static` html code).  


### PR DESCRIPTION
Update version, see #687 .
Btw, the support for 1.17 is not mentioned in the [Changelog ](https://github.com/huggingface/hub-docs/blob/main/docs/hub/spaces-changelog.md), maybe this should be added as well?