### PR TITLE
Fix SageMaker local gpu training instructions

### DIFF
--- a/docs/sagemaker/train.md
+++ b/docs/sagemaker/train.md
@@ -137,7 +137,7 @@ huggingface_estimator = HuggingFace(
 )
 ```
 
-If you are running a `TrainingJob` locally, define `instance_type='local'` or `instance_type='local-gpu'` for GPU usage. Note that this will not work with SageMaker Studio.
+If you are running a `TrainingJob` locally, define `instance_type='local'` or `instance_type='local_gpu'` for GPU usage. Note that this will not work with SageMaker Studio.
 
 ## Execute training
 


### PR DESCRIPTION
In order to run training locally with SageMaker the `instance_type` should be set to `local_gpu` and not `local-gpu` as stated in the docs.
Being new to the combination of HuggingFace and SageMaker, it took me several hours to discover that the instructions on HuggingFace were inaccurate and SageMaker docs were not too helpful either!  I could only find evidence for this on [aws-samples](https://github.com/search?q=repo%3Aaws-samples%2Famazon-sagemaker-local-mode%20local_gpu&type=code) 
In any case, I hope this helps the community.

