### PR TITLE
Make hub-docs compatible with HF Endpoints

### DIFF
--- a/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
@@ -1,89 +1,93 @@
 <script lang="ts">
-	import type { SvelteComponent } from "svelte";
-	import type { PipelineType } from "../../interfaces/Types";
-	import type { WidgetProps } from "./shared/types";
+import type { SvelteComponent } from 'svelte';
+import type { PipelineType } from '../../interfaces/Types';
+import type { WidgetProps } from './shared/types';
 
-	import AudioClassificationWidget from "./widgets/AudioClassificationWidget/AudioClassificationWidget.svelte";
-	import AudioToAudioWidget from "./widgets/AudioToAudioWidget/AudioToAudioWidget.svelte";
-	import AutomaticSpeechRecognitionWidget from "./widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte";
-	import ConversationalWidget from "./widgets/ConversationalWidget/ConversationalWidget.svelte";
-	import FeatureExtractionWidget from "./widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte";
-	import FillMaskWidget from "./widgets/FillMaskWidget/FillMaskWidget.svelte";
-	import ImageClassificationWidget from "./widgets/ImageClassificationWidget/ImageClassificationWidget.svelte";
-	import ImageToImageWidget from "./widgets/ImageToImageWidget/ImageToImageWidget.svelte";
-	import ImageToTextWidget from "./widgets/ImageToTextWidget/ImageToTextWidget.svelte";
-	import ImageSegmentationWidget from "./widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte";
-	import ObjectDetectionWidget from "./widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte";
-	import QuestionAnsweringWidget from "./widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte";
-	import VisualQuestionAnsweringWidget from "./widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte";
-	import SentenceSimilarityWidget from "./widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte";
-	import SummarizationWidget from "./widgets/SummarizationWidget/SummarizationWidget.svelte";
-	import TableQuestionAnsweringWidget from "./widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte";
-	import TextGenerationWidget from "./widgets/TextGenerationWidget/TextGenerationWidget.svelte";
-	import TextToImageWidget from "./widgets/TextToImageWidget/TextToImageWidget.svelte";
-	import TextToSpeechWidget from "./widgets/TextToSpeechWidget/TextToSpeechWidget.svelte";
-	import TokenClassificationWidget from "./widgets/TokenClassificationWidget/TokenClassificationWidget.svelte";
-	import TabularDataWidget from "./widgets/TabularDataWidget/TabularDataWidget.svelte";
-	import ReinforcementLearningWidget from "./widgets/ReinforcementLearningWidget/ReinforcementLearningWidget.svelte";
-	import ZeroShotClassificationWidget from "./widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte";
-	import ZeroShotImageClassificationWidget from "./widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte";
+import AudioClassificationWidget from './widgets/AudioClassificationWidget/AudioClassificationWidget.svelte';
+import AudioToAudioWidget from './widgets/AudioToAudioWidget/AudioToAudioWidget.svelte';
+import AutomaticSpeechRecognitionWidget from './widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte';
+import ConversationalWidget from './widgets/ConversationalWidget/ConversationalWidget.svelte';
+import FeatureExtractionWidget from './widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte';
+import FillMaskWidget from './widgets/FillMaskWidget/FillMaskWidget.svelte';
+import ImageClassificationWidget from './widgets/ImageClassificationWidget/ImageClassificationWidget.svelte';
+import ImageToImageWidget from './widgets/ImageToImageWidget/ImageToImageWidget.svelte';
+import ImageToTextWidget from './widgets/ImageToTextWidget/ImageToTextWidget.svelte';
+import ImageSegmentationWidget from './widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte';
+import ObjectDetectionWidget from './widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte';
+import QuestionAnsweringWidget from './widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte';
+import VisualQuestionAnsweringWidget from './widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte';
+import SentenceSimilarityWidget from './widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte';
+import SummarizationWidget from './widgets/SummarizationWidget/SummarizationWidget.svelte';
+import TableQuestionAnsweringWidget from './widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte';
+import TextGenerationWidget from './widgets/TextGenerationWidget/TextGenerationWidget.svelte';
+import TextToImageWidget from './widgets/TextToImageWidget/TextToImageWidget.svelte';
+import TextToSpeechWidget from './widgets/TextToSpeechWidget/TextToSpeechWidget.svelte';
+import TokenClassificationWidget from './widgets/TokenClassificationWidget/TokenClassificationWidget.svelte';
+import TabularDataWidget from './widgets/TabularDataWidget/TabularDataWidget.svelte';
+import ReinforcementLearningWidget from './widgets/ReinforcementLearningWidget/ReinforcementLearningWidget.svelte';
+import ZeroShotClassificationWidget from './widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte';
+import ZeroShotImageClassificationWidget from './widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte';
 
-	export let apiToken: WidgetProps["apiToken"] = undefined;
-	export let callApiOnMount = false;
-	export let apiUrl = "https://api-inference.huggingface.co";
-	export let model: WidgetProps["model"];
-	export let noTitle = false;
-	export let shouldUpdateUrl = false;
-	export let includeCredentials = false;
-	export let isLoggedIn = false;
+export let apiToken: WidgetProps['apiToken'] = undefined;
+export let appendRepoPath: WidgetProps['appendRepoPath'] = true;
+export let callApiOnMount = false;
+export let apiUrl = 'https://api-inference.huggingface.co';
+export let model: WidgetProps['model'];
+export let noModelLoading: WidgetProps['noModelLoading'] = false;
+export let noTitle = false;
+export let shouldUpdateUrl = false;
+export let includeCredentials = false;
+export let isLoggedIn = false;
 
-	// Note: text2text-generation, text-generation and translation all
-	// uses the TextGenerationWidget as they work almost the same.
-	// Same goes for fill-mask and text-classification.
-	// In the future it may be useful / easier to maintain if we created
-	// a single dedicated widget for each pipeline type.
-	const WIDGET_COMPONENTS: {
-		[key in PipelineType]?: typeof SvelteComponent;
-	} = {
-		"audio-to-audio": AudioToAudioWidget,
-		"audio-classification": AudioClassificationWidget,
-		"automatic-speech-recognition": AutomaticSpeechRecognitionWidget,
-		conversational: ConversationalWidget,
-		"feature-extraction": FeatureExtractionWidget,
-		"fill-mask": FillMaskWidget,
-		"image-classification": ImageClassificationWidget,
-		"image-to-image": ImageToImageWidget,
-		"image-to-text": ImageToTextWidget,
-		"image-segmentation": ImageSegmentationWidget,
-		"object-detection": ObjectDetectionWidget,
-		"question-answering": QuestionAnsweringWidget,
-		"sentence-similarity": SentenceSimilarityWidget,
-		summarization: SummarizationWidget,
-		"table-question-answering": TableQuestionAnsweringWidget,
-		"text2text-generation": TextGenerationWidget,
-		"text-classification": FillMaskWidget,
-		"text-generation": TextGenerationWidget,
-		"token-classification": TokenClassificationWidget,
-		"text-to-image": TextToImageWidget,
-		"text-to-speech": TextToSpeechWidget,
-		translation: TextGenerationWidget,
-		"tabular-classification": TabularDataWidget,
-		"tabular-regression": TabularDataWidget,
-		"visual-question-answering": VisualQuestionAnsweringWidget,
-		"reinforcement-learning": ReinforcementLearningWidget,
-		"zero-shot-classification": ZeroShotClassificationWidget,
-		"document-question-answering": VisualQuestionAnsweringWidget,
-		"zero-shot-image-classification": ZeroShotImageClassificationWidget,
-	};
+// Note: text2text-generation, text-generation and translation all
+// uses the TextGenerationWidget as they work almost the same.
+// Same goes for fill-mask and text-classification.
+// In the future it may be useful / easier to maintain if we created
+// a single dedicated widget for each pipeline type.
+const WIDGET_COMPONENTS: {
+	[key in PipelineType]?: typeof SvelteComponent;
+} = {
+	'audio-to-audio': AudioToAudioWidget,
+	'audio-classification': AudioClassificationWidget,
+	'automatic-speech-recognition': AutomaticSpeechRecognitionWidget,
+	'conversational': ConversationalWidget,
+	'feature-extraction': FeatureExtractionWidget,
+	'fill-mask': FillMaskWidget,
+	'image-classification': ImageClassificationWidget,
+	'image-to-image': ImageToImageWidget,
+	'image-to-text': ImageToTextWidget,
+	'image-segmentation': ImageSegmentationWidget,
+	'object-detection': ObjectDetectionWidget,
+	'question-answering': QuestionAnsweringWidget,
+	'sentence-similarity': SentenceSimilarityWidget,
+	'summarization': SummarizationWidget,
+	'table-question-answering': TableQuestionAnsweringWidget,
+	'text2text-generation': TextGenerationWidget,
+	'text-classification': FillMaskWidget,
+	'text-generation': TextGenerationWidget,
+	'token-classification': TokenClassificationWidget,
+	'text-to-image': TextToImageWidget,
+	'text-to-speech': TextToSpeechWidget,
+	'translation': TextGenerationWidget,
+	'tabular-classification': TabularDataWidget,
+	'tabular-regression': TabularDataWidget,
+	'visual-question-answering': VisualQuestionAnsweringWidget,
+	'reinforcement-learning': ReinforcementLearningWidget,
+	'zero-shot-classification': ZeroShotClassificationWidget,
+	'document-question-answering': VisualQuestionAnsweringWidget,
+	'zero-shot-image-classification': ZeroShotImageClassificationWidget,
+};
 
-	$: widgetComponent = WIDGET_COMPONENTS[model.pipeline_tag ?? ""];
+$: widgetComponent = WIDGET_COMPONENTS[model.pipeline_tag as PipelineType];
 
-	// prettier-ignore
-	$: widgetProps = ({
+// prettier-ignore
+$: widgetProps = ({
 		apiToken,
 		apiUrl,
+		appendRepoPath,
 		callApiOnMount,
 		model,
+		noModelLoading,
 		noTitle,
 		shouldUpdateUrl,
 		includeCredentials,
@@ -92,8 +96,5 @@
 </script>
 
 {#if widgetComponent}
-	<svelte:component
-		this={WIDGET_COMPONENTS[model.pipeline_tag ?? ""]}
-		{...widgetProps}
-	/>
+	<svelte:component this={widgetComponent} {...widgetProps} />
 {/if}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetDropzone/WidgetDropzone.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetDropzone/WidgetDropzone.svelte
@@ -77,7 +77,7 @@
 	{#if !imgSrc}
 		<span class="pointer-events-none text-sm">{label}</span>
 	{:else}
-		<div class={isDragging && "pointer-events-none"}>
+		<div class={isDragging ? "pointer-events-none" : ""}>
 			<slot />
 		</div>
 	{/if}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetHeader/WidgetHeader.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetHeader/WidgetHeader.svelte
@@ -37,7 +37,7 @@
 	{#if pipeline}
 		<a
 			class={TASKS_DATA[task] ? "hover:underline" : undefined}
-			href={TASKS_DATA[task] ? `/tasks/${task}` : undefined}
+			href={TASKS_DATA[task] ? `https://huggingface.co/tasks/${task}` : undefined}
 			target="_blank"
 			title={TASKS_DATA[task] ? `Learn more about ${task}` : undefined}
 		>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetInfo/WidgetInfo.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetInfo/WidgetInfo.svelte
@@ -1,74 +1,74 @@
 <script lang="ts">
-	import type { WidgetProps, ModelLoadInfo, LoadingStatus } from "../types";
+import type { WidgetProps, ModelLoadInfo, LoadingStatus } from '../types';
 
-	import IconAzureML from "../../../Icons/IconAzureML.svelte";
+import IconAzureML from '../../../Icons/IconAzureML.svelte';
 
-	export let model: WidgetProps["model"];
-	export let computeTime: string;
-	export let error: string;
-	export let modelLoadInfo: ModelLoadInfo = { status: "unknown" };
+export let model: WidgetProps['model'];
+export let computeTime: string;
+export let error: string;
+export let modelLoadInfo: ModelLoadInfo = { status: 'unknown' };
 
-	const status = {
-		error: "⚠️ This model could not be loaded by the inference API. ⚠️",
-		loaded: "This model is currently loaded and running on the Inference API.",
-		unknown: "This model can be loaded on the Inference API on-demand.",
-	} as const;
+const status = {
+	ignored: '',
+	error: '⚠️ This model could not be loaded by the inference API. ⚠️',
+	loaded: 'This model is currently loaded and running on the Inference API.',
+	unknown: 'This model can be loaded on the Inference API on-demand.',
+} as const;
 
-	const azureStatus = {
-		error: "⚠️ This model could not be loaded.",
-		loaded: "This model is loaded and running on AzureML Managed Endpoint",
-		unknown: "This model can be loaded loaded on AzureML Managed Endpoint",
-	} as const;
+const azureStatus = {
+	ignored: '',
+	error: '⚠️ This model could not be loaded.',
+	loaded: 'This model is loaded and running on AzureML Managed Endpoint',
+	unknown: 'This model can be loaded loaded on AzureML Managed Endpoint',
+} as const;
 
-	function getStatusReport(
-		modelLoadInfo: ModelLoadInfo,
-		statuses: Record<LoadingStatus, string>,
-		isAzure = false
-	): string {
-		if (
-			modelLoadInfo.compute_type === "cpu" &&
-			modelLoadInfo.status === "loaded" &&
-			!isAzure
-		) {
-			return `The model is loaded and running on <a class="hover:underline" href="https://huggingface.co/intel" target="_blank">Intel Xeon 3rd Gen Scalable CPU</a>`;
-		}
-		return statuses[modelLoadInfo.status];
+function getStatusReport(
+	modelLoadInfo: ModelLoadInfo,
+	statuses: Record<LoadingStatus, string>,
+	isAzure = false
+): string {
+	if (modelLoadInfo.status === 'ignored') {
+		return '';
+	} else if (modelLoadInfo.compute_type === 'cpu' && modelLoadInfo.status === 'loaded' && !isAzure) {
+		return `The model is loaded and running on <a class="hover:underline" href="https://huggingface.co/intel" target="_blank">Intel Xeon 3rd Gen Scalable CPU</a>`;
 	}
+	return statuses[modelLoadInfo.status];
+}
 
-	function getComputeTypeMsg(): string {
-		let compute_type = modelLoadInfo?.compute_type ?? "cpu";
-		if (compute_type === "cpu") {
-			return "Intel Xeon 3rd Gen Scalable cpu";
-		}
-		return compute_type;
+function getComputeTypeMsg(): string {
+	let compute_type = modelLoadInfo?.compute_type ?? 'cpu';
+	if (compute_type === 'cpu') {
+		return 'Intel Xeon 3rd Gen Scalable cpu';
 	}
+	return compute_type;
+}
 </script>
 
 <div class="mt-2">
-	<div class="text-gray-400 text-xs">
-		{#if model.id === "bigscience/bloom"}
-			<div class="flex items-baseline">
-				<div class="flex items-center whitespace-nowrap text-gray-700">
-					<IconAzureML classNames="mr-1 flex-none" /> Powered by&nbsp;
-					<a
-						class="underline hover:text-gray-800"
-						href="https://azure.microsoft.com/products/machine-learning"
-						target="_blank">AzureML</a
-					>
+	{#if modelLoadInfo.status !== 'ignored'}
+		<div class="text-gray-400 text-xs">
+			{#if model.id === 'bigscience/bloom'}
+				<div class="flex items-baseline">
+					<div class="flex items-center whitespace-nowrap text-gray-700">
+						<IconAzureML classNames="mr-1 flex-none" /> Powered by&nbsp;
+						<a
+							class="underline hover:text-gray-800"
+							href="https://azure.microsoft.com/products/machine-learning"
+							target="_blank">AzureML</a
+						>
+					</div>
+					<div class="flex border-dotter border-b border-gray-100 flex-1 mx-2 -translate-y-px" />
+					<div>
+						{@html getStatusReport(modelLoadInfo, azureStatus, true)}
+					</div>
 				</div>
-				<div
-					class="flex border-dotter border-b border-gray-100 flex-1 mx-2 -translate-y-px"
-				/>
-				<div>
-					{@html getStatusReport(modelLoadInfo, azureStatus, true)}
-				</div>
-			</div>
-		{:else if computeTime}
-			Computation time on {getComputeTypeMsg()}: {computeTime}
-		{:else}
-			{@html getStatusReport(modelLoadInfo, status)}
-		{/if}
-	</div>
+			{:else if computeTime}
+				Computation time on {getComputeTypeMsg()}: {computeTime}
+			{:else}
+				{@html getStatusReport(modelLoadInfo, status)}
+			{/if}
+		</div>
+	{/if}
 	{#if error}
 		<div class="alert alert-error mt-3">{error}</div>
 	{/if}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -3,6 +3,7 @@
 	import { delay } from "../../../../utils/ViewUtils";
 	import WidgetLabel from "../WidgetLabel/WidgetLabel.svelte";
 
+	export let classNames = "";
 	export let label: string = "";
 	export let placeholder: string = "Your sentence here...";
 	export let value: string;
@@ -80,7 +81,7 @@
 	<svelte:fragment slot="after">
 		<!-- `whitespace-pre-wrap inline-block` are needed to get correct newlines from `el.textContent` on Chrome -->
 		<span
-			class="{isLoading ? 'pointer-events-none' : ''} {label
+			class="{isLoading ? 'pointer-events-none' : ''} {classNames} {label
 				? 'mt-1.5'
 				: ''} block overflow-auto resize-y py-2 px-3 w-full {size === 'small'
 				? 'min-h-[42px]'

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -1,77 +1,69 @@
 <script lang="ts">
-	import type { WidgetProps, ModelLoadInfo } from "../types";
-	import type { WidgetInputSample } from "../../../../interfaces/Types";
+import type { WidgetProps, ModelLoadInfo } from '../types';
+import type { WidgetInputSample } from '../../../../interfaces/Types';
 
-	import { onMount } from "svelte";
-	import IconCross from "../../../Icons/IconCross.svelte";
-	import WidgetInputSamples from "../WidgetInputSamples/WidgetInputSamples.svelte";
-	import WidgetInputSamplesGroup from "../WidgetInputSamplesGroup/WidgetInputSamplesGroup.svelte";
-	import WidgetFooter from "../WidgetFooter/WidgetFooter.svelte";
-	import WidgetHeader from "../WidgetHeader/WidgetHeader.svelte";
-	import WidgetInfo from "../WidgetInfo/WidgetInfo.svelte";
-	import WidgetModelLoading from "../WidgetModelLoading/WidgetModelLoading.svelte";
-	import { getModelLoadInfo } from "../../shared/helpers";
+import { onMount } from 'svelte';
+import IconCross from '../../../Icons/IconCross.svelte';
+import WidgetInputSamples from '../WidgetInputSamples/WidgetInputSamples.svelte';
+import WidgetInputSamplesGroup from '../WidgetInputSamplesGroup/WidgetInputSamplesGroup.svelte';
+import WidgetFooter from '../WidgetFooter/WidgetFooter.svelte';
+import WidgetHeader from '../WidgetHeader/WidgetHeader.svelte';
+import WidgetInfo from '../WidgetInfo/WidgetInfo.svelte';
+import WidgetModelLoading from '../WidgetModelLoading/WidgetModelLoading.svelte';
+import { getModelLoadInfo } from '../../shared/helpers';
 
-	export let apiUrl: string;
-	export let computeTime: string;
-	export let error: string;
-	export let isLoading = false;
-	export let model: WidgetProps["model"];
-	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let modelLoading = {
-		isLoading: false,
-		estimatedTime: 0,
-	};
-	export let noTitle = false;
-	export let outputJson: string;
-	export let applyInputSample: (sample: Record<string, any>) => void =
-		({}) => {};
-	export let previewInputSample: (sample: Record<string, any>) => void =
-		({}) => {};
+export let apiUrl: string;
+export let computeTime: string;
+export let error: string;
+export let isLoading = false;
+export let model: WidgetProps['model'];
+export let modelLoading: {
+	isLoading: boolean;
+	estimatedTime: number;
+};
+export let noModelLoading = false;
+export let noTitle = false;
+export let outputJson: string;
+export let applyInputSample: (sample: Record<string, any>) => void = ({}) => {};
+export let previewInputSample: (sample: Record<string, any>) => void = ({}) => {};
 
-	let isMaximized = false;
-	let modelLoadInfo: ModelLoadInfo = { status: "unknown" };
-	let selectedInputGroup: string;
+let isMaximized = false;
+let modelLoadInfo: ModelLoadInfo = { status: true ? 'ignored' : 'unknown' };
+let selectedInputGroup: string;
 
-	const inputSamples: WidgetInputSample[] = (model?.widgetData ?? [])
-		.sort(
-			(sample1, sample2) =>
-				(sample2.example_title ? 1 : 0) - (sample1.example_title ? 1 : 0)
-		)
-		.map((sample, idx) => ({
-			example_title: `Example ${++idx}`,
-			group: "Group 1",
-			...sample,
-		}));
+const inputSamples: WidgetInputSample[] = (model?.widgetData ?? [])
+	.sort((sample1, sample2) => (sample2.example_title ? 1 : 0) - (sample1.example_title ? 1 : 0))
+	.map((sample, idx) => ({
+		example_title: `Example ${++idx}`,
+		group: 'Group 1',
+		...sample,
+	}));
 
-	const inputGroups: { group: string; inputSamples: WidgetInputSample[] }[] =
-		[];
-	for (const inputSample of inputSamples) {
-		const isExist = inputGroups.find(
-			({ group }) => group === inputSample.group
-		);
-		if (!isExist) {
-			inputGroups.push({ group: inputSample.group, inputSamples: [] });
-		}
-		inputGroups
-			.find(({ group }) => group === inputSample.group)
-			?.inputSamples.push(inputSample);
+const inputGroups: { group: string; inputSamples: WidgetInputSample[] }[] = [];
+for (const inputSample of inputSamples) {
+	const isExist = inputGroups.find(({ group }) => group === inputSample.group);
+	if (!isExist) {
+		inputGroups.push({ group: inputSample.group, inputSamples: [] });
 	}
+	inputGroups.find(({ group }) => group === inputSample.group)?.inputSamples.push(inputSample);
+}
 
-	$: selectedInputSamples =
-		inputGroups.length === 1
-			? inputGroups[0]
-			: inputGroups.find(({ group }) => group === selectedInputGroup);
+$: selectedInputSamples =
+	inputGroups.length === 1 ? inputGroups[0] : inputGroups.find(({ group }) => group === selectedInputGroup);
 
-	onMount(() => {
-		getModelLoadInfo(apiUrl, model.id, includeCredentials).then((info) => {
-			modelLoadInfo = info;
-		});
+onMount(() => {
+	if (noModelLoading) {
+		modelLoadInfo = { status: 'ignored' };
+		return;
+	}
+	getModelLoadInfo(apiUrl, model.id).then((info) => {
+		modelLoadInfo = info;
 	});
+});
 
-	function onClickMaximizeBtn() {
-		isMaximized = !isMaximized;
-	}
+function onClickMaximizeBtn() {
+	isMaximized = !isMaximized;
+}
 </script>
 
 <div
@@ -95,9 +87,7 @@
 					/>
 				{/if}
 				<WidgetInputSamples
-					classNames={!selectedInputSamples
-						? "opacity-50 pointer-events-none"
-						: ""}
+					classNames={!selectedInputSamples ? 'opacity-50 pointer-events-none' : ''}
 					{isLoading}
 					inputSamples={selectedInputSamples?.inputSamples ?? []}
 					{applyInputSample}

--- a/js/src/lib/components/InferenceWidget/shared/types.ts
+++ b/js/src/lib/components/InferenceWidget/shared/types.ts
@@ -3,8 +3,10 @@ import type { ModelData } from '../../../interfaces/Types';
 export interface WidgetProps {
 	apiToken?: string;
 	apiUrl: string;
+	appendRepoPath?: boolean;
 	callApiOnMount: boolean;
 	model: ModelData;
+	noModelLoading?: boolean;
 	noTitle: boolean;
 	shouldUpdateUrl: boolean;
 	includeCredentials: boolean;
@@ -12,7 +14,7 @@ export interface WidgetProps {
 }
 
 
-export type LoadingStatus = "error" | "loaded" | "unknown";
+export type LoadingStatus = "error" | "loaded" | "unknown" | "ignored";
 
 export type ComputeType = "cpu" | "gpu";
 

--- a/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
@@ -16,8 +16,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
 
@@ -91,7 +93,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -167,13 +171,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -15,8 +15,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
 
@@ -92,7 +94,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 		isLoading = false;
 		// Reset values
@@ -168,13 +172,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -17,8 +17,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
 
@@ -93,7 +95,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -162,13 +166,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
@@ -15,8 +15,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -100,7 +102,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -171,13 +175,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
@@ -15,8 +15,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -76,7 +78,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -139,13 +143,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
@@ -16,8 +16,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -78,7 +80,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -109,7 +113,7 @@
 			// entries = body -> text-classificartion
 			// entries = body[0] -> summarization
 			const entries = (
-				model.pipeline_tag === "text-classification" ? body[0] ?? [] : body
+				body?.[0] && Array.isArray(body[0]) ? body[0] : body
 			) as Record<string, unknown>[];
 			return entries
 				.filter((x) => !!x)
@@ -134,13 +138,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -15,8 +15,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
 
@@ -64,7 +66,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -132,13 +136,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
@@ -19,8 +19,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
 
@@ -79,7 +81,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -252,13 +256,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToImageWidget/ImageToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToImageWidget/ImageToImageWidget.svelte
@@ -16,8 +16,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
 
@@ -112,7 +114,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -155,13 +159,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
@@ -15,8 +15,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
 
@@ -64,7 +66,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -124,13 +128,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
@@ -19,8 +19,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
 
@@ -69,7 +71,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -158,13 +162,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
@@ -15,8 +15,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -96,7 +98,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -150,13 +154,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
@@ -15,8 +15,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
 
@@ -86,7 +88,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -156,13 +160,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
@@ -16,8 +16,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -78,7 +80,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -125,13 +129,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
@@ -29,8 +29,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -115,7 +117,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -180,13 +184,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/TabularDataWidget/TabularDataWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TabularDataWidget/TabularDataWidget.svelte
@@ -22,8 +22,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -134,7 +136,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -207,13 +211,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -20,8 +20,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -120,7 +122,8 @@
 			withModelLoading,
 			includeCredentials,
 			isOnLoadCall,
-			useCache
+			useCache,
+			appendRepoPath,
 		);
 
 		// Reset values
@@ -138,7 +141,7 @@
 			if (output.length === 0) {
 				warning = "No text was generated";
 			} else if (model?.pipeline_tag === "text-generation") {
-				const outputWithoutInput = output.slice(text.length);
+				const outputWithoutInput = noModelLoading ? output : output.slice(text.length);
 				inferenceTimer.stop();
 				if (outputWithoutInput.length === 0) {
 					warning = "No text was generated";
@@ -162,7 +165,7 @@
 
 	function parseOutput(body: unknown): string {
 		if (Array.isArray(body) && body.length) {
-			const firstEntry = body[0];
+			const firstEntry = body[0] ?? {};
 			return (
 				firstEntry["generated_text"] ?? // text-generation + text2text-generation
 				firstEntry["translation_text"] ?? // translation
@@ -198,13 +201,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
@@ -14,8 +14,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -76,7 +78,8 @@
 			withModelLoading,
 			includeCredentials,
 			isOnLoadCall,
-			useCache
+			useCache,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -123,13 +126,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
@@ -16,8 +16,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -77,7 +79,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -124,13 +128,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
@@ -31,8 +31,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -95,7 +97,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -253,13 +257,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -16,8 +16,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
 
@@ -127,7 +129,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -170,13 +174,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
@@ -17,8 +17,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
 
@@ -46,7 +48,7 @@
 			fileReader.onload = async () => {
 				try {
 					const imageBase64WithPrefix: string = fileReader.result as string;
-					imageBase64 = imageBase64WithPrefix.split(",")[1]; // remove prefix
+					imageBase64 = imageBase64WithPrefix.split(",")[1] ?? ""; // remove prefix
 					isLoading = false;
 					resolve();
 				} catch (err) {
@@ -129,7 +131,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -175,13 +179,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
@@ -18,8 +18,10 @@
 
 	export let apiToken: WidgetProps["apiToken"];
 	export let apiUrl: WidgetProps["apiUrl"];
+	export let appendRepoPath: WidgetProps["appendRepoPath"];
 	export let callApiOnMount: WidgetProps["callApiOnMount"];
 	export let model: WidgetProps["model"];
+	export let noModelLoading: WidgetProps["noModelLoading"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
@@ -112,7 +114,9 @@
 			parseOutput,
 			withModelLoading,
 			includeCredentials,
-			isOnLoadCall
+			isOnLoadCall,
+			true,
+			appendRepoPath,
 		);
 
 		isLoading = false;
@@ -177,13 +181,13 @@
 
 <WidgetWrapper
 	{apiUrl}
-	{includeCredentials}
 	{applyInputSample}
 	{computeTime}
 	{error}
 	{isLoading}
 	{model}
 	{modelLoading}
+	{noModelLoading}
 	{noTitle}
 	{outputJson}
 	{previewInputSample}

--- a/js/src/lib/components/PipelineIcon/PipelineIcon.svelte
+++ b/js/src/lib/components/PipelineIcon/PipelineIcon.svelte
@@ -80,9 +80,11 @@
 		"text-to-video": IconTextToVideo,
 		"document-question-answering": IconDocumentQuestionAnswering,
 	};
+
+	$: component = pipeline in ICON_COMPONENTS ? ICON_COMPONENTS[<PipelineType>pipeline] : IconFillMask;
 </script>
 
 <svelte:component
-	this={ICON_COMPONENTS[pipeline] ?? IconFillMask}
+	this={component ?? IconFillMask}
 	{classNames}
 />

--- a/js/src/lib/components/PipelineTag/PipelineTag.svelte
+++ b/js/src/lib/components/PipelineTag/PipelineTag.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
-	import { PIPELINE_DATA } from "../../interfaces/Types";
-	import PipelineIcon from "../PipelineIcon/PipelineIcon.svelte";
+import { PIPELINE_DATA, type PipelineType } from '../../interfaces/Types';
+import PipelineIcon from '../PipelineIcon/PipelineIcon.svelte';
 
-	export let classNames = "";
-	export let pipeline = "";
+export let classNames = '';
+export let pipeline = '';
+
+$: pipelineName = pipeline ? PIPELINE_DATA[<PipelineType>pipeline]?.name ?? pipeline : pipeline;
 </script>
 
 <div class="inline-flex items-center {classNames}">
 	<PipelineIcon classNames="mr-1" {pipeline} />
 	<span>
-		{PIPELINE_DATA[pipeline].name ?? pipeline}
+		{pipelineName}
 	</span>
 </div>

--- a/js/src/lib/inferenceSnippets/inputs.ts
+++ b/js/src/lib/inferenceSnippets/inputs.ts
@@ -125,7 +125,7 @@ export function getModelInputSnippet(model: ModelData, noWrap = false, noQuotes 
 			if (noQuotes) {
 				const REGEX_QUOTES = /^"(.+)"$/s;
 				const match = result.match(REGEX_QUOTES);
-				result = match ? match[1] : result;
+				result = match?.[1] ? match[1] : result;
 			}
 			return result;
 		}

--- a/js/src/lib/interfaces/Libraries.ts
+++ b/js/src/lib/interfaces/Libraries.ts
@@ -73,7 +73,7 @@ export interface LibraryUiElement {
 
 function nameWithoutNamespace(modelId: string): string {
 	const splitted = modelId.split("/");
-	return splitted.length === 1 ? splitted[0] : splitted[1];
+	return splitted[1] ?? splitted[0] ?? "";
 }
 
 //#region snippets

--- a/js/src/lib/utils/ViewUtils.ts
+++ b/js/src/lib/utils/ViewUtils.ts
@@ -19,7 +19,7 @@ const ESCAPED = {
  * HTML escapes the passed string
  */
 export function escape(html: unknown): string {
-	return String(html).replace(/["'&<>]/g, match => ESCAPED[match]);
+	return String(html).replace(/["'&<>]/g, match => ESCAPED[match as keyof typeof ESCAPED]);
 }
 
 /**
@@ -49,7 +49,7 @@ export function sum(arr: number[]): number {
 /**
  * Return a random item from an array
  */
-export function randomItem<T>(arr: T[]): T {
+export function randomItem<T>(arr: T[]): T | undefined {
 	return arr[Math.floor(Math.random() * arr.length)];
 }
 
@@ -65,7 +65,7 @@ export function parseJSON<T>(x: unknown): T | undefined {
 	} catch (e) {
 		if (e instanceof SyntaxError) {
 			console.error(e.name);
-		} else {
+		} else if (e instanceof Error) {
 			console.error(e.message);
 		}
 		return undefined;


### PR DESCRIPTION
This PR contains modifications made so that `hf-endpoints` can import `hub-docs` as a Git submodule and use its components, utils and types (instead of having a local custom copy). This way the project can get every update pushed to `hub-docs` and we won't have to manually maintain dozens of files manually anymore. 

The main changes are:
- adding a `noModelLoading` props to Widgets. If set to false, it deactivates the API status check (which is not handled in this context of Endpoints).
- adding an `appendRepoPath` props to Widgets. If set to false, it prevents the fetching function from appending `/models/${repoId}` to the API url.
- fix some typing issues (typing is stricter on the Endpoints side)

This changes shouldn't affect moon-landing in any way, However, they probably are going to conflict with https://github.com/huggingface/hub-docs/pull/895 :'( 