### PR TITLE
Add `credentials` to model status fetch

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -17,6 +17,7 @@
 	export let error: string;
 	export let isLoading = false;
 	export let model: WidgetProps["model"];
+	export let includeCredentials: WidgetProps["includeCredentials"];
 	export let modelLoading = {
 		isLoading: false,
 		estimatedTime: 0,
@@ -63,7 +64,7 @@
 			: inputGroups.find(({ group }) => group === selectedInputGroup);
 
 	onMount(() => {
-		getModelLoadInfo(apiUrl, model.id).then((info) => {
+		getModelLoadInfo(apiUrl, model.id, includeCredentials).then((info) => {
 			modelLoadInfo = info;
 		});
 	});

--- a/js/src/lib/components/InferenceWidget/shared/helpers.ts
+++ b/js/src/lib/components/InferenceWidget/shared/helpers.ts
@@ -180,8 +180,8 @@ export async function getResponse<T>(
 }
 
 
-export async function getModelLoadInfo(url: string, repoId: string): Promise<ModelLoadInfo> {
-	const response = await fetch(`${url}/status/${repoId}`);
+export async function getModelLoadInfo(url: string, repoId: string, includeCredentials = false): Promise<ModelLoadInfo> {
+	const response = await fetch(`${url}/status/${repoId}`, {credentials: includeCredentials ? "include" : "same-origin"});
 	const output = await response.json();
 	if (response.ok && typeof output === 'object' && output.loaded !== undefined) {
 		const status = output.loaded ? 'loaded' : 'unknown';

--- a/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
@@ -167,6 +167,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -168,6 +168,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -162,6 +162,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
@@ -171,6 +171,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
@@ -139,6 +139,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
@@ -134,6 +134,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -132,6 +132,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
@@ -252,6 +252,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToImageWidget/ImageToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToImageWidget/ImageToImageWidget.svelte
@@ -155,6 +155,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
@@ -124,6 +124,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
@@ -158,6 +158,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
@@ -150,6 +150,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
@@ -156,6 +156,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
@@ -125,6 +125,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
@@ -180,6 +180,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/TabularDataWidget/TabularDataWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TabularDataWidget/TabularDataWidget.svelte
@@ -207,6 +207,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -198,6 +198,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
@@ -123,6 +123,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
@@ -124,6 +124,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
@@ -253,6 +253,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -170,6 +170,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
@@ -175,6 +175,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
@@ -177,6 +177,7 @@
 
 <WidgetWrapper
 	{apiUrl}
+	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}


### PR DESCRIPTION
Just like the fetch to infrence, fetch to model status should have `credentials` attribute set as well

Had to change bunch of files but the only change that needs to be reviewed is https://github.com/huggingface/hub-docs/pull/889/files#diff-db7f2d2a8101371aad01e3f7679a486c69e58a9082807f80aa04697ab1471f9c