### PR TITLE
Fix Dockerfile in spaces-sdks-docker-first-demo.md

### DIFF
--- a/docs/hub/spaces-sdks-docker-first-demo.md
+++ b/docs/hub/spaces-sdks-docker-first-demo.md
@@ -70,7 +70,7 @@ RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 
 COPY . .
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "7860"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "7860"]
 
 ```
 


### PR DESCRIPTION
This PR changes `app.main:app`  to `main:app` in spaces-sdks-docker-first-demo.md to avoid `ModuleNotFoundError: No module named 'app'` error.

There was a fix[1] apply on example demo, but the doc is outdate. 

[1] https://huggingface.co/spaces/SpacesExamples/fastapi_dummy/commit/7487ea38a0c757aef965d57d7e7a7f66bbbcc216
[2] https://huggingface.co/docs/hub/spaces-sdks-docker-first-demo#create-the-dockerfile