### PR TITLE
Fix sort param in models link

### DIFF
--- a/docs/hub/adapter-transformers.md
+++ b/docs/hub/adapter-transformers.md
@@ -4,7 +4,7 @@
 
 ## Exploring adapter-transformers in the Hub
 
-You can find over a hundred `adapter-transformer` models by filtering at the left of the [models page](https://huggingface.co/models?library=adapter-transformers&sort=download). Some adapter models can be found in the Adapter Hub [repository](https://github.com/adapter-hub/hub). Models from both sources are then aggregated in the [AdapterHub](https://adapterhub.ml/explore/).
+You can find over a hundred `adapter-transformer` models by filtering at the left of the [models page](https://huggingface.co/models?library=adapter-transformers&sort=downloads). Some adapter models can be found in the Adapter Hub [repository](https://github.com/adapter-hub/hub). Models from both sources are then aggregated in the [AdapterHub](https://adapterhub.ml/explore/).
 
 
 ## Using existing models


### PR DESCRIPTION
Fix sort param in models link

*models* link results in 400 error "Invalid sort parameter". This is due to `sort=download` vs `sort=downloads`.

* Change to correct sort param in models link