### PR TITLE
Add JS snippets to task pages

### DIFF
--- a/tasks/src/audio-classification/about.md
+++ b/tasks/src/audio-classification/about.md
@@ -48,6 +48,18 @@ data = query("sample1.flac")
 # {'label': 'sad', 'score': 0.07}]
 ```
 
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to infer with audio classification models on Hugging Face Hub.
+
+```javascript
+import { HfInference } from "@huggingface/inference";
+
+const inference = new HfInference(HF_ACCESS_TOKEN);
+await inference.audioClassification({
+  data: await (await fetch("sample.flac")).blob(),
+  model: "facebook/mms-lid-126",  
+})
+```
+
 ### Speaker Identification
 
 Speaker Identification is classifying the audio of the person speaking. Speakers are usually predefined. You can try out this task with [this model](https://huggingface.co/superb/wav2vec2-base-superb-sid). A useful dataset for this task is VoxCeleb1.

--- a/tasks/src/audio-to-audio/about.md
+++ b/tasks/src/audio-to-audio/about.md
@@ -29,6 +29,17 @@ def query(filename):
 
 data = query("sample1.flac")
 ```
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to infer with audio-to-audio models on Hugging Face Hub.
+
+```javascript
+import { HfInference } from "@huggingface/inference";
+
+const inference = new HfInference(HF_ACCESS_TOKEN);
+await inference.audioToAudio({
+  data: await (await fetch("sample.flac")).blob(),
+  model: "speechbrain/sepformer-wham",  
+})
+```
 
 ### Audio Source Separation
 

--- a/tasks/src/automatic-speech-recognition/about.md
+++ b/tasks/src/automatic-speech-recognition/about.md
@@ -49,6 +49,18 @@ pipe("sample.flac")
 # {'text': "GOING ALONG SLUSHY COUNTRY ROADS AND SPEAKING TO DAMP AUDIENCES IN DRAUGHTY SCHOOL ROOMS DAY AFTER DAY FOR A FORTNIGHT HE'LL HAVE TO PUT IN AN APPEARANCE AT SOME PLACE OF WORSHIP ON SUNDAY MORNING AND HE CAN COME TO US IMMEDIATELY AFTERWARDS"}
 ```
 
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to transcribe text with javascript using models on Hugging Face Hub.
+
+```javascript
+import { HfInference } from "@huggingface/inference";
+
+const inference = new HfInference(HF_ACCESS_TOKEN);
+await inference.automaticSpeechRecognition({
+  data: await (await fetch("sample.flac")).blob(),
+  model: "facebook/wav2vec2-base-960h",  
+})
+```
+
 ## Solving ASR for your own data
 
 We have some great news! You can do fine-tuning (transfer learning) to train a well-performing model without requiring as much data. Pretrained models such as Wav2Vec2 and HuBERT exist. [Facebook's Wav2Vec2 XLS-R model](https://ai.facebook.com/blog/wav2vec-20-learning-the-structure-of-speech-from-raw-audio/) is a large multilingual model trained on 128 languages and with 436K hours of speech.

--- a/tasks/src/conversational/about.md
+++ b/tasks/src/conversational/about.md
@@ -29,6 +29,18 @@ converse([conversation_1, conversation_2])
 ## bot >> The Last Question
 ```
 
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to infer with conversational models on Hugging Face Hub.
+
+```javascript
+import { HfInference } from "@huggingface/inference";
+
+const inference = new HfInference(HF_ACCESS_TOKEN);
+await inference.conversational({
+  model: 'facebook/blenderbot-400M-distill',
+  inputs: "Going to the movies tonight - any suggestions?"
+})
+```
+
 ## Useful Resources
 
 - Learn how ChatGPT and InstructGPT work in this blog: [Illustrating Reinforcement Learning from Human Feedback (RLHF)](https://huggingface.co/blog/rlhf)

--- a/tasks/src/image-classification/about.md
+++ b/tasks/src/image-classification/about.md
@@ -22,6 +22,18 @@ clf("path_to_a_cat_image")
 ]
 ```
 
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to classify images using models on Hugging Face Hub.
+
+```javascript
+import { HfInference } from "@huggingface/inference";
+
+const inference = new HfInference(HF_ACCESS_TOKEN);
+await inference.imageClassification({
+  data: await (await fetch('https://picsum.photos/300/300')).blob(),
+  model: 'microsoft/resnet-50',  
+})
+```
+
 ## Useful Resources
 
 - [Let's Play Pictionary with Machine Learning!](https://www.youtube.com/watch?v=LS9Y2wDVI0k)

--- a/tasks/src/image-segmentation/about.md
+++ b/tasks/src/image-segmentation/about.md
@@ -40,6 +40,18 @@ model("cat.png")
 # ...]
 ```
 
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to infer image segmentation models on Hugging Face Hub.
+
+```javascript
+import { HfInference } from "@huggingface/inference";
+
+const inference = new HfInference(HF_ACCESS_TOKEN);
+await inference.imageSegmentation({
+  data: await (await fetch('https://picsum.photos/300/300')).blob(),
+  model: 'facebook/detr-resnet-50-panoptic',  
+})
+```
+
 ## Useful Resources
 
 Would you like to learn more about image segmentation? Great! Here you can find some curated resources that you may find helpful!

--- a/tasks/src/image-to-image/about.md
+++ b/tasks/src/image-to-image/about.md
@@ -38,6 +38,21 @@ images = pipe(prompt=prompt, image=init_image, strength=0.75, guidance_scale=7.5
 images[0].save("fantasy_landscape.png")
 ```
 
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to infer image-to-image models on Hugging Face Hub.
+
+```javascript
+import { HfInference } from "@huggingface/inference";
+
+const inference = new HfInference(HF_ACCESS_TOKEN);
+await inference.imageToImage({
+  data: await (await fetch('image')).blob(),
+  model: "timbrooks/instruct-pix2pix", 
+  parameters: {
+    prompt: "Deblur this image"
+  }
+})
+
+
 ## ControlNet
 
 Controlling outputs of diffusion models only with a text prompt is a challenging problem. ControlNet is a neural network type that provides an image based control to diffusion models. These controls can be edges or landmarks in an image.

--- a/tasks/src/image-to-text/about.md
+++ b/tasks/src/image-to-text/about.md
@@ -37,6 +37,18 @@ generated_text = processor.batch_decode(generated_ids, skip_special_tokens=True)
 
 ```
 
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to infer image-to-text models on Hugging Face Hub.
+
+```javascript
+import { HfInference } from "@huggingface/inference";
+
+const inference = new HfInference(HF_ACCESS_TOKEN);
+await inference.imageToText({
+  data: await (await fetch('https://picsum.photos/300/300')).blob(),
+  model: 'Salesforce/blip-image-captioning-base',  
+})
+```
+
 ## Useful Resources
 - [Image Captioning](https://huggingface.co/docs/transformers/main/en/tasks/image_captioning)
 - [Image captioning use case](https://blog.google/outreach-initiatives/accessibility/get-image-descriptions/)

--- a/tasks/src/summarization/about.md
+++ b/tasks/src/summarization/about.md
@@ -16,8 +16,22 @@ You can use the 🤗 Transformers library `summarization` pipeline to infer with
 from transformers import pipeline
 
 classifier = pipeline("summarization")
-classifier("Paris is the capital and most populous city of France, with an estimated population of 2,175,601 residents as of 2018, in an area of more than 105 square kilometres (41 square miles). The City of Paris is the centre and seat of government of the region and province of Île-de-France, or Paris Region, which has an estimated population of 12,174,880, or about 18 percent of the population of France as of 2017.”)
+classifier("Paris is the capital and most populous city of France, with an estimated population of 2,175,601 residents as of 2018, in an area of more than 105 square kilometres (41 square miles). The City of Paris is the centre and seat of government of the region and province of Île-de-France, or Paris Region, which has an estimated population of 12,174,880, or about 18 percent of the population of France as of 2017.")
 ## [{ "summary_text": " Paris is the capital and most populous city of France..." }]
+```
+
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to infer summarization models on Hugging Face Hub.
+
+```javascript
+import { HfInference } from "@huggingface/inference";
+
+const inference = new HfInference(HF_ACCESS_TOKEN);
+const inputs = "Paris is the capital and most populous city of France, with an estimated population of 2,175,601 residents as of 2018, in an area of more than 105 square kilometres (41 square miles). The City of Paris is the centre and seat of government of the region and province of Île-de-France, or Paris Region, which has an estimated population of 12,174,880, or about 18 percent of the population of France as of 2017."
+
+await inference.summarization({
+  model: 'sshleifer/distilbart-cnn-12-6',
+  inputs
+})
 ```
 
 ## Useful Resources

--- a/tasks/src/text-classification/about.md
+++ b/tasks/src/text-classification/about.md
@@ -112,6 +112,17 @@ classifier("Which city is the capital of France?, Where is the capital of France
 ## [{'label': 'paraphrase', 'score': 0.998}]
 ```
 
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to infer text classification models on Hugging Face Hub.
+
+```javascript
+import { HfInference } from "@huggingface/inference";
+
+const inference = new HfInference(HF_ACCESS_TOKEN);
+await inference.conversational({
+  model: 'distilbert-base-uncased-finetuned-sst-2-english',
+  inputs: "I love this movie!"
+})
+```
 ### Grammatical Correctness
 
 Linguistic Acceptability is the task of assessing the grammatical acceptability of a sentence. The classes in this task are “acceptable” and “unacceptable”. The benchmark dataset used for this task is [Corpus of Linguistic Acceptability (CoLA)](https://huggingface.co/datasets/glue/viewer/cola/test). The dataset consists of texts and their labels.

--- a/tasks/src/text-generation/about.md
+++ b/tasks/src/text-generation/about.md
@@ -44,6 +44,7 @@ generator("Hello, I'm a language model", max_length = 30, num_return_sequences=3
 ##  {'generated_text': "Hello, I'm a language modeler. I write and maintain software in Python. I love to code, and that includes coding things that require writing"}, ...
 ```
 
+
 [Text-to-Text generation models](https://huggingface.co/models?pipeline_tag=text2text-generation&sort=downloads) have a separate pipeline called `text2text-generation`. This pipeline takes an input containing the sentence including the task and returns the output of the accomplished task.
 
 ```python
@@ -57,23 +58,20 @@ text2text_generator("translate from English to French: I'm very happy")
 [{'generated_text': 'Je suis très heureux'}]
 ```
 
-The [T0 model](https://huggingface.co/bigscience/T0) is even more robust and flexible on task prompts.
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to infer text classification models on Hugging Face Hub.
 
-```python
-text2text_generator = pipeline("text2text-generation", model = "bigscience/T0")
+```javascript
+import { HfInference } from "@huggingface/inference";
 
-text2text_generator("Is the word 'table' used in the same meaning in the two previous sentences? Sentence A: you can leave the books on the table over there. Sentence B: the tables in this book are very hard to read." )
-## [{"generated_text": "No"}]
-
-text2text_generator("A is the son's of B's brother. What is the family relationship between A and B?")
-## [{"generated_text": "brother"}]
-
-text2text_generator("Is this review positive or negative? Review: this is the best cast iron skillet you will ever buy")
-## [{"generated_text": "positive"}]
-
-text2text_generator("Reorder the words in this sentence: justin and name bieber years is my am I 27 old.")
-##  [{"generated_text": "Justin Bieber is my name and I am 27 years old"}]
+const inference = new HfInference(HF_ACCESS_TOKEN);
+await inference.conversational({
+  model: 'distilbert-base-uncased-finetuned-sst-2-english',
+  inputs: "I love this movie!"
+})
 ```
+
+
+
 
 ## Useful Resources
 

--- a/tasks/src/text-to-image/about.md
+++ b/tasks/src/text-to-image/about.md
@@ -1,5 +1,4 @@
 ## Use Cases
-
 ### Data Generation
   
 Businesses can generate data for their their use cases by inputting text and getting image outputs. 
@@ -20,9 +19,36 @@ Architects can utilise the models to construct an environment based out on the r
 
 You can contribute variants of this task [here](https://github.com/huggingface/hub-docs/blob/main/tasks/src/text-to-image/about.md).
 
+
 ## Inference
 
-You can add a small snippet [here](https://github.com/huggingface/hub-docs/blob/main/tasks/src/text-to-image/about.md) that shows how to infer with `text-to-image` models.
+You can use diffusers pipelines to infer with `text-to-image` models.
+```python
+from diffusers import StableDiffusionPipeline, EulerDiscreteScheduler
+
+model_id = "stabilityai/stable-diffusion-2"
+scheduler = EulerDiscreteScheduler.from_pretrained(model_id, subfolder="scheduler")
+pipe = StableDiffusionPipeline.from_pretrained(model_id, scheduler=scheduler, torch_dtype=torch.float16)
+pipe = pipe.to("cuda")
+
+prompt = "a photo of an astronaut riding a horse on mars"
+image = pipe(prompt).images[0]
+```
+
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to infer text-to-image models on Hugging Face Hub.
+
+```javascript
+import { HfInference } from "@huggingface/inference";
+
+const inference = new HfInference(HF_ACCESS_TOKEN);
+await inference.textToImage({
+  model: 'stabilityai/stable-diffusion-2',
+  inputs: 'award winning high resolution photo of a giant tortoise/((ladybird)) hybrid, [trending on artstation]',
+  parameters: {
+    negative_prompt: 'blurry',
+  }
+})
+```
   
 ## Useful Resources
 - [Hugging Face Diffusion Models Course](https://github.com/huggingface/diffusion-models-class)

--- a/tasks/src/text-to-speech/about.md
+++ b/tasks/src/text-to-speech/about.md
@@ -38,6 +38,19 @@ model = Text2Speech.from_pretrained("espnet/kan-bayashi_ljspeech_vits")
 speech, *_ = model("text to generate speech from")
 ```
 
+
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to infer summarization models on Hugging Face Hub.
+
+```javascript
+import { HfInference } from "@huggingface/inference";
+
+const inference = new HfInference(HF_ACCESS_TOKEN);
+await inference.textToSpeech({
+  model: 'facebook/mms-tts',
+  inputs: "text to generate speech from"
+})
+```
+
 ## Useful Resources
 - [ML for Audio Study Group - Text to Speech Deep Dive](https://www.youtube.com/watch?v=aLBedWj-5CQ)
 - [An introduction to SpeechT5, a multi-purpose speech recognition and synthesis model](https://huggingface.co/blog/speecht5).

--- a/tasks/src/token-classification/about.md
+++ b/tasks/src/token-classification/about.md
@@ -21,6 +21,8 @@ classifier = pipeline("ner")
 classifier("Hello I'm Omar and I live in Zürich.")
 ```
 
+
+
 ### Part-of-Speech (PoS) Tagging
 In PoS tagging, the model recognizes parts of speech, such as nouns, pronouns, adjectives, or verbs, in a given text. The task is formulated as labeling each word with a part of the speech.
 

--- a/tasks/src/translation/about.md
+++ b/tasks/src/translation/about.md
@@ -32,6 +32,18 @@ translator("How are you?")
 # [{'translation_text': 'Comment allez-vous ?'}]
 ```
 
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to infer translation models on Hugging Face Hub.
+
+```javascript
+import { HfInference } from "@huggingface/inference";
+
+const inference = new HfInference(HF_ACCESS_TOKEN);
+await inference.translation({
+  model: 't5-base',
+  inputs: 'My name is Wolfgang and I live in Berlin'
+})
+```
+
 ## Useful Resources
 
 Would you like to learn more about Translation? Great! Here you can find some curated resources that you may find helpful!


### PR DESCRIPTION
This PR adds `huggingface.js` snippets for task inferences. I wasn't super sure of the snippets that take multiple inputs so this one only adds the ones that have single input for now. Will add them later.