### PR TITLE
Fixed maximize button issue #643

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/WidgetFooter/WidgetFooter.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetFooter/WidgetFooter.svelte
@@ -4,7 +4,7 @@
 
 	export let onClickMaximizeBtn: () => void;
 	export let outputJson: string;
-
+	export let isMaximized: boolean;
 	let isOutputJsonVisible = false;
 </script>
 
@@ -26,7 +26,7 @@
 		on:click|preventDefault={onClickMaximizeBtn}
 	>
 		<IconMaximize classNames="mr-1" />
-		Maximize
+		{isMaximized ? 'Minimize' : 'Maximize'}
 	</button>
 </div>
 {#if outputJson && isOutputJsonVisible}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -111,5 +111,5 @@
 		<WidgetModelLoading estimatedTime={modelLoading.estimatedTime} />
 	{/if}
 	<slot name="bottom" />
-	<WidgetFooter {onClickMaximizeBtn} {outputJson} />
+	<WidgetFooter {onClickMaximizeBtn} {outputJson} {isMaximized}/>
 </div>


### PR DESCRIPTION
I encountered a bug on the Huggingface website where the maximize button on the Hosted inference API block did not toggle to the minimize button when clicked, unlike other blocks on the page. 

To fix this issue, I updated the button functionality so that it now toggles between the maximize and minimize icon when clicked. However, I did not modify the icon design since I am not familiar with the website's design language. 

I believe this fix will improve the user experience on the website. I would appreciate it if the Huggingface team could review this pull request and implement the changes accordingly.

Thank you for your time.