### PR TITLE
[Model State] Use stores to share info between components

### DIFF
--- a/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
@@ -1,3 +1,10 @@
+<script context="module" lang="ts">
+	import type { ModelLoadInfo } from "./shared/types";
+	import { writable } from "svelte/store";
+
+	export const modelLoadStates = writable<Record<string, ModelLoadInfo>>({});
+</script>
+
 <script lang="ts">
 	import type { SvelteComponent } from "svelte";
 	import type { PipelineType } from "../../interfaces/Types";

--- a/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
@@ -1,5 +1,6 @@
 <script context="module" lang="ts">
 	import type { ModelLoadInfo } from "./shared/types";
+
 	import { writable } from "svelte/store";
 
 	export const modelLoadStates = writable<Record<string, ModelLoadInfo>>({});

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -12,6 +12,7 @@
 	import WidgetInfo from "../WidgetInfo/WidgetInfo.svelte";
 	import WidgetModelLoading from "../WidgetModelLoading/WidgetModelLoading.svelte";
 	import { getModelLoadInfo } from "../../shared/helpers";
+	import { modelLoadStates } from "../../InferenceWidget.svelte";
 
 	export let apiUrl: string;
 	export let computeTime: string;
@@ -55,6 +56,7 @@
 	onMount(() => {
 		(async () => {
 			modelLoadInfo = await getModelLoadInfo(apiUrl, model.id, includeCredentials);
+			$modelLoadStates[model.id] = modelLoadInfo;
 		})();
 	});
 


### PR DESCRIPTION
follow up to https://github.com/huggingface/hub-docs/pull/935

Use [svelte-store](https://svelte.dev/docs/svelte-store) to share the model load data between different components that need same data without sending multiple fetch requests to api-inference/status