### PR TITLE
[Docs] Resolve URL linking to wrong library tag

### DIFF
--- a/docs/hub/span_marker.md
+++ b/docs/hub/span_marker.md
@@ -4,7 +4,7 @@
 
 ## Exploring SpanMarker in the Hub
 
-You can find `span_marker` models by filtering at the left of the [models page](https://huggingface.co/models?library=span_marker).
+You can find `span_marker` models by filtering at the left of the [models page](https://huggingface.co/models?library=span-marker).
 
 All models on the Hub come with these useful features:
 1. An automatically generated model card with a brief description.


### PR DESCRIPTION
Hello!

## Pull Request overiew
* Replace the library tag `span_marker` with the correct `span-marker` in the SpanMarker docs.

## Details
This originates from before I changed from `span_marker` to `span-marker`, I just missed this one case.

Before: https://huggingface.co/models?library=span_marker
After: https://huggingface.co/models?library=span-marker

- Tom Aarsen