### PR TITLE
Fix Inference API status check, allow modelLoadInfo to be passed as prop

### DIFF
--- a/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
@@ -37,7 +37,7 @@
 	export let includeCredentials = false;
 	export let isLoggedIn = false;
 	export let modelLoadInfo: ModelLoadInfo | undefined = undefined;
-	
+
 	// Note: text2text-generation, text-generation and translation all
 	// uses the TextGenerationWidget as they work almost the same.
 	// Same goes for fill-mask and text-classification.

--- a/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { SvelteComponent } from "svelte";
 	import type { PipelineType } from "../../interfaces/Types";
-	import type { WidgetProps } from "./shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "./shared/types";
 
 	import AudioClassificationWidget from "./widgets/AudioClassificationWidget/AudioClassificationWidget.svelte";
 	import AudioToAudioWidget from "./widgets/AudioToAudioWidget/AudioToAudioWidget.svelte";
@@ -36,7 +36,8 @@
 	export let shouldUpdateUrl = false;
 	export let includeCredentials = false;
 	export let isLoggedIn = false;
-
+	export let modelLoadInfo: ModelLoadInfo | undefined = undefined;
+	
 	// Note: text2text-generation, text-generation and translation all
 	// uses the TextGenerationWidget as they work almost the same.
 	// Same goes for fill-mask and text-classification.
@@ -88,6 +89,7 @@
 		shouldUpdateUrl,
 		includeCredentials,
 		isLoggedIn,
+		modelLoadInfo
 	}) as WidgetProps;
 </script>
 

--- a/js/src/lib/components/InferenceWidget/shared/WidgetInfo/WidgetInfo.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetInfo/WidgetInfo.svelte
@@ -6,7 +6,7 @@
 	export let model: WidgetProps["model"];
 	export let computeTime: string;
 	export let error: string;
-	export let modelLoadInfo: ModelLoadInfo;
+	export let modelLoadInfo: ModelLoadInfo | undefined;
 
 	const status = {
 		TooBig: "⚠️ This model is too large to be loaded by the inference API. ⚠️",
@@ -21,10 +21,13 @@
 	} as const;
 
 	function getStatusReport(
-		modelLoadInfo: ModelLoadInfo,
+		modelLoadInfo: ModelLoadInfo | undefined,
 		statuses: Record<LoadingStatus, string>,
 		isAzure = false
 	): string {
+		if (!modelLoadInfo) {
+			return "Unable to get model status.";
+		}
 		if (
 			modelLoadInfo.compute_type === "cpu" &&
 			modelLoadInfo.state === "Loaded" &&
@@ -36,6 +39,9 @@
 	}
 
 	function getComputeTypeMsg(): string {
+		if (!modelLoadInfo) {
+			return "Unknown compute type";
+		}
 		let compute_type = modelLoadInfo?.compute_type ?? "cpu";
 		if (compute_type === "cpu") {
 			return "Intel Xeon 3rd Gen Scalable cpu";

--- a/js/src/lib/components/InferenceWidget/shared/WidgetInfo/WidgetInfo.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetInfo/WidgetInfo.svelte
@@ -6,18 +6,18 @@
 	export let model: WidgetProps["model"];
 	export let computeTime: string;
 	export let error: string;
-	export let modelLoadInfo: ModelLoadInfo = { status: "unknown" };
+	export let modelLoadInfo: ModelLoadInfo;
 
 	const status = {
-		error: "⚠️ This model could not be loaded by the inference API. ⚠️",
-		loaded: "This model is currently loaded and running on the Inference API.",
-		unknown: "This model can be loaded on the Inference API on-demand.",
+		TooBig: "⚠️ This model is too large to be loaded by the inference API. ⚠️",
+		Loaded: "This model is currently loaded and running on the Inference API.",
+		Loadable: "This model can be loaded on the Inference API on-demand.",
 	} as const;
 
 	const azureStatus = {
-		error: "⚠️ This model could not be loaded.",
-		loaded: "This model is loaded and running on AzureML Managed Endpoint",
-		unknown: "This model can be loaded loaded on AzureML Managed Endpoint",
+		TooBig: "⚠️ This model is too large to be loaded by the inference API.",
+		Loaded: "This model is loaded and running on AzureML Managed Endpoint",
+		Loadable: "This model can be loaded loaded on AzureML Managed Endpoint",
 	} as const;
 
 	function getStatusReport(
@@ -27,12 +27,12 @@
 	): string {
 		if (
 			modelLoadInfo.compute_type === "cpu" &&
-			modelLoadInfo.status === "loaded" &&
+			modelLoadInfo.state === "Loaded" &&
 			!isAzure
 		) {
 			return `The model is loaded and running on <a class="hover:underline" href="https://huggingface.co/intel" target="_blank">Intel Xeon 3rd Gen Scalable CPU</a>`;
 		}
-		return statuses[modelLoadInfo.status];
+		return statuses[modelLoadInfo.state];
 	}
 
 	function getComputeTypeMsg(): string {

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -24,12 +24,10 @@
 	};
 	export let noTitle = false;
 	export let outputJson: string;
-	export let applyInputSample: (
-		sample: Record<string, any>
-	) => void = ({}) => {};
-	export let previewInputSample: (
-		sample: Record<string, any>
-	) => void = ({}) => {};
+	export let applyInputSample: (sample: Record<string, any>) => void =
+		({}) => {};
+	export let previewInputSample: (sample: Record<string, any>) => void =
+		({}) => {};
 	export let modelLoadInfo: ModelLoadInfo | undefined;
 
 	let isMaximized = false;

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -24,13 +24,15 @@
 	};
 	export let noTitle = false;
 	export let outputJson: string;
-	export let applyInputSample: (sample: Record<string, any>) => void =
-		({}) => {};
-	export let previewInputSample: (sample: Record<string, any>) => void =
-		({}) => {};
+	export let applyInputSample: (
+		sample: Record<string, any>
+	) => void = ({}) => {};
+	export let previewInputSample: (
+		sample: Record<string, any>
+	) => void = ({}) => {};
+	export let modelLoadInfo: ModelLoadInfo | undefined;
 
 	let isMaximized = false;
-	let modelLoadInfo: ModelLoadInfo = { status: "unknown" };
 	let selectedInputGroup: string;
 
 	const inputSamples: WidgetInputSample[] = (model?.widgetData ?? [])
@@ -64,6 +66,7 @@
 			: inputGroups.find(({ group }) => group === selectedInputGroup);
 
 	onMount(() => {
+		if (modelLoadInfo) return;
 		getModelLoadInfo(apiUrl, model.id, includeCredentials).then((info) => {
 			modelLoadInfo = info;
 		});
@@ -75,11 +78,11 @@
 </script>
 
 <div
-	class="flex flex-col w-full max-w-full
-	{isMaximized ? 'fixed inset-0 bg-white p-12 z-20' : ''}"
+	class="flex w-full max-w-full flex-col
+	{isMaximized ? 'fixed inset-0 z-20 bg-white p-12' : ''}"
 >
 	{#if isMaximized}
-		<button class="absolute top-6 right-12" on:click={onClickMaximizeBtn}>
+		<button class="absolute right-12 top-6" on:click={onClickMaximizeBtn}>
 			<IconCross classNames="text-xl text-gray-500 hover:text-black" />
 		</button>
 	{/if}

--- a/js/src/lib/components/InferenceWidget/shared/helpers.ts
+++ b/js/src/lib/components/InferenceWidget/shared/helpers.ts
@@ -180,16 +180,14 @@ export async function getResponse<T>(
 }
 
 
-export async function getModelLoadInfo(url: string, repoId: string, includeCredentials = false): Promise<ModelLoadInfo> {
+export async function getModelLoadInfo(url: string, repoId: string, includeCredentials = false): Promise<ModelLoadInfo | undefined> {
 	const response = await fetch(`${url}/status/${repoId}`, {credentials: includeCredentials ? "include" : "same-origin"});
 	const output = await response.json();
-	if (response.ok && typeof output === 'object' && output.loaded !== undefined) {
-		const status = output.loaded ? 'loaded' : 'unknown';
-		const compute_type = output.compute_type;
-		return {status, compute_type}
+	if (response.ok) {
+		return output as ModelLoadInfo;
 	} else {
 		console.warn(response.status, output.error);
-		return {status: 'error'};
+		return undefined;
 	}
 }
 

--- a/js/src/lib/components/InferenceWidget/shared/types.ts
+++ b/js/src/lib/components/InferenceWidget/shared/types.ts
@@ -20,7 +20,7 @@ export type ComputeType = "cpu" | "gpu";
 export type ModelLoadInfo = {
 	loaded:       boolean;
 	state:        "Loaded" | "Loadable" | "TooBig";
-	compute_type: "cpu" | "ppu";
+	compute_type: "cpu" | "gpu";
 	framework:    string;
 }
 

--- a/js/src/lib/components/InferenceWidget/shared/types.ts
+++ b/js/src/lib/components/InferenceWidget/shared/types.ts
@@ -9,16 +9,19 @@ export interface WidgetProps {
 	shouldUpdateUrl: boolean;
 	includeCredentials: boolean;
 	isLoggedIn?: boolean;
+	modelLoadInfo?: ModelLoadInfo;
 }
 
 
-export type LoadingStatus = "error" | "loaded" | "unknown";
+export type LoadingStatus = "Loaded" | "Loadable" | "TooBig";
 
 export type ComputeType = "cpu" | "gpu";
 
 export type ModelLoadInfo = {
-	status: LoadingStatus;
-	compute_type?: ComputeType;
+	loaded:       boolean;
+	state:        "Loaded" | "Loadable" | "TooBig";
+	compute_type: "cpu" | "ppu";
+	framework:    string;
 }
 
 export type TableData = Record<string, (string | number)[]>;

--- a/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 	import WidgetAudioTrack from "../../shared/WidgetAudioTrack/WidgetAudioTrack.svelte";
@@ -20,6 +20,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -174,6 +175,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import WidgetAudioTrack from "../../shared/WidgetAudioTrack/WidgetAudioTrack.svelte";
 	import WidgetFileInput from "../../shared/WidgetFileInput/WidgetFileInput.svelte";
@@ -19,6 +19,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -175,6 +176,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import WidgetAudioTrack from "../../shared/WidgetAudioTrack/WidgetAudioTrack.svelte";
 	import WidgetFileInput from "../../shared/WidgetFileInput/WidgetFileInput.svelte";
@@ -21,6 +21,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -169,6 +170,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 	import WidgetOutputConvo from "../../shared/WidgetOutputConvo/WidgetOutputConvo.svelte";
@@ -20,6 +20,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	interface Conversation {
 		generated_responses: string[];
@@ -178,6 +179,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 	import WidgetQuickInput from "../../shared/WidgetQuickInput/WidgetQuickInput.svelte";
@@ -20,6 +20,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -146,6 +147,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 	import WidgetOutputChart from "../../shared/WidgetOutputChart/WidgetOutputChart.svelte";
@@ -21,6 +21,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -141,6 +142,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 
@@ -19,6 +19,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -139,6 +140,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps, ImageSegment } from "../../shared/types";
+	import type { WidgetProps, ImageSegment, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 
@@ -23,6 +23,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	const maskOpacity = Math.floor(255 * 0.6);
 	const colorToRgb = COLORS.reduce((acc, clr) => {
@@ -259,6 +260,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	import type { WidgetProps, ImageSegment, ModelLoadInfo } from "../../shared/types";
+	import type {
+		WidgetProps,
+		ImageSegment,
+		ModelLoadInfo,
+	} from "../../shared/types";
 
 	import { onMount } from "svelte";
 

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToImageWidget/ImageToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToImageWidget/ImageToImageWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 
@@ -20,6 +20,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -162,6 +163,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 
@@ -19,6 +19,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -131,6 +132,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps, DetectedObject } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo, DetectedObject } from "../../shared/types";
 
 	import { onMount } from "svelte";
 
@@ -23,6 +23,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -165,6 +166,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	import type { WidgetProps, ModelLoadInfo, DetectedObject } from "../../shared/types";
+	import type {
+		WidgetProps,
+		ModelLoadInfo,
+		DetectedObject,
+	} from "../../shared/types";
 
 	import { onMount } from "svelte";
 

--- a/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 	import WidgetQuickInput from "../../shared/WidgetQuickInput/WidgetQuickInput.svelte";
@@ -20,6 +20,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let context = "";
 	let computeTime = "";
@@ -157,6 +158,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ReinforcementLearningWidget/ReinforcementLearningWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ReinforcementLearningWidget/ReinforcementLearningWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 	import { onMount } from "svelte";
 	import IconSpin from "../../../Icons/IconSpin.svelte";
 	import IconCross from "../../../Icons/IconCross.svelte";

--- a/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 	import WidgetOutputChart from "../../shared/WidgetOutputChart/WidgetOutputChart.svelte";
@@ -19,6 +19,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let sourceSentence = "";
 	let comparisonSentences: Array<string> = [];
@@ -163,6 +164,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 	import WidgetOutputText from "../../shared/WidgetOutputText/WidgetOutputText.svelte";
@@ -21,6 +21,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -132,6 +133,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
@@ -34,6 +34,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -187,6 +188,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/TabularDataWidget/TabularDataWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TabularDataWidget/TabularDataWidget.svelte
@@ -27,6 +27,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	const columns: string[] = Object.keys(
 		model?.widgetData?.[0]?.structuredData ?? {}
@@ -214,6 +215,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 	import type { PipelineType } from "../../../../interfaces/Types";
 
 	import { onMount } from "svelte";
@@ -25,6 +25,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 	export let isLoggedIn: WidgetProps["includeCredentials"];
 
 	const isBloomLoginRequired =
@@ -205,6 +206,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 	import WidgetQuickInput from "../../shared/WidgetQuickInput/WidgetQuickInput.svelte";
@@ -19,6 +19,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -130,6 +131,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 	import WidgetAudioTrack from "../../shared/WidgetAudioTrack/WidgetAudioTrack.svelte";
@@ -21,6 +21,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -131,6 +132,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 	import WidgetOuputTokens from "../../shared/WidgetOutputTokens/WidgetOutputTokens.svelte";
@@ -36,6 +36,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -260,6 +261,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 
@@ -20,6 +20,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let computeTime = "";
 	let error: string = "";
@@ -177,6 +178,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 
@@ -21,6 +21,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let candidateLabels = "";
 	let computeTime = "";
@@ -182,6 +183,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WidgetProps } from "../../shared/types";
+	import type { WidgetProps, ModelLoadInfo } from "../../shared/types";
 
 	import { onMount } from "svelte";
 	import WidgetCheckbox from "../../shared/WidgetCheckbox/WidgetCheckbox.svelte";
@@ -23,6 +23,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let modelLoadInfo: ModelLoadInfo;
 
 	let candidateLabels = "";
 	let computeTime = "";
@@ -184,6 +185,7 @@
 	{isLoading}
 	{model}
 	{modelLoading}
+	{modelLoadInfo}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/routes/[...model].svelte
+++ b/js/src/routes/[...model].svelte
@@ -37,23 +37,22 @@
 	export let message: string | undefined;
 </script>
 
-<a href="/" class="pt-3 ml-3 block underline">← Back to index</a>
+<a href="/" class="ml-3 block pt-3 underline">← Back to index</a>
 <ModeSwitcher />
 
 <div class="container py-24">
 	{#if model}
 		<div>
-			<a class="text-xs block mb-3 text-gray-300" href="/{model.id}">
+			<a class="mb-3 block text-xs text-gray-300" href="/{model.id}">
 				<code>{model.id}</code>
 			</a>
-			<div class="p-5 shadow-sm rounded-xl bg-white max-w-3xl">
+			<div class="max-w-3xl rounded-xl bg-white p-5 shadow-sm">
 				<InferenceWidget {model} />
 			</div>
 		</div>
 
-		<pre
-			class="text-xs text-gray-900 px-3 py-4 mt-16">
-			{ JSON.stringify(model, null, 2) }
+		<pre class="mt-16 px-3 py-4 text-xs text-gray-900">
+			{JSON.stringify(model, null, 2)}
 		</pre>
 	{:else}
 		<div>Error. Probably non existent model. {message}</div>

--- a/js/src/routes/[...model].svelte
+++ b/js/src/routes/[...model].svelte
@@ -37,23 +37,23 @@
 	export let message: string | undefined;
 </script>
 
-<a href="/" class="ml-3 block pt-3 underline">← Back to index</a>
+<a href="/" class="pt-3 ml-3 block underline">← Back to index</a>
 <ModeSwitcher />
 
 <div class="container py-24">
 	{#if model}
 		<div>
-			<a class="mb-3 block text-xs text-gray-300" href="/{model.id}">
+			<a class="text-xs block mb-3 text-gray-300" href="/{model.id}">
 				<code>{model.id}</code>
 			</a>
-			<div class="max-w-3xl rounded-xl bg-white p-5 shadow-sm">
+			<div class="p-5 shadow-sm rounded-xl bg-white max-w-3xl">
 				<InferenceWidget {model} />
 			</div>
 		</div>
 
 		<pre
-			class="mt-16 px-3 py-4 text-xs text-gray-900">
-			{JSON.stringify(model, null, 2)}
+			class="text-xs text-gray-900 px-3 py-4 mt-16">
+			{ JSON.stringify(model, null, 2) }
 		</pre>
 	{:else}
 		<div>Error. Probably non existent model. {message}</div>

--- a/js/src/routes/[...model].svelte
+++ b/js/src/routes/[...model].svelte
@@ -51,7 +51,8 @@
 			</div>
 		</div>
 
-		<pre class="mt-16 px-3 py-4 text-xs text-gray-900">
+		<pre
+			class="mt-16 px-3 py-4 text-xs text-gray-900">
 			{JSON.stringify(model, null, 2)}
 		</pre>
 	{:else}


### PR DESCRIPTION
To reduce the number of calls made to the inference API status check, we let modeLoadInfo to be passed in as a prop - if not provided as a prop, it makes the api call directly as it always has. This allows the Model Page in moon-landing, which needs to make the status check request, reuse the model status instead of making another call. See discussion here: https://github.com/huggingface/moon-landing/pull/6975

Also I believe the status API got out of sync at some point with the actual API returned by api-inference - fixed now. This is why currently every model says `This model can be loaded on the Inference API on-demand` even when that isn't the case.