### PR TITLE
add snippets for image-to-text

### DIFF
--- a/js/src/lib/inferenceSnippets/inputs.ts
+++ b/js/src/lib/inferenceSnippets/inputs.ts
@@ -67,6 +67,8 @@ const inputsFeatureExtraction = () =>
 
 const inputsImageClassification = () => `"cats.jpg"`;
 
+const inputsImageToText = () => `"cats.jpg"`;
+
 const inputsImageSegmentation = () => `"cats.jpg"`;
 
 const inputsObjectDetection = () => `"cats.jpg"`;
@@ -93,6 +95,7 @@ const modelInputSnippets: {
 	"feature-extraction":           inputsFeatureExtraction,
 	"fill-mask":                    inputsFillMask,
 	"image-classification":         inputsImageClassification,
+	"image-to-text":                inputsImageToText,
 	"image-segmentation":           inputsImageSegmentation,
 	"object-detection":             inputsObjectDetection,
 	"question-answering":           inputsQuestionAnswering,

--- a/js/src/lib/inferenceSnippets/serveCurl.ts
+++ b/js/src/lib/inferenceSnippets/serveCurl.ts
@@ -45,6 +45,7 @@ export const curlSnippets:
 	"audio-to-audio":               snippetFile,
 	"audio-classification":         snippetFile,
 	"image-classification":         snippetFile,
+	"image-to-text":                snippetFile,
 	"object-detection":             snippetFile,
 	"image-segmentation":           snippetFile,
 };

--- a/js/src/lib/inferenceSnippets/serveJs.ts
+++ b/js/src/lib/inferenceSnippets/serveJs.ts
@@ -96,6 +96,7 @@ export const jsSnippets:
 	"audio-to-audio":               snippetFile,
 	"audio-classification":         snippetFile,
 	"image-classification":         snippetFile,
+	"image-to-text":                snippetFile,
 	"object-detection":             snippetFile,
 	"image-segmentation":           snippetFile,
 };

--- a/js/src/lib/inferenceSnippets/servePython.ts
+++ b/js/src/lib/inferenceSnippets/servePython.ts
@@ -64,6 +64,7 @@ export const pythonSnippets:
 	"audio-to-audio":               snippetFile,
 	"audio-classification":         snippetFile,
 	"image-classification":         snippetFile,
+	"image-to-text":                snippetFile,
 	"object-detection":             snippetFile,
 	"image-segmentation":           snippetFile,
 };


### PR DESCRIPTION
<img width="873" alt="image" src="https://github.com/huggingface/hub-docs/assets/38108242/2bbeee8b-6138-49f5-b8e7-331e806dc9bb">
<img width="873" alt="image" src="https://github.com/huggingface/hub-docs/assets/38108242/ddb67768-d0fb-4990-92d9-1f1416d2e2c5">
<img width="876" alt="image" src="https://github.com/huggingface/hub-docs/assets/38108242/291f7209-9d1c-41f5-824f-e496cc188e7f">



Request: https://github.com/huggingface/hub-docs/issues/735