### PR TITLE
Add `Content-Type: application/json` in curl examples

### DIFF
--- a/js/src/lib/inferenceSnippets/serveCurl.ts
+++ b/js/src/lib/inferenceSnippets/serveCurl.ts
@@ -5,16 +5,16 @@ export const snippetBasic = (model: ModelData, accessToken: string): string =>
 	`curl https://api-inference.huggingface.co/models/${model.id} \\
 	-X POST \\
 	-d '{"inputs": ${getModelInputSnippet(model, true)}}' \\
+	-H 'Content-Type: application/json'
 	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}
-	-H 'Content-Type: application/json'"
 `;
 
 export const snippetZeroShotClassification = (model: ModelData, accessToken: string): string =>
 	`curl https://api-inference.huggingface.co/models/${model.id} \\
 	-X POST \\
 	-d '{"inputs": ${getModelInputSnippet(model, true)}, "parameters": {"candidate_labels": ["refund", "legal", "faq"]}}' \\
+	-H 'Content-Type: application/json'
 	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}
-	-H 'Content-Type: application/json'"
 `;
 
 export const snippetFile = (model: ModelData, accessToken: string): string =>

--- a/js/src/lib/inferenceSnippets/serveCurl.ts
+++ b/js/src/lib/inferenceSnippets/serveCurl.ts
@@ -5,14 +5,16 @@ export const snippetBasic = (model: ModelData, accessToken: string): string =>
 	`curl https://api-inference.huggingface.co/models/${model.id} \\
 	-X POST \\
 	-d '{"inputs": ${getModelInputSnippet(model, true)}}' \\
-	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"
+	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}
+	-H 'Content-Type: application/json'"
 `;
 
 export const snippetZeroShotClassification = (model: ModelData, accessToken: string): string =>
 	`curl https://api-inference.huggingface.co/models/${model.id} \\
 	-X POST \\
 	-d '{"inputs": ${getModelInputSnippet(model, true)}, "parameters": {"candidate_labels": ["refund", "legal", "faq"]}}' \\
-	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"
+	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}
+	-H 'Content-Type: application/json'"
 `;
 
 export const snippetFile = (model: ModelData, accessToken: string): string =>

--- a/js/src/lib/inferenceSnippets/serveCurl.ts
+++ b/js/src/lib/inferenceSnippets/serveCurl.ts
@@ -6,7 +6,7 @@ export const snippetBasic = (model: ModelData, accessToken: string): string =>
 	-X POST \\
 	-d '{"inputs": ${getModelInputSnippet(model, true)}}' \\
 	-H 'Content-Type: application/json'
-	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}
+	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"
 `;
 
 export const snippetZeroShotClassification = (model: ModelData, accessToken: string): string =>
@@ -14,7 +14,7 @@ export const snippetZeroShotClassification = (model: ModelData, accessToken: str
 	-X POST \\
 	-d '{"inputs": ${getModelInputSnippet(model, true)}, "parameters": {"candidate_labels": ["refund", "legal", "faq"]}}' \\
 	-H 'Content-Type: application/json'
-	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}
+	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"
 `;
 
 export const snippetFile = (model: ModelData, accessToken: string): string =>


### PR DESCRIPTION
Related to [slack thread](https://huggingface.slack.com/archives/C016D661PAN/p1694595733748539) (internal) cc @osanseviero @Narsil @julien-c 

Models served on Inference API with TGI (e.g meta-llama/Llama-2-70B-chat-hf) requires `'Content-Type: application/json'` to be set as header otherwise the server throws an error (_Expected request with Content-Type: application/json_). Let's add it to the cURL snippets to be consistent even if models served with `transformers` don't need it.

Another possibility would be to [disable the check on TGI side](https://huggingface.slack.com/archives/C016D661PAN/p1694596312771789?thread_ts=1694595733.748539&cid=C016D661PAN).

**EDIT:** it's also possible to add the header only to the text-generation snippets. Seems a bit inconsistent to me but I can update the PR if needed.

