### PR TITLE
Make snippet a list of strings

### DIFF
--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -68,7 +68,7 @@ export interface LibraryUiElement {
 	/**
 	 * Code snippet displayed on model page
 	 */
-	snippet:  (model: ModelData) => string;
+	snippets: (model: ModelData) => string[];
 }
 
 function nameWithoutNamespace(modelId: string): string {
@@ -79,24 +79,24 @@ function nameWithoutNamespace(modelId: string): string {
 //#region snippets
 
 const adapter_transformers = (model: ModelData) =>
-	`from transformers import ${model.config?.adapter_transformers?.model_class}
+	[`from transformers import ${model.config?.adapter_transformers?.model_class}
 
 model = ${model.config?.adapter_transformers?.model_class}.from_pretrained("${model.config?.adapter_transformers?.model_name}")
-model.load_adapter("${model.id}", source="hf")`;
+model.load_adapter("${model.id}", source="hf")`];
 
 const allennlpUnknown = (model: ModelData) =>
-	`import allennlp_models
+	[`import allennlp_models
 from allennlp.predictors.predictor import Predictor
 
-predictor = Predictor.from_path("hf://${model.id}")`;
+predictor = Predictor.from_path("hf://${model.id}")`];
 
 const allennlpQuestionAnswering = (model: ModelData) =>
-	`import allennlp_models
+	[`import allennlp_models
 from allennlp.predictors.predictor import Predictor
 
 predictor = Predictor.from_path("hf://${model.id}")
 predictor_input = {"passage": "My name is Wolfgang and I live in Berlin", "question": "Where do I live?"}
-predictions = predictor.predict_json(predictor_input)`;
+predictions = predictor.predict_json(predictor_input)`];
 
 const allennlp = (model: ModelData) => {
 	if (model.tags?.includes("question-answering")) {
@@ -106,43 +106,43 @@ const allennlp = (model: ModelData) => {
 };
 
 const asteroid = (model: ModelData) =>
-	`from asteroid.models import BaseModel
+	[`from asteroid.models import BaseModel
 
-model = BaseModel.from_pretrained("${model.id}")`;
+model = BaseModel.from_pretrained("${model.id}")`];
 
 function get_base_diffusers_model(model: ModelData): string {
 	return model.cardData?.base_model ?? 'fill-in-base-model'
 }
 
 const bertopic = (model: ModelData) =>
-	`from bertopic import BERTopic
+	[`from bertopic import BERTopic
 
-model = BERTopic.load("${model.id}")`;
+model = BERTopic.load("${model.id}")`];
 
 const diffusers_default = (model: ModelData) =>
-	`from diffusers import DiffusionPipeline
+	[`from diffusers import DiffusionPipeline
 
-pipeline = DiffusionPipeline.from_pretrained("${model.id}")`;
+pipeline = DiffusionPipeline.from_pretrained("${model.id}")`];
 
 const diffusers_controlnet = (model: ModelData) =>
-	`from diffusers import ControlNetModel, StableDiffusionControlNetPipeline
+	[`from diffusers import ControlNetModel, StableDiffusionControlNetPipeline
 
 controlnet = ControlNetModel.from_pretrained("${model.id}")
 pipeline = StableDiffusionControlNetPipeline.from_pretrained(
 	"${get_base_diffusers_model(model)}", controlnet=controlnet
-)`;
+)`];
 
 const diffusers_lora = (model: ModelData) =>
-	`from diffusers import DiffusionPipeline
+	[`from diffusers import DiffusionPipeline
 
 pipeline = DiffusionPipeline.from_pretrained("${get_base_diffusers_model(model)}")
-pipeline.load_lora_weights("${model.id}")`;
+pipeline.load_lora_weights("${model.id}")`];
 
 const diffusers_textual_inversion = (model: ModelData) =>
-	`from diffusers import DiffusionPipeline
+	[`from diffusers import DiffusionPipeline
 
 pipeline = DiffusionPipeline.from_pretrained("${get_base_diffusers_model(model)}")
-pipeline.load_textual_inversion("${model.id}")`;
+pipeline.load_textual_inversion("${model.id}")`];
 
 const diffusers = (model: ModelData) => {
 	if (model.tags?.includes("controlnet")) {
@@ -157,24 +157,24 @@ const diffusers = (model: ModelData) => {
 }
 
 const espnetTTS = (model: ModelData) =>
-	`from espnet2.bin.tts_inference import Text2Speech
+	[`from espnet2.bin.tts_inference import Text2Speech
 
 model = Text2Speech.from_pretrained("${model.id}")
 
-speech, *_ = model("text to generate speech from")`;
+speech, *_ = model("text to generate speech from")`];
 
 const espnetASR = (model: ModelData) =>
-	`from espnet2.bin.asr_inference import Speech2Text
+	[`from espnet2.bin.asr_inference import Speech2Text
 
 model = Speech2Text.from_pretrained(
   "${model.id}"
 )
 
 speech, rate = soundfile.read("speech.wav")
-text, *_ = model(speech)[0]`;
+text, *_ = model(speech)[0]`];
 
 const espnetUnknown = () =>
-	`unknown model type (must be text-to-speech or automatic-speech-recognition)`;
+	[`unknown model type (must be text-to-speech or automatic-speech-recognition)`];
 
 const espnet = (model: ModelData) => {
 	if (model.tags?.includes("text-to-speech")) {
@@ -186,54 +186,52 @@ const espnet = (model: ModelData) => {
 };
 
 const fairseq = (model: ModelData) =>
-	`from fairseq.checkpoint_utils import load_model_ensemble_and_task_from_hf_hub
+	[`from fairseq.checkpoint_utils import load_model_ensemble_and_task_from_hf_hub
 
 models, cfg, task = load_model_ensemble_and_task_from_hf_hub(
     "${model.id}"
-)`;
+)`];
 
 
 const flair = (model: ModelData) =>
-	`from flair.models import SequenceTagger
+	[`from flair.models import SequenceTagger
 
-tagger = SequenceTagger.load("${model.id}")`;
+tagger = SequenceTagger.load("${model.id}")`];
 
 const keras = (model: ModelData) =>
-	`from huggingface_hub import from_pretrained_keras
+	[`from huggingface_hub import from_pretrained_keras
 
 model = from_pretrained_keras("${model.id}")
-`;
+`];
 
 const open_clip = (model: ModelData) =>
-	`import open_clip
+	[`import open_clip
 
 model, preprocess_train, preprocess_val = open_clip.create_model_and_transforms('hf-hub:${model.id}')
-tokenizer = open_clip.get_tokenizer('hf-hub:${model.id}')`;
-
-
+tokenizer = open_clip.get_tokenizer('hf-hub:${model.id}')`];
 
 const paddlenlp = (model: ModelData) => {
 	if (model.config?.architectures?.[0]) {
 		const architecture = model.config.architectures[0];
-		return [
+		return [[
 			`from paddlenlp.transformers import AutoTokenizer, ${architecture}`,
 			"",
 			`tokenizer = AutoTokenizer.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
 			`model = ${architecture}.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
-		].join("\n");
+		].join("\n")];
 	} else {
-		return [
+		return [[
 			`# ⚠️ Type of model unknown`,
 			`from paddlenlp.transformers import AutoTokenizer, AutoModel`,
 			"",
 			`tokenizer = AutoTokenizer.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
 			`model = AutoModel.from_pretrained("${model.id}"${model.private ? ", use_auth_token=True" : ""}, from_hf_hub=True)`,
-		].join("\n");
+		].join("\n")];
 	}
 };
 
 const pyannote_audio_pipeline = (model: ModelData) =>
-	`from pyannote.audio import Pipeline
+	[`from pyannote.audio import Pipeline
   
 pipeline = Pipeline.from_pretrained("${model.id}")
 
@@ -246,10 +244,10 @@ excerpt = Segment(start=2.0, end=5.0)
 
 from pyannote.audio import Audio
 waveform, sample_rate = Audio().crop("file.wav", excerpt)
-pipeline({"waveform": waveform, "sample_rate": sample_rate})`;
+pipeline({"waveform": waveform, "sample_rate": sample_rate})`];
 
 const pyannote_audio_model = (model: ModelData) =>
-	`from pyannote.audio import Model, Inference
+	[`from pyannote.audio import Model, Inference
 
 model = Model.from_pretrained("${model.id}")
 inference = Inference(model)
@@ -260,7 +258,7 @@ inference("file.wav")
 # inference on an excerpt
 from pyannote.core import Segment
 excerpt = Segment(start=2.0, end=5.0)
-inference.crop("file.wav", excerpt)`;
+inference.crop("file.wav", excerpt)`];
 
 const pyannote_audio = (model: ModelData) => {
 	if (model.tags?.includes("pyannote-audio-pipeline")) {
@@ -270,24 +268,24 @@ const pyannote_audio = (model: ModelData) => {
 };
 
 const tensorflowttsTextToMel = (model: ModelData) =>
-	`from tensorflow_tts.inference import AutoProcessor, TFAutoModel
+	[`from tensorflow_tts.inference import AutoProcessor, TFAutoModel
 
 processor = AutoProcessor.from_pretrained("${model.id}")
 model = TFAutoModel.from_pretrained("${model.id}")
-`;
+`];
 
 const tensorflowttsMelToWav = (model: ModelData) =>
-	`from tensorflow_tts.inference import TFAutoModel
+	[`from tensorflow_tts.inference import TFAutoModel
 
 model = TFAutoModel.from_pretrained("${model.id}")
 audios = model.inference(mels)
-`;
+`];
 
 const tensorflowttsUnknown = (model: ModelData) =>
-	`from tensorflow_tts.inference import TFAutoModel
+	[`from tensorflow_tts.inference import TFAutoModel
 
 model = TFAutoModel.from_pretrained("${model.id}")
-`;
+`];
 
 const tensorflowtts = (model: ModelData) => {
 	if (model.tags?.includes("text-to-mel")) {
@@ -299,57 +297,69 @@ const tensorflowtts = (model: ModelData) => {
 };
 
 const timm = (model: ModelData) =>
-	`import timm
+	[`import timm
 
-model = timm.create_model("hf_hub:${model.id}", pretrained=True)`;
+model = timm.create_model("hf_hub:${model.id}", pretrained=True)`];
+
+const skopsPickle = (model: ModelData, modelFile: string) => {
+	return [`import joblib
+from skops.hub_utils import download
+download("${model.id}", "path_to_folder")
+model = joblib.load(
+	"${modelFile}"
+)
+# only load pickle files from sources you trust
+# read more about it here https://skops.readthedocs.io/en/stable/persistence.html`];
+}
+
+const skopsFormat = (model: ModelData, modelFile: string) => {
+	return [`from skops.hub_utils import download
+from skops.io import load
+download("${model.id}", "path_to_folder")
+# make sure model file is in skops format
+# if model is a pickle file, make sure it's from a source you trust
+model = load("path_to_folder/${modelFile}")`];
+}
+
+const skopsJobLib = (model: ModelData) => {
+	return [`from huggingface_hub import hf_hub_download
+import joblib
+model = joblib.load(
+	hf_hub_download("${model.id}", "sklearn_model.joblib")
+)
+# only load pickle files from sources you trust
+# read more about it here https://skops.readthedocs.io/en/stable/persistence.html`];
+}
 
 const sklearn = (model: ModelData) => {
 	if (model.tags?.includes("skops")) {
 		const skopsmodelFile = model.config?.sklearn?.filename;
 		const skopssaveFormat = model.config?.sklearn?.model_format;
 		if (skopssaveFormat === "pickle") {
-			return `import joblib
-from skops.hub_utils import download
-download("${model.id}", "path_to_folder")
-model = joblib.load(
-	"${skopsmodelFile}"
-)
-# only load pickle files from sources you trust
-# read more about it here https://skops.readthedocs.io/en/stable/persistence.html`;
+			return skopsPickle(model, skopsmodelFile)
 		} else {
-			return `from skops.hub_utils import download
-from skops.io import load
-download("${model.id}", "path_to_folder")
-# make sure model file is in skops format
-# if model is a pickle file, make sure it's from a source you trust
-model = load("path_to_folder/${skopsmodelFile}")`;
+			return skopsFormat(model, skopsmodelFile)
 		}
 	} else {
-		return `from huggingface_hub import hf_hub_download
-import joblib
-model = joblib.load(
-	hf_hub_download("${model.id}", "sklearn_model.joblib")
-)
-# only load pickle files from sources you trust
-# read more about it here https://skops.readthedocs.io/en/stable/persistence.html`;
+		return skopsJobLib(model);
 	}
 };
 
 const fastai = (model: ModelData) =>
-	`from huggingface_hub import from_pretrained_fastai
+	[`from huggingface_hub import from_pretrained_fastai
 
-learn = from_pretrained_fastai("${model.id}")`;
+learn = from_pretrained_fastai("${model.id}")`];
 
 const sampleFactory = (model: ModelData) =>
-	`python -m sample_factory.huggingface.load_from_hub -r ${model.id} -d ./train_dir`;
+	[`python -m sample_factory.huggingface.load_from_hub -r ${model.id} -d ./train_dir`];
 
 const sentenceTransformers = (model: ModelData) =>
-	`from sentence_transformers import SentenceTransformer
+	[`from sentence_transformers import SentenceTransformer
 
-model = SentenceTransformer("${model.id}")`;
+model = SentenceTransformer("${model.id}")`];
 
 const spacy = (model: ModelData) =>
-	`!pip install https://huggingface.co/${model.id}/resolve/main/${nameWithoutNamespace(model.id)}-any-py3-none-any.whl
+	[`!pip install https://huggingface.co/${model.id}/resolve/main/${nameWithoutNamespace(model.id)}-any-py3-none-any.whl
 
 # Using spacy.load().
 import spacy
@@ -357,18 +367,18 @@ nlp = spacy.load("${nameWithoutNamespace(model.id)}")
 
 # Importing as module.
 import ${nameWithoutNamespace(model.id)}
-nlp = ${nameWithoutNamespace(model.id)}.load()`;
+nlp = ${nameWithoutNamespace(model.id)}.load()`];
 
 const span_marker = (model: ModelData) =>
-	`from span_marker import SpanMarkerModel
+	[`from span_marker import SpanMarkerModel
 
-model = SpanMarkerModel.from_pretrained("${model.id}")`;
+model = SpanMarkerModel.from_pretrained("${model.id}")`];
 
 const stanza = (model: ModelData) =>
-	`import stanza
+	[`import stanza
 
 stanza.download("${nameWithoutNamespace(model.id).replace("stanza-", "")}")
-nlp = stanza.Pipeline("${nameWithoutNamespace(model.id).replace("stanza-", "")}")`;
+nlp = stanza.Pipeline("${nameWithoutNamespace(model.id).replace("stanza-", "")}")`];
 
 
 const speechBrainMethod = (speechbrainInterface: string) => {
@@ -390,60 +400,73 @@ const speechBrainMethod = (speechbrainInterface: string) => {
 const speechbrain = (model: ModelData) => {
 	const speechbrainInterface = model.config?.speechbrain?.interface;
 	if (speechbrainInterface === undefined) {
-		return `# interface not specified in config.json`;
+		return [`# interface not specified in config.json`];
 	}
 
 	const speechbrainMethod = speechBrainMethod(speechbrainInterface);
 	if (speechbrainMethod === undefined) {
-		return `# interface in config.json invalid`;
+		return [`# interface in config.json invalid`];
 	}
 
-	return `from speechbrain.pretrained import ${speechbrainInterface}
+	return [`from speechbrain.pretrained import ${speechbrainInterface}
 model = ${speechbrainInterface}.from_hparams(
   "${model.id}"
 )
-model.${speechbrainMethod}("file.wav")`;
+model.${speechbrainMethod}("file.wav")`];
 };
 
 const transformers = (model: ModelData) => {
 	const info = model.transformersInfo;
 	if (!info) {
-		return `# ⚠️ Type of model unknown`;
+		return [`# ⚠️ Type of model unknown`];
 	}
 	const remote_code_snippet = info.custom_class ? ", trust_remote_code=True" : "";
+
+	let autoSnippet: string;
 	if (info.processor) {
 		const varName = info.processor === "AutoTokenizer" ? "tokenizer"
 			: info.processor === "AutoFeatureExtractor" ? "extractor"
 				: "processor"
 			;
-		return [
+		autoSnippet = [
+			"# Load model directly",
 			`from transformers import ${info.processor}, ${info.auto_model}`,
 			"",
 			`${varName} = ${info.processor}.from_pretrained("${model.id}"` + remote_code_snippet + ")",
-			"",
-			`model = ${info.auto_model}.from_pretrained("${model.id}"` + remote_code_snippet + ")",
+			`model = ${info.auto_model}.from_pretrained("${model.id}"` + remote_code_snippet + ")"
 		].join("\n");
 	} else {
-		return [
+		autoSnippet = [
+			"# Load model directly",
 			`from transformers import ${info.auto_model}`,
-			"",
 			`model = ${info.auto_model}.from_pretrained("${model.id}"` + remote_code_snippet + ")",
 		].join("\n");
 	}
+
+	if(info.pipeline_tag) {
+		const pipelineSnippet = [
+			"# Use a pipeline as a high-level helper",
+			"from transformers import pipeline",
+			"",
+			`pipe = pipeline("${info.pipeline_tag}", model="${model.id}"` + remote_code_snippet + ")"
+		].join("\n")
+		return [pipelineSnippet, autoSnippet];
+	}
+	return [autoSnippet]
 };
 
 const transformersJS = (model: ModelData) => {
 	if (!model.pipeline_tag) {
-		return `// ⚠️ Unknown pipeline tag`;
+		return [`// ⚠️ Unknown pipeline tag`];
 	}
 
 	const libName = '@xenova/transformers';
 
-	return `// npm i ${libName}
+	return [`// npm i ${libName}
 import { pipeline } from '${libName}';
 
 // Allocate pipeline
-const pipe = await pipeline('${model.pipeline_tag}', '${model.id}');`;
+const pipe = await pipeline('${model.pipeline_tag}', '${model.id}');`];
 };
 
 const peftTask = (peftTaskType?: string) => {
@@ -465,248 +488,247 @@ const peft = (model: ModelData) => {
 	const { base_model_name: peftBaseModel, task_type: peftTaskType } = model.config?.peft ?? {};
 	const pefttask = peftTask(peftTaskType);
 	if (!pefttask) {
-		return `Task type is invalid.`;
+		return [`Task type is invalid.`];
 	}
 	if (!peftBaseModel) {
-		return `Base model is not found.`;
+		return [`Base model is not found.`];
 	}
 
-	return `from peft import PeftModel, PeftConfig
+	return [`from peft import PeftModel, PeftConfig
 from transformers import AutoModelFor${pefttask}
 
 config = PeftConfig.from_pretrained("${model.id}")
 model = AutoModelFor${pefttask}.from_pretrained("${peftBaseModel}")
-model = PeftModel.from_pretrained(model, "${model.id}")`;
+model = PeftModel.from_pretrained(model, "${model.id}")`];
 };
 
 const fasttext = (model: ModelData) =>
-	`from huggingface_hub import hf_hub_download
+	[`from huggingface_hub import hf_hub_download
 import fasttext
 
-model = fasttext.load_model(hf_hub_download("${model.id}", "model.bin"))`;
+model = fasttext.load_model(hf_hub_download("${model.id}", "model.bin"))`];
 
 const stableBaselines3 = (model: ModelData) =>
-	`from huggingface_sb3 import load_from_hub
+	[`from huggingface_sb3 import load_from_hub
 checkpoint = load_from_hub(
 	repo_id="${model.id}",
 	filename="{MODEL FILENAME}.zip",
-)`;
+)`];
 
-const nemoDomainResolver = (domain: string, model: ModelData): string | undefined => {
+const nemoDomainResolver = (domain: string, model: ModelData): string[] | undefined => {
 	switch (domain) {
 		case "ASR":
-			return `import nemo.collections.asr as nemo_asr
+			return [`import nemo.collections.asr as nemo_asr
 asr_model = nemo_asr.models.ASRModel.from_pretrained("${model.id}")
 
-transcriptions = asr_model.transcribe(["file.wav"])`;
+transcriptions = asr_model.transcribe(["file.wav"])`];
 		default:
 			return undefined;
 	}
 };
 
 const mlAgents = (model: ModelData) =>
-	`mlagents-load-from-hf --repo-id="${model.id}" --local-dir="./downloads"`;
+	[`mlagents-load-from-hf --repo-id="${model.id}" --local-dir="./downloads"`];
 
 const nemo = (model: ModelData) => {
-	let command: string | undefined = undefined;
+	let command: string[] | undefined = undefined;
 	// Resolve the tag to a nemo domain/sub-domain 
 	if (model.tags?.includes("automatic-speech-recognition")) {
 		command = nemoDomainResolver("ASR", model);
 	}
 
-	return command ?? `# tag did not correspond to a valid NeMo domain.`;
+	return command ?? [`# tag did not correspond to a valid NeMo domain.`];
 };
 
 const pythae = (model: ModelData) =>
-	`from pythae.models import AutoModel
+	[`from pythae.models import AutoModel
 
-model = AutoModel.load_from_hf_hub("${model.id}")`;
+model = AutoModel.load_from_hf_hub("${model.id}")`];
 
 //#endregion
 
 
 
 export const MODEL_LIBRARIES_UI_ELEMENTS: Partial<Record<ModelLibraryKey, LibraryUiElement>> = {
-	// ^^ TODO(remove the optional ? marker when Stanza snippet is available)
 	"adapter-transformers": {
 		btnLabel: "Adapter Transformers",
 		repoName: "adapter-transformers",
 		repoUrl:  "https://github.com/Adapter-Hub/adapter-transformers",
-		snippet:  adapter_transformers,
+		snippets: adapter_transformers,
 	},
 	"allennlp": {
 		btnLabel: "AllenNLP",
 		repoName: "AllenNLP",
 		repoUrl:  "https://github.com/allenai/allennlp",
-		snippet:  allennlp,
+		snippets: allennlp,
 	},
 	"asteroid": {
 		btnLabel: "Asteroid",
 		repoName: "Asteroid",
 		repoUrl:  "https://github.com/asteroid-team/asteroid",
-		snippet:  asteroid,
+		snippets: asteroid,
 	},
 	"bertopic": {
 		btnLabel: "BERTopic",
 		repoName: "BERTopic",
 		repoUrl:  "https://github.com/MaartenGr/BERTopic",
-		snippet:  bertopic,
+		snippets: bertopic,
 	},
 	"diffusers": {
 		btnLabel: "Diffusers",
 		repoName: "🤗/diffusers",
 		repoUrl:  "https://github.com/huggingface/diffusers",
-		snippet:  diffusers,
+		snippets: diffusers,
 	},
 	"espnet": {
 		btnLabel: "ESPnet",
 		repoName: "ESPnet",
 		repoUrl:  "https://github.com/espnet/espnet",
-		snippet:  espnet,
+		snippets: espnet,
 	},
 	"fairseq": {
 		btnLabel: "Fairseq",
 		repoName: "fairseq",
 		repoUrl:  "https://github.com/pytorch/fairseq",
-		snippet:  fairseq,
+		snippets: fairseq,
 	},
 	"flair": {
 		btnLabel: "Flair",
 		repoName: "Flair",
 		repoUrl:  "https://github.com/flairNLP/flair",
-		snippet:  flair,
+		snippets: flair,
 	},
 	"keras": {
 		btnLabel: "Keras",
 		repoName: "Keras",
 		repoUrl:  "https://github.com/keras-team/keras",
-		snippet:  keras,
+		snippets: keras,
 	},
 	"nemo": {
 		btnLabel: "NeMo",
 		repoName: "NeMo",
 		repoUrl:  "https://github.com/NVIDIA/NeMo",
-		snippet:  nemo,
+		snippets: nemo,
 	},
 	"open_clip": {
 		btnLabel: "OpenCLIP",
 		repoName: "OpenCLIP",
 		repoUrl:  "https://github.com/mlfoundations/open_clip",
-		snippet:  open_clip,
+		snippets: open_clip,
 	},
 	"paddlenlp": {
 		btnLabel: "paddlenlp",
 		repoName: "PaddleNLP",
 		repoUrl:  "https://github.com/PaddlePaddle/PaddleNLP",
-		snippet:  paddlenlp,
+		snippets: paddlenlp,
 	},
 	"peft": {
 		btnLabel: "PEFT",
 		repoName: "PEFT",
 		repoUrl:  "https://github.com/huggingface/peft",
-		snippet:  peft,
+		snippets: peft,
 	},
 	"pyannote-audio": {
 		btnLabel: "pyannote.audio",
 		repoName: "pyannote-audio",
 		repoUrl:  "https://github.com/pyannote/pyannote-audio",
-		snippet:  pyannote_audio,
+		snippets: pyannote_audio,
 	},
 	"sentence-transformers": {
 		btnLabel: "sentence-transformers",
 		repoName: "sentence-transformers",
 		repoUrl:  "https://github.com/UKPLab/sentence-transformers",
-		snippet:  sentenceTransformers,
+		snippets: sentenceTransformers,
 	},
 	"sklearn": {
 		btnLabel: "Scikit-learn",
 		repoName: "Scikit-learn",
 		repoUrl:  "https://github.com/scikit-learn/scikit-learn",
-		snippet:  sklearn,
+		snippets: sklearn,
 	},
 	"fastai": {
 		btnLabel: "fastai",
 		repoName: "fastai",
 		repoUrl:  "https://github.com/fastai/fastai",
-		snippet:  fastai,
+		snippets: fastai,
 	},
 	"spacy": {
 		btnLabel: "spaCy",
 		repoName: "spaCy",
 		repoUrl:  "https://github.com/explosion/spaCy",
-		snippet:  spacy,
+		snippets: spacy,
 	},
 	"span-marker": {
 		btnLabel: "SpanMarker",
 		repoName: "SpanMarkerNER",
 		repoUrl:  "https://github.com/tomaarsen/SpanMarkerNER",
-		snippet:  span_marker,
+		snippets: span_marker,
 	},
 	"speechbrain": {
 		btnLabel: "speechbrain",
 		repoName: "speechbrain",
 		repoUrl:  "https://github.com/speechbrain/speechbrain",
-		snippet:  speechbrain,
+		snippets: speechbrain,
 	},
 	"stanza": {
 		btnLabel: "Stanza",
 		repoName: "stanza",
 		repoUrl:  "https://github.com/stanfordnlp/stanza",
-		snippet:  stanza,
+		snippets: stanza,
 	},
 	"tensorflowtts": {
 		btnLabel: "TensorFlowTTS",
 		repoName: "TensorFlowTTS",
 		repoUrl:  "https://github.com/TensorSpeech/TensorFlowTTS",
-		snippet:  tensorflowtts,
+		snippets: tensorflowtts,
 	},
 	"timm": {
 		btnLabel: "timm",
 		repoName: "pytorch-image-models",
 		repoUrl:  "https://github.com/rwightman/pytorch-image-models",
-		snippet:  timm,
+		snippets: timm,
 	},
 	"transformers": {
 		btnLabel: "Transformers",
 		repoName: "🤗/transformers",
 		repoUrl:  "https://github.com/huggingface/transformers",
-		snippet:  transformers,
+		snippets: transformers,
 	},
 	"transformers.js": {
 		btnLabel: "Transformers.js",
 		repoName: "transformers.js",
 		repoUrl:  "https://github.com/xenova/transformers.js",
-		snippet:  transformersJS,
+		snippets: transformersJS,
 	},
 	"fasttext": {
 		btnLabel: "fastText",
 		repoName: "fastText",
 		repoUrl:  "https://fasttext.cc/",
-		snippet:  fasttext,
+		snippets: fasttext,
 	},
 	"sample-factory": {
 		btnLabel: "sample-factory",
 		repoName: "sample-factory",
 		repoUrl:  "https://github.com/alex-petrenko/sample-factory",
-		snippet:  sampleFactory,
+		snippets: sampleFactory,
 	},
 	"stable-baselines3": {
 		btnLabel: "stable-baselines3",
 		repoName: "stable-baselines3",
 		repoUrl:  "https://github.com/huggingface/huggingface_sb3",
-		snippet:  stableBaselines3,
+		snippets: stableBaselines3,
 	},
 	"ml-agents": {
 		btnLabel: "ml-agents",
 		repoName: "ml-agents",
 		repoUrl:  "https://github.com/huggingface/ml-agents",
-		snippet:  mlAgents,
+		snippets: mlAgents,
 	},
 	"pythae": {
 		btnLabel: "pythae",
 		repoName: "pythae",
 		repoUrl:  "https://github.com/clementchadebec/benchmark_VAE",
-		snippet:  pythae,
+		snippets: pythae,
 	},
 } as const;
 


### PR DESCRIPTION
Fixes #11 

This PR makes the snippets a list of strings, hence allowing to have multiple snippets for a given model. Additionally,
* Add code snippet with `pipeline` to transformers
* Refactor sklearn code into functions 

Initial version, missing design changes
![Screenshot from 2023-06-30 14-14-38](https://github.com/huggingface/hub-docs/assets/7246357/103206df-457e-44e0-a8a4-fc1b9c13b632)
![Screenshot from 2023-06-30 14-14-22](https://github.com/huggingface/hub-docs/assets/7246357/ce6e282f-06f2-4260-bfae-3e1d6cbb10fa)
