### PR TITLE
Added variations and inference documentation for Reinforcement Learning Task

### DIFF
--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -62,7 +62,7 @@ Observations and states are the information our agent gets from the environment.
 Inference in reinforcement learning differs from other modalities, in which there's a model and test data. In reinforcement learning, once you have trained an agent in an environment, you try to run the trained agent for additional steps to get the average reward. 
 
 
-A typical training cycle consists of gathering experience from the environment, training the model, and running the model on a test environment to obtain average reward. Below there's a snippet on how you can interact with the environment using the `gymnasium` library, train a model using `stable-baselines3` and run the agent on test environment.
+A typical training cycle consists of gathering experience from the environment, training the agent, and running the agent on a test environment to obtain average reward. Below there's a snippet on how you can interact with the environment using the `gymnasium` library, train an agent using `stable-baselines3`, evalute the agent on test environment and infer actions from the trained agent.
 
   
 ```python
@@ -113,7 +113,7 @@ model.learn(total_timesteps = 1000)
 model_name = "PPO-LunarLander-v2"
 model.save(model_name)
 ```
-Below code shows how to make inference with an agent trained using `stable-baselines3`
+Below code shows how to evaluate an agent trained using `stable-baselines3`
 ```python
 # Loading a saved model and evaluating the model for 10 episodes
 from stable_baselines3.common.evaluation import evaluate_policy
@@ -132,6 +132,28 @@ mean_reward, std_reward = evaluate_policy(model, eval_env, n_eval_episodes = 10,
 										  deterministic=True)
 
 print(f"mean_reward={mean_reward:.2f} +/- {std_reward}")
+```
+
+Below code snippet shows how to infer actions from an agent trained using `stable-baselines3`
+
+```python
+from stable_baselines3.common.evaluation import evaluate_policy
+from stable_baselines3 import PPO
+
+# Loading the saved model
+model = PPO.load("PPO-LunarLander-v2",env=env)
+
+# Getting the environment from the trained agent
+env = model.get_env()
+
+obs = env.reset()
+for i in range(1000):
+	# getting action predictions from the trained agent
+	action, _states = model.predict(obs, deterministic=True)
+	
+	# taking the predicted action in the environment to observe next state and rewards
+    obs, rewards, dones, info = env.step(action)
+
 ```
 
 For more information, you can check out the documentations of the respective libraries.

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -103,7 +103,8 @@ model = PPO(policy = "MlpPolicy",
 			n_epochs = 4,
 			verbose = 1)
 
-# trains the model for 1000 time steps
+# train the model for 1000 time steps
+
 model.learn(total_timesteps = 1000)
 
 # Saving the model in desired directory

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -72,7 +72,6 @@ observation, info = env.reset()
 
 for _ in range(20):
 	action = env.action_space.sample() # samples random action from action sample space
-	print("Action Take:",action)
 
 	observation, reward, terminated, truncated, info = env.step(action) # takes the action in the env
 

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -111,7 +111,7 @@ model.learn(total_timesteps = 1000)
 model_name = "PPO-LunarLander-v2"
 model.save(model_name)
 ```
-
+Below code shows how to make inference with an agent trained using `stable-baselines3`
 ```python
 # Loading a saved model and evaluating the model for 10 episodes
 from stable_baselines3.common.evaluation import evaluate_policy

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -94,7 +94,8 @@ from stable_baselines3 import PPO
 
 env = gym.make("LunarLander-v2")
 
-# Model Initialization
+# initialize the model
+
 model = PPO(policy = "MlpPolicy",
 			env = env,
 			n_steps = 1024,

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -60,7 +60,6 @@ Observations and states are the information our agent gets from the environment.
 
 Inference in reinforcement learning differs from other modalities, in which there's a model and test data. In reinforcement learning, once you have trained an agent in an environment, you try to run the trained agent for additional steps to get the average reward. 
 
-
 A typical training cycle consists of gathering experience from the environment, training the agent, and running the agent on a test environment to obtain average reward. Below there's a snippet on how you can interact with the environment using the `gymnasium` library, train an agent using `stable-baselines3`, evalute the agent on test environment and infer actions from the trained agent.
 
   

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -16,7 +16,8 @@ Reinforcement learning is the science to train computers to make decisions and t
 ## Task Variants 
 
 ### Model Based RL
-In Model based Reinforcement Learning, we try to create a model of the environment (learn the state transition probabilities and the reward function) for finding optimal actions for the agent. Some typical examples for Model Based RL algorithms are Dynamic Programming, Value Iteration & Policy Iteration
+In model based reinforcement learning techniques intend to create a model of the environment, learn the state transition probabilities and the reward function, to find the optimal action. Some typical examples for model based reinforcement learning algorithms are dynamic programming, value iteration and policy iteration.
+
 
 
 ### Model Free RL

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -61,7 +61,8 @@ Observations and states are the information our agent gets from the environment.
 
 Inference in Reinforcement learning, differs a bit from traditional supervised learning where you just deal with model and test data. In RL, once you have trained an agent in an env, you try to run the trained agent for specific no of steps to get the average reward its able to get. 
 
-A typical training cycle comprises of gathering experience from env, training the model and running the model on test env to get average reward. Below we have showcased, how you can interact with the env using gymnasium library, train a model using stable-baselines3 and run it on test environment.
+A typical training cycle consists of gathering experience from the environment, training the model, and running the model on a test environment to obtain average reward. Below there's a snippet on how you can interact with the environment using the `gymnasium` library, train a model using `stable-baselines3` and run the agent on test environment.
+
   
 ```python
 # Here we are running 20 episodes of CartPole-v1 environment, taking random actions

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -90,7 +90,8 @@ env.close()
 # Training a PPO model on LunarLander-v2 environment using stable-baselines3 library and saving the model
 from stable_baselines3 import PPO
 
-# Environment Initialization
+# initialize the environment
+
 env = gym.make("LunarLander-v2")
 
 # Model Initialization

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -73,7 +73,9 @@ observation, info = env.reset()
 for _ in range(20):
 	action = env.action_space.sample() # samples random action from action sample space
 
-	observation, reward, terminated, truncated, info = env.step(action) # takes the action in the env
+        # the agent takes the action 
+	observation, reward, terminated, truncated, info = env.step(action)
+
 
 if terminated or truncated: # if the agent reaches terminal state, we reset the environment
 	print("Environment is reset")

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -86,6 +86,7 @@ if terminated or truncated:
 env.close()
 ```
 
+Below snippet shows how to train a PPO model on LunarLander-v2 environment using `stable-baselines3` library and saving the model
 ```python
 # Training a PPO model on LunarLander-v2 environment using stable-baselines3 library and saving the model
 from stable_baselines3 import PPO

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -104,7 +104,6 @@ model = PPO(policy = "MlpPolicy",
 			verbose = 1)
 
 # train the model for 1000 time steps
-
 model.learn(total_timesteps = 1000)
 
 # Saving the model in desired directory

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -59,7 +59,8 @@ Observations and states are the information our agent gets from the environment.
 
 ## Inference
 
-Inference in Reinforcement learning, differs a bit from traditional supervised learning where you just deal with model and test data. In RL, once you have trained an agent in an env, you try to run the trained agent for specific no of steps to get the average reward its able to get. 
+Inference in reinforcement learning differs from other modalities, in which there's a model and test data. In reinforcement learning, once you have trained an agent in an environment, you try to run the trained agent for additional steps to get the average reward. 
+
 
 A typical training cycle consists of gathering experience from the environment, training the model, and running the model on a test environment to obtain average reward. Below there's a snippet on how you can interact with the environment using the `gymnasium` library, train a model using `stable-baselines3` and run the agent on test environment.
 

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -150,7 +150,6 @@ for i in range(1000):
 	
 	# taking the predicted action in the environment to observe next state and rewards
     obs, rewards, dones, info = env.step(action)
-
 ```
 
 For more information, you can check out the documentations of the respective libraries.

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -77,7 +77,9 @@ for _ in range(20):
 	observation, reward, terminated, truncated, info = env.step(action)
 
 
-if terminated or truncated: # if the agent reaches terminal state, we reset the environment
+# if the agent reaches terminal state, we reset the environment
+if terminated or truncated: 
+
 	print("Environment is reset")
 	observation = env.reset()
 

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -15,7 +15,12 @@ Reinforcement learning is the science to train computers to make decisions and t
 
 ## Task Variants 
 
-You can contribute variants of this task [here](https://github.com/huggingface/hub-docs/blob/main/tasks/src/reinforcement-learning/about.md).
+### Model Based RL
+In Model based Reinforcement Learning, we try to create a model of the environment (learn the state transition probabilities and the reward function) for finding optimal actions for the agent. Some typical examples for Model Based RL algorithms are Dynamic Programming, Value Iteration & Policy Iteration
+
+
+### Model Free RL
+In Model Free RL, agent decides on optimal actions, solely based on its experience in the environment and the reward it collects during that journey. This is one of the most commonly used algorithms specially beneficial in complex environments where modelling of state transition probabilities and reward functions are quite difficult. Some of the examples will be SARSA, Q-Learning, Actor-Critic, Proximal Policy Optimization (PPO) algorithms.
 
 ## Glossary
 
@@ -52,7 +57,77 @@ Observations and states are the information our agent gets from the environment.
 
 ## Inference
 
-You can add a small snippet [here](https://github.com/huggingface/hub-docs/blob/main/tasks/src/reinforcement-learning/about.md) that shows how to infer with `reinforcement-learning` models.
+Inference in Reinforcement learning, differs a bit from traditional supervised learning where you just deal with model and test data. In RL, once you have trained an agent in an env, you try to run the trained agent for specific no of steps to get the average reward its able to get. 
+
+A typical training cycle comprises of gathering experience from env, training the model and running the model on test env to get average reward. Below we have showcased, how you can interact with the env using gymnasium library, train a model using stable-baselines3 and run it on test environment.
+  
+```python
+# Here we are running 20 episodes of CartPole-v1 environment, taking random actions
+import gymnasium as gym
+
+env = gym.make("CartPole-v1")
+observation, info = env.reset()
+
+for _ in range(20):
+	action = env.action_space.sample() # samples random action from action sample space
+	print("Action Take:",action)
+
+	observation, reward, terminated, truncated, info = env.step(action) # takes the action in the env
+
+if terminated or truncated: # if the agent reaches terminal state, we reset the environment
+	print("Environment is reset")
+	observation = env.reset()
+
+env.close()
+```
+
+```python
+# Training a PPO model on LunarLander-v2 environment using stable-baselines3 library and saving the model
+from stable_baselines3 import PPO
+
+# Environment Initialization
+env = gym.make("LunarLander-v2")
+
+# Model Initialization
+model = PPO(policy = "MlpPolicy",
+			env = env,
+			n_steps = 1024,
+			batch_size = 64,
+			n_epochs = 4,
+			verbose = 1)
+
+# trains the model for 1000 time steps
+model.learn(total_timesteps = 1000)
+
+# Saving the model in desired directory
+model_name = "PPO-LunarLander-v2"
+model.save(model_name)
+```
+
+```python
+# Loading a saved model and evaluating the model for 10 episodes
+from stable_baselines3.common.evaluation import evaluate_policy
+from stable_baselines3 import PPO
+
+
+env = gym.make("LunarLander-v2")
+# Loading the saved model
+model = PPO.load("PPO-LunarLander-v2",env=env)
+
+# Initializating the evaluation environment
+eval_env = gym.make("LunarLander-v2")
+
+# Running the trained agent on eval_env for 10 time steps and getting the mean reward
+mean_reward, std_reward = evaluate_policy(model, eval_env, n_eval_episodes = 10,
+										  deterministic=True)
+
+print(f"mean_reward={mean_reward:.2f} +/- {std_reward}")
+```
+
+For more information, you can check out the documentations of the respective libraries.
+
+[Gymnasium Documentation](https://gymnasium.farama.org/)
+[Stable Baselines Documentation](https://stable-baselines3.readthedocs.io/en/master/)
 
 ## Useful Resources
 

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -88,7 +88,6 @@ env.close()
 
 Below snippet shows how to train a PPO model on LunarLander-v2 environment using `stable-baselines3` library and saving the model
 ```python
-# Training a PPO model on LunarLander-v2 environment using stable-baselines3 library and saving the model
 from stable_baselines3 import PPO
 
 # initialize the environment

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -19,7 +19,6 @@ Reinforcement learning is the science to train computers to make decisions and t
 In model based reinforcement learning techniques intend to create a model of the environment, learn the state transition probabilities and the reward function, to find the optimal action. Some typical examples for model based reinforcement learning algorithms are dynamic programming, value iteration and policy iteration.
 
 
-
 ### Model Free RL
 In model free reinforcement learning, agent decides on optimal actions based on its experience in the environment and the reward it collects from it. This is one of the most commonly used algorithms beneficial in complex environments, where modeling of state transition probabilities and reward functions are difficult. Some of the examples of model free reinforcement learning are SARSA, Q-Learning, actor-critic and proximal policy optimization (PPO) algorithms.
 

--- a/tasks/src/reinforcement-learning/about.md
+++ b/tasks/src/reinforcement-learning/about.md
@@ -21,7 +21,8 @@ In model based reinforcement learning techniques intend to create a model of the
 
 
 ### Model Free RL
-In Model Free RL, agent decides on optimal actions, solely based on its experience in the environment and the reward it collects during that journey. This is one of the most commonly used algorithms specially beneficial in complex environments where modelling of state transition probabilities and reward functions are quite difficult. Some of the examples will be SARSA, Q-Learning, Actor-Critic, Proximal Policy Optimization (PPO) algorithms.
+In model free reinforcement learning, agent decides on optimal actions based on its experience in the environment and the reward it collects from it. This is one of the most commonly used algorithms beneficial in complex environments, where modeling of state transition probabilities and reward functions are difficult. Some of the examples of model free reinforcement learning are SARSA, Q-Learning, actor-critic and proximal policy optimization (PPO) algorithms.
+
 
 ## Glossary
 


### PR DESCRIPTION
Addresses https://github.com/huggingface/hub-docs/issues/357.

- Added Variations (Model Based & Model Free RL)
- Added Inference Code Snippets for:
        - Interacting with the Environment using Gymnasium
        - Training, Saving, Loading and Evaluating an agent using stable-baselines3