### PR TITLE
[Tasks] adds links to the task guides in the docs

### DIFF
--- a/tasks/src/audio-classification/about.md
+++ b/tasks/src/audio-classification/about.md
@@ -56,4 +56,18 @@ Speaker Identification is classifying the audio of the person speaking. Speakers
 
 We have some great news! You can do fine-tuning (transfer learning) to train a well-performing model without requiring as much data. Pretrained models such as Wav2Vec2 and HuBERT exist. [Facebook's Wav2Vec2 XLS-R model](https://ai.facebook.com/blog/wav2vec-20-learning-the-structure-of-speech-from-raw-audio/) is a large multilingual model trained on 128 languages and with 436K hours of speech.
 
-We suggest checking out the following [example](https://github.com/huggingface/transformers/tree/main/examples/pytorch/audio-classification) ([Colab Notebook](https://colab.research.google.com/github/huggingface/notebooks/blob/master/examples/audio_classification.ipynb)) to learn how to fine-tune a model for audio classification with a single or multiple GPUs and share it on the Hub.
+## Useful Resources
+
+Would you like to learn more about the topic? Awesome! Here you can find some curated resources that you may find helpful!
+
+### Notebooks
+
+- [PyTorch](https://colab.research.google.com/github/huggingface/notebooks/blob/master/examples/audio_classification.ipynb)
+
+### Scripts for training
+
+- [PyTorch](https://github.com/huggingface/transformers/tree/main/examples/pytorch/audio-classification) 
+
+### Documentation
+
+- [Audio classification task guide](https://huggingface.co/docs/transformers/tasks/audio_classification)

--- a/tasks/src/automatic-speech-recognition/about.md
+++ b/tasks/src/automatic-speech-recognition/about.md
@@ -69,5 +69,6 @@ These events help democratize ASR for all languages, including low-resource lang
 - [ML for Audio Study Group - Intro to Audio and ASR Deep Dive](https://www.youtube.com/watch?v=D-MH6YjuIlE)
 - [Massively Multilingual ASR: 50 Languages, 1 Model, 1 Billion Parameters](https://arxiv.org/pdf/2007.03001.pdf)
 - An ASR toolkit made by [NVIDIA: NeMo](https://github.com/NVIDIA/NeMo) with code and pretrained models useful for new ASR models. Watch the [introductory video](https://www.youtube.com/embed/wBgpMf_KQVw) for an overview.
-- [An introduction to SpeechT5, a multi-purpose speech recognition and synthesis model](https://huggingface.co/blog/speecht5).
+- [An introduction to SpeechT5, a multi-purpose speech recognition and synthesis model](https://huggingface.co/blog/speecht5)
 - [A guide on Fine-tuning Whisper For Multilingual ASR with 🤗Transformers](https://huggingface.co/blog/fine-tune-whisper)
+- [Automatic speech recognition task guide](https://huggingface.co/docs/transformers/tasks/asr)

--- a/tasks/src/depth-estimation/about.md
+++ b/tasks/src/depth-estimation/about.md
@@ -33,5 +33,5 @@ result
 
 ## Useful Resources
 
-In this area, you can insert useful resources about how to train or use a model for this task.
+- [Monocular depth estimation task guide](https://huggingface.co/docs/transformers/tasks/monocular_depth_estimation)
 

--- a/tasks/src/document-question-answering/about.md
+++ b/tasks/src/document-question-answering/about.md
@@ -47,4 +47,8 @@ Would you like to learn more about Document QA? Awesome! Here are some curated r
 - [Fine-tuning LayoutLMv2 on DocVQA dataset](https://github.com/NielsRogge/Transformers-Tutorials/tree/1b4bad710c41017d07a8f63b46a12523bfd2e835/LayoutLMv2/DocVQA)
 - [Accelerating Document AI](https://huggingface.co/blog/document-ai)
 
+### Documentation
+
+- [Document question answering task guide](https://huggingface.co/docs/transformers/tasks/document_question_answering)
+
 The contents of this page are contributed by [Eliott Zemour](https://huggingface.co/eliolio) and reviewed by [Kwadwo Agyapon-Ntra](https://huggingface.co/KayO) and [Ankur Goyal](https://huggingface.co/ankrgyl).

--- a/tasks/src/fill-mask/about.md
+++ b/tasks/src/fill-mask/about.md
@@ -45,3 +45,7 @@ Would you like to learn more about the topic? Awesome! Here you can find some cu
 - [PyTorch](https://github.com/huggingface/transformers/tree/main/examples/pytorch/language-modeling)
 - [Flax](https://github.com/huggingface/transformers/tree/main/examples/flax/language-modeling)
 - [TensorFlow](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/language-modeling)
+
+### Documentation
+
+- [Masked language modeling task guide](https://huggingface.co/docs/transformers/tasks/masked_language_modeling)

--- a/tasks/src/image-classification/about.md
+++ b/tasks/src/image-classification/about.md
@@ -29,6 +29,7 @@ clf("path_to_a_cat_image")
 - [Walkthrough of Computer Vision Ecosystem in Hugging Face - CV Study Group](https://www.youtube.com/watch?v=oL-xmufhZM8)
 - [Computer Vision Study Group: Swin Transformer](https://www.youtube.com/watch?v=Ngikt-K1Ecc)
 - [Computer Vision Study Group: Masked Autoencoders Paper Walkthrough](https://www.youtube.com/watch?v=Ngikt-K1Ecc)
+- [Image classification task guide](https://huggingface.co/docs/transformers/tasks/image_classification)
 
 ### Creating your own image classifier in just a few minutes
 

--- a/tasks/src/image-segmentation/about.md
+++ b/tasks/src/image-segmentation/about.md
@@ -48,3 +48,4 @@ Would you like to learn more about image segmentation? Great! Here you can find 
 - [Walkthrough of Computer Vision Ecosystem in Hugging Face - CV Study Group](https://www.youtube.com/watch?v=oL-xmufhZM8)
 - [A Guide on Universal Image Segmentation with Mask2Former and OneFormer](https://huggingface.co/blog/mask2former)
 - [Zero-shot image segmentation with CLIPSeg](https://huggingface.co/blog/clipseg-zero-shot)
+- [Semantic segmentation task guide](https://huggingface.co/docs/transformers/tasks/semantic_segmentation)

--- a/tasks/src/object-detection/about.md
+++ b/tasks/src/object-detection/about.md
@@ -33,3 +33,4 @@ model("path_to_cat_image")
 
 # Useful Resources
 - [Walkthrough of Computer Vision Ecosystem in Hugging Face - CV Study Group](https://www.youtube.com/watch?v=oL-xmufhZM8)
+- [Object detection task guide](https://huggingface.co/docs/transformers/tasks/object_detection)

--- a/tasks/src/question-answering/about.md
+++ b/tasks/src/question-answering/about.md
@@ -50,3 +50,7 @@ Would you like to learn more about QA? Awesome! Here are some curated resources 
 - [PyTorch](https://github.com/huggingface/transformers/tree/main/examples/pytorch/question-answering)
 - [TensorFlow](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/question-answering)
 - [Flax](https://github.com/huggingface/transformers/tree/main/examples/flax/question-answering)
+
+### Documentation
+
+- [Question answering task guide](https://huggingface.co/docs/transformers/tasks/question_answering)

--- a/tasks/src/summarization/about.md
+++ b/tasks/src/summarization/about.md
@@ -37,3 +37,7 @@ Would you like to learn more about the topic? Awesome! Here you can find some cu
 - [PyTorch](https://github.com/huggingface/transformers/tree/main/examples/pytorch/summarization)
 - [TensorFlow](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/summarization)
 - [Flax](https://github.com/huggingface/transformers/tree/main/examples/flax/summarization)
+
+### Documentation
+
+- [Summarization task guide](https://huggingface.co/docs/transformers/tasks/summarization)

--- a/tasks/src/text-classification/about.md
+++ b/tasks/src/text-classification/about.md
@@ -6,7 +6,7 @@ You can track the sentiments of your customers from the product reviews using se
 
 ## Task Variants
 
-### Natural Language Infenrence (NLI)
+### Natural Language Inference (NLI)
 
 In NLI the model determines the relationship between two given texts. Concretely, the model takes a premise and a hypothesis and returns a class that can either be:
 
@@ -153,3 +153,7 @@ Would you like to learn more about the topic? Awesome! Here you can find some cu
 - [PyTorch](https://github.com/huggingface/transformers/tree/main/examples/pytorch/text-classification)
 - [TensorFlow](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/text-classification)
 - [Flax](https://github.com/huggingface/transformers/tree/main/examples/flax/text-classification)
+
+### Documentation
+
+- [Text classification task guide](https://huggingface.co/docs/transformers/tasks/sequence_classification)

--- a/tasks/src/text-generation/about.md
+++ b/tasks/src/text-generation/about.md
@@ -99,3 +99,4 @@ Would you like to learn more about the topic? Awesome! Here you can find some cu
 ### Documentation
 
 - [Causal language modeling task guide](https://huggingface.co/docs/transformers/tasks/language_modeling)
+- [Text generation strategies](https://huggingface.co/docs/transformers/generation_strategies)

--- a/tasks/src/text-generation/about.md
+++ b/tasks/src/text-generation/about.md
@@ -95,3 +95,7 @@ Would you like to learn more about the topic? Awesome! Here you can find some cu
 - [Training a CLM in PyTorch](https://github.com/huggingface/transformers/tree/main/examples/pytorch/language-modeling)
 - [Training a CLM in TensorFlow](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/language-modeling)
 - [Text Generation in PyTorch](https://github.com/huggingface/transformers/tree/main/examples/pytorch/text-generation)
+
+### Documentation
+
+- [Causal language modeling task guide](https://huggingface.co/docs/transformers/tasks/language_modeling)

--- a/tasks/src/token-classification/about.md
+++ b/tasks/src/token-classification/about.md
@@ -70,3 +70,7 @@ Would you like to learn more about token classification? Great! Here you can fin
 - [PyTorch](https://github.com/huggingface/transformers/tree/main/examples/pytorch/token-classification)
 - [TensorFlow](https://github.com/huggingface/transformers/tree/main/examples/tensorflow)
 - [Flax](https://github.com/huggingface/transformers/tree/main/examples/flax/token-classification)
+
+### Documentation
+
+- [Token classification task guide](https://huggingface.co/docs/transformers/tasks/token_classification)

--- a/tasks/src/translation/about.md
+++ b/tasks/src/translation/about.md
@@ -47,3 +47,7 @@ Would you like to learn more about Translation? Great! Here you can find some cu
 
 - [PyTorch](https://github.com/huggingface/transformers/tree/main/examples/pytorch/translation)
 - [TensorFlow](https://github.com/huggingface/transformers/tree/main/examples/tensorflow/translation)
+
+### Documentation
+
+- [Translation task guide](https://huggingface.co/docs/transformers/tasks/translation)

--- a/tasks/src/video-classification/about.md
+++ b/tasks/src/video-classification/about.md
@@ -1,4 +1,4 @@
-## Use Cases
+## Use Cases
 Video classification models can be used to categorize what a video is all about.
 
 ### Activity Recognition
@@ -47,6 +47,7 @@ print(model.config.id2label[predicted_label])
 - [Developing a simple video classification model](https://keras.io/examples/vision/video_classification)
 - [Video classification with Transformers](https://keras.io/examples/vision/video_transformers)
 - [Building a video archive](https://www.youtube.com/watch?v=_IeS1m8r6SY)
+- [Video classification task guide](https://huggingface.co/docs/transformers/tasks/video_classification)
 
 ### Creating your own video classifier in minutes
 - [Fine-tuning tutorial notebook (PyTorch)](https://colab.research.google.com/github/huggingface/notebooks/blob/main/examples/video_classification.ipynb)

--- a/tasks/src/zero-shot-image-classification/about.md
+++ b/tasks/src/zero-shot-image-classification/about.md
@@ -61,6 +61,8 @@ The highest probability is 0.995 for the label cat and dog
 
 You can contribute useful resources about this task [here](https://github.com/huggingface/hub-docs/blob/main/tasks/src/zero-shot-image-classification/about.md).
 
+Check out [Zero-shot image classification task guide](https://huggingface.co/docs/transformers/tasks/zero_shot_image_classification).
+
 This page was made possible thanks to the efforts of [Shamima Hossain](https://huggingface.co/Shamima), [Haider Zaidi
 ](https://huggingface.co/chefhaider) and [Paarth Bhatnagar](https://huggingface.co/Paarth).
 


### PR DESCRIPTION
This PR adds resources to the Task pages, specifically links to official task guides in the Transformers documentation. cc @merveenoyan 