### PR TITLE
Michelle user access tokens update

### DIFF
--- a/docs/hub/security-tokens.md
+++ b/docs/hub/security-tokens.md
@@ -15,6 +15,8 @@ Access tokens allow applications and notebooks to perform specific actions speci
 
 - `write`: tokens with this role additionally grant write access to the repositories you have write access to. Use this token if you need to create or push content to a repository (e.g., when training a model or modifying a model card).
 
+Note that Organization API Tokens have been deprecated. If you are a member of an organization with read/write/admin role, then your User Access Tokens will be able to read/write the resources according to the token permission (read/write) and organization membership (read/write/admin).
+
 ## How to manage User Access Tokens?
 
 To create an access token, go to your settings, then click on the [Access Tokens tab](https://huggingface.co/settings/tokens). Click on the **New token** button to create a new User Access Token.

--- a/docs/hub/security-tokens.md
+++ b/docs/hub/security-tokens.md
@@ -19,7 +19,7 @@ Note that Organization API Tokens have been deprecated:
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/API-token.png"/>
-<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/API-token-dark.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/API-token_dark.png"/>
 </div>
 
 If you are a member of an organization with read/write/admin role, then your User Access Tokens will be able to read/write the resources according to the token permission (read/write) and organization membership (read/write/admin).

--- a/docs/hub/security-tokens.md
+++ b/docs/hub/security-tokens.md
@@ -72,4 +72,4 @@ We recommend you create one access token per app or usage. For instance, you cou
  
  This way, you can invalidate one token without impacting your other usages.
 
-We also recommend only giving the appropriate role to each token you create. If you only need read access (i.e., loading a dataset with the `datasets` library or retrieving the weights of a model), only give your access token the `read` role.
+We also recommend only giving the appropriate role to each token you create. If you only need read access (e.g., loading a dataset with the `datasets` library or retrieving the weights of a model), only give your access token the `read` role.

--- a/docs/hub/security-tokens.md
+++ b/docs/hub/security-tokens.md
@@ -5,8 +5,8 @@
 User Access Tokens are the preferred way to authenticate an application or notebook to Hugging Face services. You can manage your access tokens in your [settings](https://huggingface.co/settings/tokens).
 
 <div class="flex justify-center">
-<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/access-tokens.png"/>
-<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/access-tokens-dark.png"/>
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/User-Access-Token.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/User-Access-Token-dark.png"/>
 </div>
 
 Access tokens allow applications and notebooks to perform specific actions specified by the scope of the roles shown in the following:
@@ -15,7 +15,14 @@ Access tokens allow applications and notebooks to perform specific actions speci
 
 - `write`: tokens with this role additionally grant write access to the repositories you have write access to. Use this token if you need to create or push content to a repository (e.g., when training a model or modifying a model card).
 
-Note that Organization API Tokens have been deprecated. If you are a member of an organization with read/write/admin role, then your User Access Tokens will be able to read/write the resources according to the token permission (read/write) and organization membership (read/write/admin).
+Note that Organization API Tokens have been deprecated: 
+
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/API-token.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/API-token-dark.png"/>
+</div>
+
+If you are a member of an organization with read/write/admin role, then your User Access Tokens will be able to read/write the resources according to the token permission (read/write) and organization membership (read/write/admin).
 
 ## How to manage User Access Tokens?
 


### PR DESCRIPTION
Hi @mishig25 ! Could let me know if you think the screenshot updates are okay (since the official deprecation of Organization API tokens?) I've added the images to https://huggingface.co/datasets/huggingface/documentation-images/discussions/156.

Credit to @jeffboudier for the line: "If your user is member of an organization with read/write/admin role, then your User Access Tokens will be able to read/write the resources according to the token permission (read/write) and organization membership (read/write/admin)"

cc @jeffboudier @SBrandeis for viz since this doc update was reported by user via email