### PR TITLE
Remove `dark:...` classes from token classification widget

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/WidgetOutputTokens/WidgetOutputTokens.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetOutputTokens/WidgetOutputTokens.svelte
@@ -75,7 +75,7 @@
 							data-entity="${spanTag.span.type}" data-hash="${hash}" data-index="${
 						spanTag.span.index ?? ""
 					}"
-							class="bg-${color}-100 text-${color}-800 rounded px-1 py-0.5 dark:text-${color}-100 dark:bg-${color}-700"
+							class="bg-${color}-100 text-${color}-800 rounded px-1 py-0.5"
 						>`;
 				} else {
 					out += `<span


### PR DESCRIPTION
Closes #12, closes #764

Hello!

## Pull Request overview
* Remove `dark:text-${color}-100` and `dark:bg-${color}-700` classes from token classification spans.

## Details
See #12 and #764 for the bug that this PR solves. That second issue already mentions the issue at hand: this CSS rule makes the text color the same as the background color:
```css
:is(.dark .dark\:text-indigo-100) {
 --tw-text-opacity:1;
 color:rgb(224 231 255/var(--tw-text-opacity));
}
```

It is hard to test whether my intuition that these `dark:` classes should be removed, as I'm not sure how to build one of the widgets locally. However, I can verify that it should work in another way:
1. Open https://huggingface.co/tomaarsen/span-marker-bert-tiny-fewnerd-coarse-super?text=Amelia+Earhart+flew+her+single+engine+Lockheed+Vega+5B+across+the+Atlantic+to+Paris.
2. Select one of the two invisible spans, and click on the stylesheet for `.dark .dark\:text-indigo-100`.

That stylesheet with nearly 3000 rules has a few `dark\:text-...-...` rules. The file that generates the token spans for the widget uses only certain ones, though: 
https://github.com/huggingface/hub-docs/blob/52bc2b2f6735f991d8d4f337c5269dc76f73beac/js/src/lib/components/InferenceWidget/shared/WidgetOutputTokens/WidgetOutputTokens.svelte#L74-L79
With color being one of:
https://github.com/huggingface/hub-docs/blob/52bc2b2f6735f991d8d4f337c5269dc76f73beac/js/src/lib/components/InferenceWidget/shared/WidgetOutputTokens/WidgetOutputTokens.svelte#L20-L29

These are all combinations that are generated and appear in the final HTML:
```
['dark\:text-teal-100', 'dark\:text-indigo-100', 'dark\:text-orange-100', 'dark\:text-sky-100', 'dark\:text-violet-100', 'dark\:text-purple-100', 'dark\:text-fuchsia-100', 'dark\:text-pink-100']
['dark\:bg-teal-700', 'dark\:bg-indigo-700', 'dark\:bg-orange-700', 'dark\:bg-sky-700', 'dark\:bg-violet-700', 'dark\:bg-purple-700', 'dark\:bg-fuchsia-700', 'dark\:bg-pink-700']
```
Out of these, only one has a rule in the stylesheet: `dark\:text-indigo-100`. This is exactly the one that is causing problems - problems that are resolved when we remove this rule.

With other words, this shows that we should be able to safely remove the `dark:text-${color}-100` and `dark:bg-${color}-700` classes with only one effect: the indigo tokens should be visible now. All other scenarios should stay the same.

If any of you know of an approach to test out a "real" widget with this branch, then please give it a try. That'll be a more consistent method than my "verification" of this PR.

- Tom Aarsen