### PR TITLE
Fix broken hashlink spaces-overview.md

### DIFF
--- a/docs/hub/spaces-overview.md
+++ b/docs/hub/spaces-overview.md
@@ -54,7 +54,7 @@ Read more in our dedicated sections on [Spaces GPU Upgrades](./spaces-gpus) and 
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-gpu-settings-dark.png"/>
 </div>
 
-## Managing secrets and environment variables 
+## Managing secrets and environment variables[[managing-secrets]]
 <a id="managing-secrets"></a>
 If your app requires environment variables (for instance, secret keys or tokens), do not hard-code them inside your app! Instead, go to the **Settings** page of your Space repository and add a new variable or secret. Use variables if you need to store non-sensitive configuration values and secrets for storing access tokens, API keys, or any sensitive value or credentials.
 


### PR DESCRIPTION
Since the md heading was changed, the previous hashlink is broken.
Using the special doc-builder syntax to customize the hashlink