### PR TITLE
fix: audio-to-audio examples

### DIFF
--- a/tasks/src/audio-to-audio/data.ts
+++ b/tasks/src/audio-to-audio/data.ts
@@ -2,6 +2,10 @@ import type { TaskDataCustom } from "../Types";
 
 const taskData: TaskDataCustom = {
 	datasets: [
+		{
+			description: "512-element X-vector embeddings of speakers from CMU ARCTIC dataset.",
+			id:          "Matthijs/cmu-arctic-xvectors",
+		},
 	],
 	demo: {
 		inputs: [

--- a/tasks/src/audio-to-audio/data.ts
+++ b/tasks/src/audio-to-audio/data.ts
@@ -47,7 +47,7 @@ const taskData: TaskDataCustom = {
 	],
 	spaces:       [
 		{
-			description: "An application that can separate speech.",
+			description: "An application for speech separation.",
 			id:          "younver/speechbrain-speech-separation",
 		},
 		{

--- a/tasks/src/audio-to-audio/data.ts
+++ b/tasks/src/audio-to-audio/data.ts
@@ -51,8 +51,8 @@ const taskData: TaskDataCustom = {
 			id:          "younver/speechbrain-speech-separation",
 		},
 		{
-			description: "An application that can translate from speech to speech between Hokkien and English.",
-			id:          "facebook/Hokkien_Translation",
+			description: "An application that built to style transfer to audio using Huggingface diffusers.",
+			id:          "nakas/audio-diffusion_style_transfer",
 		},
 	],
 	summary:      "Audio-to-Audio is a family of tasks in which the input is an audio and the output is one or multiple generated audios. Some example tasks are speech enhancement and source separation.",

--- a/tasks/src/audio-to-audio/data.ts
+++ b/tasks/src/audio-to-audio/data.ts
@@ -44,7 +44,7 @@ const taskData: TaskDataCustom = {
 	spaces:       [
 		{
 			description: "An application that can separate speech.",
-			id:          "akhaliq/speechbrain-speech-seperation",
+			id:          "younver/speechbrain-speech-separation",
 		},
 		{
 			description: "An application that can translate from speech to speech between Hokkien and English.",

--- a/tasks/src/audio-to-audio/data.ts
+++ b/tasks/src/audio-to-audio/data.ts
@@ -51,7 +51,7 @@ const taskData: TaskDataCustom = {
 			id:          "younver/speechbrain-speech-separation",
 		},
 		{
-			description: "An application that built to style transfer to audio using Huggingface diffusers.",
+			description: "An application for audio style transfer.",
 			id:          "nakas/audio-diffusion_style_transfer",
 		},
 	],


### PR DESCRIPTION
closes `Audio-to-audio` task of https://github.com/huggingface/hub-docs/issues/792

- fixed `akhaliq/speechbrain-speech-seperation` space since there was a build failure by duplicating the space since it's been a while since last contribution.
- changed `facebook/Hokkien_Translation` space since the space was not working anymore.
- added `Matthijs/cmu-arctic-xvectors` embeddings dataset

cc: @merveenoyan