### PR TITLE
Remove indentation in SpanMarker snippet

### DIFF
--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -318,7 +318,7 @@ nlp = ${nameWithoutNamespace(model.id)}.load()`;
 const span_marker = (model: ModelData) =>
 	`from span_marker import SpanMarkerModel
 
-	model = SpanMarkerModel.from_pretrained("${model.id}")`;
+model = SpanMarkerModel.from_pretrained("${model.id}")`;
 
 const stanza = (model: ModelData) =>
 	`import stanza


### PR DESCRIPTION
Hello!

## Pull Request overview
* Remove indentation in SpanMarker snippet.

## Details
![image](https://user-images.githubusercontent.com/37621491/235897665-5fe29241-ff4f-4433-80c1-f4e6f9ab2056.png)
I definitely should have caught this earlier, that's on me.

Thanks again,

- Tom Aarsen