### PR TITLE
Suggestion to revampt API endpoint table (`hub-docs/api.md`)

### DIFF
--- a/docs/hub/api.md
+++ b/docs/hub/api.md
@@ -33,7 +33,7 @@ params = {
 
 This is equivalent to `huggingface_hub.list_models()`.
 
-## GET /api/models/{repo_id} or /api/models/{repo_id}/revision/{revision}
+## GET /api/models/(repo_id) or /api/models/(repo_id)/revision/(revision)
 
 Get all information for a specific model.
 
@@ -73,7 +73,7 @@ params = {
 
 This is equivalent to `huggingface_hub.list_datasets()`.
 
-## GET /api/datasets/{repo_id} or /api/datasets/{repo_id}/revision/{revision}
+## GET /api/datasets/(repo_id) or /api/datasets/(repo_id)/revision/(revision)
 
 Get all information for a specific dataset.
 
@@ -87,11 +87,11 @@ params = {"full": "full"}
 
 This is equivalent to `huggingface_hub.dataset_info(repo_id, revision)`.
 
-## GET /api/datasets/{repo_id}/parquet
+## GET /api/datasets/(repo_id)/parquet
 
 Get the list of auto-converted parquet files.
 
-## GET /api/datasets/{repo_id}/parquet/{config}/{split}/{n}.parquet
+## GET /api/datasets/(repo_id)/parquet/(config)/(split)/(n).parquet
 
 Get the nth shard of the auto-converted parquet files.
 
@@ -130,7 +130,7 @@ params = {
 
 This is equivalent to `huggingface_hub.list_spaces()`.
 
-## GET /api/spaces/{repo_id} or /api/spaces/{repo_id}/revision/{revision}
+## GET /api/spaces/(repo_id) or /api/spaces/(repo_id)/revision/(revision)
 Get all information for a specific model.
 
 This is equivalent to `huggingface_hub.space_info(repo_id, revision)`.
@@ -185,7 +185,7 @@ payload = {
 
 This is equivalent to `huggingface_hub.delete_repo()`.
 
-## PUT /api/repos/{type}/{repo_id}/settings
+## PUT /api/repos/(type)/(repo_id)/settings
 
 Update repo visibility.
 

--- a/docs/hub/api.md
+++ b/docs/hub/api.md
@@ -4,7 +4,7 @@ We have open endpoints that you can use to retrieve information from the Hub as 
 
 The base URL for those endpoints below is `https://huggingface.co`. For example, to construct the `/api/models` call below, one can call the URL [https://huggingface.co/api/models](https://huggingface.co/api/models)
 
-## GET `/api/models`
+## GET /api/models
 
 Get information from all models in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the following pages. You can specify additional parameters to have more specific results.
 - `search`: Filter based on substrings for repos and their usernames, such as `resnet` or `microsoft`
@@ -33,19 +33,19 @@ params = {
 
 This is equivalent to `huggingface_hub.list_models()`.
 
-## GET `/api/models/{repo_id}` or `/api/models/{repo_id}/revision/{revision}`
+## GET /api/models/{repo_id} or /api/models/{repo_id}/revision/{revision}
 
 Get all information for a specific model.
 
 This is equivalent to `huggingface_hub.model_info(repo_id, revision)`.
 
-## GET `/api/models-tags-by-type`
+## GET /api/models-tags-by-type
 
 Gets all the available model tags hosted in the Hub.
 
 This is equivalent to `huggingface_hub.get_model_tags()`.
 
-## GET `/api/datasets`
+## GET /api/datasets
 
 Get information from all datasets in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the following pages. You can specify additional parameters to have more specific results.
 - `search`: Filter based on substrings for repos and their usernames, such as `pets` or `microsoft`
@@ -73,7 +73,7 @@ params = {
 
 This is equivalent to `huggingface_hub.list_datasets()`.
 
-## GET `/api/datasets/{repo_id}` or `/api/datasets/{repo_id}/revision/{revision}`
+## GET /api/datasets/{repo_id} or /api/datasets/{repo_id}/revision/{revision}
 
 Get all information for a specific dataset.
 
@@ -87,21 +87,21 @@ params = {"full": "full"}
 
 This is equivalent to `huggingface_hub.dataset_info(repo_id, revision)`.
 
-## GET `/api/datasets/{repo_id}/parquet`
+## GET /api/datasets/{repo_id}/parquet
 
 Get the list of auto-converted parquet files.
 
-## GET `/api/datasets/{repo_id}/parquet/{config}/{split}/{n}.parquet`
+## GET /api/datasets/{repo_id}/parquet/{config}/{split}/{n}.parquet
 
 Get the nth shard of the auto-converted parquet files.
 
-## GET `/api/datasets-tags-by-type `
+## GET /api/datasets-tags-by-type
 
 Gets all the available dataset tags hosted in the Hub
 
 This is equivalent to `huggingface_hub.get_dataset_tags()`.
 
-## GET `/api/spaces`
+## GET /api/spaces
 
 Get information from all Spaces in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the following pages. You can specify additional parameters to have more specific results.
 - `search`: Filter based on substrings for repos and their usernames, such as `resnet` or `microsoft`
@@ -130,18 +130,18 @@ params = {
 
 This is equivalent to `huggingface_hub.list_spaces()`.
 
-## GET `/api/spaces/{repo_id}` or `/api/spaces/{repo_id}/revision/{revision}`
+## GET /api/spaces/{repo_id} or /api/spaces/{repo_id}/revision/{revision}
 Get all information for a specific model.
 
 This is equivalent to `huggingface_hub.space_info(repo_id, revision)`.
 
-## GET `/api/metrics`
+## GET /api/metrics
 
 Get information from all metrics in the Hub.
 
 This is equivalent to `huggingface_hub.list_metrics()`.
 
-## POST `/api/repos/create`
+## POST /api/repos/create
 
 Create a repository. It's a model repo by default.
 
@@ -164,7 +164,7 @@ payload = {
 
 This is equivalent to `huggingface_hub.create_repo()`.
 
-## DELETE `/api/repos/delete`
+## DELETE /api/repos/delete
 
 Delete a repository. It's a model repo by default.
 
@@ -185,7 +185,7 @@ payload = {
 
 This is equivalent to `huggingface_hub.delete_repo()`.
 
-## PUT `/api/repos/{type}/{repo_id}/settings`
+## PUT /api/repos/{type}/{repo_id}/settings
 
 Update repo visibility.
 
@@ -199,7 +199,7 @@ payload = {
 
 This is equivalent to `huggingface_hub.update_repo_visibility()`.
 
-## POST `/api/repos/move`
+## POST /api/repos/move
 
 Move a repository (rename within the same namespace or transfer from user to organization).
 
@@ -214,7 +214,7 @@ payload = {
 
 This is equivalent to `huggingface_hub.move_repo()`.
 
-## GET `/api/whoami-v2`
+## GET /api/whoami-v2
 
 Get username and organizations the user belongs to.
 

--- a/docs/hub/api.md
+++ b/docs/hub/api.md
@@ -97,7 +97,7 @@ Get the nth shard of the auto-converted parquet files.
 
 ## GET /api/datasets-tags-by-type
 
-Gets all the available dataset tags hosted in the Hub
+Gets all the available dataset tags hosted in the Hub.
 
 This is equivalent to `huggingface_hub.get_dataset_tags()`.
 

--- a/docs/hub/api.md
+++ b/docs/hub/api.md
@@ -2,25 +2,226 @@
 
 We have open endpoints that you can use to retrieve information from the Hub as well as perform certain actions such as creating model, dataset or Space repos. We offer a wrapper Python library, [`huggingface_hub`](https://github.com/huggingface/huggingface_hub), that allows easy access to these endpoints. We also provide [webhooks](./webhooks) to receive real-time incremental info about repos. Enjoy!
 
-## Endpoints table
+The base URL for those endpoints below is `https://huggingface.co`. For example, to construct the `/api/models` call below, one can call the URL [https://huggingface.co/api/models](https://huggingface.co/api/models)
 
-The base URL for those endpoints below is `https://huggingface.co`. For example, to construct the `api/models` call below, one can call the URL [https://huggingface.co/api/models](https://huggingface.co/api/models)
+## GET `/api/models`
 
-| Endpoint                                                                     	| Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            	| `huggingface_hub` root methods    	| Payload                                                                                                                                                               	|   	|
-|------------------------------------------------------------------------------	|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|-----------------------------------	|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------	|---	|
-| /api/models     GET                                                          	| Get information from all models in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the following pages. You can specify additional parameters to have more specific results.   - `search`: Filter based on substrings for repos and their usernames, such as `resnet` or `microsoft` - `author`: Filter models by an author or organization, such as `huggingface` or `microsoft` - `filter`: Filter based on tags, such as `text-classification` or `spacy`. - `sort`: Property to use when sorting, such as `downloads` or `author`.  - `direction`: Direction in which to sort, such as `-1` for descending, and anything else for ascending. - `limit`: Limit the number of models fetched.  - `full`: Whether to fetch most model data, such as all tags, the files, etc.  - `config`: Whether to also fetch the repo config. 	| `list_models()`                   	| ```params= {   "search":"search", "author":"author", "filter":"filter", "sort":"sort", "direction":"direction", "limit":"limit", "full":"full", "config":"config"}``` 	|   	|
-| /api/models/{repo_id}   /api/models/{repo_id}/revision/{revision}    GET     	| Get all information for a specific model.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              	| `model_info(repo_id, revision)`   	| ```headers = { "authorization" :  "Bearer $token" }```                                                                                                                	|   	|
-| /api/models-tags-by-type   GET                                               	| Gets all the available model tags hosted in the Hub                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    	| `get_model_tags()`                	|                                                                                                                                                                       	|   	|
-| /api/datasets     GET                                                        	| Get information from all datasets in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the following pages. You can specify additional parameters to have more specific results. - `search`: Filter based on substrings for repos and their usernames, such as `pets` or `microsoft`   - `author`: Filter datasets by an other or organization, such as `huggingface` or `microsoft` - `filter`: Filter based on tags, such as `task_categories:text-classification` or `languages:en`. - `sort`: Property to use when sorting, such as `downloads` or `author`. - `direction`: Direction in which to sort, such as `-1` for descending, and anything else for ascending. - `limit`: Limit the number of datasets fetched.  - `full`: Whether to fetch most dataset data, such as all tags, the files, etc.                         	| `list_datasets()`                 	| ```params= {   "search":"search", "author":"author", "filter":"filter", "sort":"sort", "direction":"direction", "limit":"limit", "full":"full", "config":"config"}``` 	|   	|
-| /api/datasets/{repo_id}   /api/datasets/{repo_id}/revision/{revision}    GET 	| Get all information for a specific dataset.   - `full`: Whether to fetch most dataset data, such as all tags, the files, etc.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          	| `dataset_info(repo_id, revision)` 	| ```headers = { "authorization" :  "Bearer $token", "full" : "full"  }```                                                                                              	|   	|
-| /api/datasets/{repo_id}/parquet   /api/datasets/{repo_id}/parquet/{config}/{split}       GET 	| Get the list of auto-converted parquet files.                                                                                                                                                                                                                                                                                                                                                                                                                                                             	|  	| ```headers = { "authorization" :  "Bearer $token", "full" : "full"  }```                                                                                              	|   	|
-| /api/datasets/{repo_id}/parquet/{config}/{split}/{n}.parquet       GET 	| Get the nth shard of the auto-converted parquet files.                                                                                                                                                                                                                                                                                                                                                                                                                                                             	|  	| ```headers = { "authorization" :  "Bearer $token", "full" : "full"  }```                                                                                              	|   	|
-| /api/datasets-tags-by-type   GET                                             	| Gets all the available dataset tags hosted in the Hub                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  	| `get_dataset_tags()`              	|                                                                                                                                                                       	|   	|
-| /api/spaces     GET                                                          	| Get information from all Spaces in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the following pages. You can specify additional parameters to have more specific results.   - `search`: Filter based on substrings for repos and their usernames, such as `resnet` or `microsoft` - `author`: Filter models by an author or organization, such as `huggingface` or `microsoft` - `filter`: Filter based on tags, such as `text-classification` or `spacy`. - `sort`: Property to use when sorting, such as `downloads` or `author`.  - `direction`: Direction in which to sort, such as `-1` for descending, and anything else for ascending. - `limit`: Limit the number of models fetched.  - `full`: Whether to fetch most model data, such as all tags, the files, etc.  - `config`: Whether to also fetch the repo config. 	| `list_spaces()`                   	| ```params= {   "search":"search", "author":"author", "filter":"filter", "sort":"sort", "direction":"direction", "limit":"limit", "full":"full", "config":"config"}``` 	|   	|
-| /api/spaces/{repo_id}   /api/spaces/{repo_id}/revision/{revision}    GET     	| Get all information for a specific model.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              	| `space_info(repo_id, revision)`   	| ```headers = { "authorization" :  "Bearer $token" }```                                                                                                                	|   	|
-| /api/metrics     GET                                                         	| Get information from all metrics in the Hub.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           	| `list_metrics()`                  	|                                                                                                                                                                       	|   	|
-| /api/repos/create     POST                                                   	| Create a repository. It's a model repo by default.   -         type: Type of repo (datasets or spaces; model by default).   - name: Name of repo.   - organization: Name of organization. -   - private: Whether the repo is private.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  	| `create_repo()`                   	| ```headers = { authorization :  "Bearer $token" }```  ```json= {"type":"type", "repo_id":"repo_id", "private":"private"}```                  	|   	|
-| /api/repos/delete    DELETE                                                  	| Delete a repository. It's a model repo by default.   -         type: Type of repo (datasets or spaces; model by default).   - name: Name of repo.   - organization: Name of organization.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              	| `delete_repo()`                   	| ```headers = { "authorization" :  "Bearer $token" }```  ```json= {"type":"type", "name":"name", "organization":"organization"}```                                     	|   	|
-| /api/repos/{type}/{repo_id}/settings   PUT                                   	| Update repo visibility.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                	| `update_repo_visibility()`        	| ```headers = { "authorization" :  "Bearer $token" }```  ```json= {"private":"private"}```                                                                             	|   	|
-| /api/repos/move POST                                                         	| Move a repository (rename within same namespace or transfer from user to organization).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 	| `move_repo()`                     	| ```headers = { "authorization" :  "Bearer $token" }```    ```json= {"fromRepo" : "namespace/repo_name", "toRepo" : "namespace2/repo_name2"}```                        	|   	|
-| /api/whoami-v2    GET                                                           	| Get username and organizations the user belongs to.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    	| `whoami(token)`                   	| ```headers = { "authorization" :  "Bearer $token" }```                                                                                                                	|   	|
+Get information from all models in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the following pages. You can specify additional parameters to have more specific results.
+- `search`: Filter based on substrings for repos and their usernames, such as `resnet` or `microsoft`
+- `author`: Filter models by an author or organization, such as `huggingface` or `microsoft`
+- `filter`: Filter based on tags, such as `text-classification` or `spacy`.
+- `sort`: Property to use when sorting, such as `downloads` or `author`.
+- `direction`: Direction in which to sort, such as `-1` for descending, and anything else for ascending.
+- `limit`: Limit the number of models fetched.
+- `full`: Whether to fetch most model data, such as all tags, the files, etc.
+- `config`: Whether to also fetch the repo config.
+
+Payload:
+
+```js
+params = {
+    "search":"search",
+    "author":"author",
+    "filter":"filter",
+    "sort":"sort",
+    "direction":"direction",
+    "limit":"limit",
+    "full":"full",
+    "config":"config"
+}
+```
+
+This is equivalent to `huggingface_hub.list_models()`.
+
+## GET `/api/models/{repo_id}` or `/api/models/{repo_id}/revision/{revision}`
+
+Get all information for a specific model.
+
+This is equivalent to `huggingface_hub.model_info(repo_id, revision)`.
+
+## GET `/api/models-tags-by-type`
+
+Gets all the available model tags hosted in the Hub.
+
+This is equivalent to `huggingface_hub.get_model_tags()`.
+
+## GET `/api/datasets`
+
+Get information from all datasets in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the following pages. You can specify additional parameters to have more specific results.
+- `search`: Filter based on substrings for repos and their usernames, such as `pets` or `microsoft`
+- `author`: Filter datasets by an author or organization, such as `huggingface` or `microsoft`
+- `filter`: Filter based on tags, such as `task_categories:text-classification` or `languages:en`.
+- `sort`: Property to use when sorting, such as `downloads` or `author`.
+- `direction`: Direction in which to sort, such as `-1` for descending, and anything else for ascending.
+- `limit`: Limit the number of datasets fetched.
+- `full`: Whether to fetch most dataset data, such as all tags, the files, etc.
+
+Payload:
+
+```js
+params = {
+    "search":"search",
+    "author":"author",
+    "filter":"filter",
+    "sort":"sort",
+    "direction":"direction",
+    "limit":"limit",
+    "full":"full",
+    "config":"config"
+}
+```
+
+This is equivalent to `huggingface_hub.list_datasets()`.
+
+## GET `/api/datasets/{repo_id}` or `/api/datasets/{repo_id}/revision/{revision}`
+
+Get all information for a specific dataset.
+
+- `full`: Whether to fetch most dataset data, such as all tags, the files, etc.
+
+Payload:
+
+```js
+params = {"full": "full"}
+```
+
+This is equivalent to `huggingface_hub.dataset_info(repo_id, revision)`.
+
+## GET `/api/datasets/{repo_id}/parquet`
+
+Get the list of auto-converted parquet files.
+
+## GET `/api/datasets/{repo_id}/parquet/{config}/{split}/{n}.parquet`
+
+Get the nth shard of the auto-converted parquet files.
+
+## GET `/api/datasets-tags-by-type `
+
+Gets all the available dataset tags hosted in the Hub
+
+This is equivalent to `huggingface_hub.get_dataset_tags()`.
+
+## GET `/api/spaces`
+
+Get information from all Spaces in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the following pages. You can specify additional parameters to have more specific results.
+- `search`: Filter based on substrings for repos and their usernames, such as `resnet` or `microsoft`
+- `author`: Filter models by an author or organization, such as `huggingface` or `microsoft`
+- `filter`: Filter based on tags, such as `text-classification` or `spacy`.
+- `sort`: Property to use when sorting, such as `downloads` or `author`.
+- `direction`: Direction in which to sort, such as `-1` for descending, and anything else for ascending.
+- `limit`: Limit the number of models fetched.
+- `full`: Whether to fetch most model data, such as all tags, the files, etc.
+- `config`: Whether to also fetch the repo config.
+
+Payload:
+
+```js
+params = {
+    "search":"search",
+    "author":"author",
+    "filter":"filter",
+    "sort":"sort",
+    "direction":"direction",
+    "limit":"limit",
+    "full":"full",
+    "config":"config"
+}
+```
+
+This is equivalent to `huggingface_hub.list_spaces()`.
+
+## GET `/api/spaces/{repo_id}` or `/api/spaces/{repo_id}/revision/{revision}`
+Get all information for a specific model.
+
+This is equivalent to `huggingface_hub.space_info(repo_id, revision)`.
+
+## GET `/api/metrics`
+
+Get information from all metrics in the Hub.
+
+This is equivalent to `huggingface_hub.list_metrics()`.
+
+## POST `/api/repos/create`
+
+Create a repository. It's a model repo by default.
+
+Parameters:
+- `type`: Type of repo (dataset or space; model by default).
+- `name`: Name of repo.
+- `organization`: Name of organization (optional).
+- `private`: Whether the repo is private.
+
+Payload:
+
+```js
+payload = {
+    "type":"type",
+    "name":"name",
+    "organization": "organization",
+    "private":"private"
+}
+```
+
+This is equivalent to `huggingface_hub.create_repo()`.
+
+## DELETE `/api/repos/delete`
+
+Delete a repository. It's a model repo by default.
+
+Parameters:
+- `type`: Type of repo (dataset or space; model by default).
+- `name`: Name of repo.
+- `organization`: Name of organization (optional).
+
+Payload:
+
+```js
+payload = {
+    "type": "type",
+    "name": "name",
+    "organization": "organization",
+}
+```
+
+This is equivalent to `huggingface_hub.delete_repo()`.
+
+## PUT `/api/repos/{type}/{repo_id}/settings`
+
+Update repo visibility.
+
+Payload:
+
+```js
+payload = {
+    "private": "private",
+}
+```
+
+This is equivalent to `huggingface_hub.update_repo_visibility()`.
+
+## POST `/api/repos/move`
+
+Move a repository (rename within the same namespace or transfer from user to organization).
+
+Payload:
+
+```js
+payload = {
+    "fromRepo" : "namespace/repo_name",
+    "toRepo" : "namespace2/repo_name2"
+}
+```
+
+This is equivalent to `huggingface_hub.move_repo()`.
+
+## GET `/api/whoami-v2`
+
+Get username and organizations the user belongs to.
+
+Payload:
+
+```js
+headers = { "authorization" :  "Bearer $token" }
+```
+
+This is equivalent to `huggingface_hub.whoami()`.


### PR DESCRIPTION
Discussed multiple times. Last time in https://github.com/huggingface/huggingface_hub/issues/1682#issuecomment-1728161950. I'll first revamp the table and in a later PR add the Collection API endpoints.

Let's agree on the layout first. What I did here is to delete the table and have 1 endpoint = 1 section in the page. That should create a "nice" table of content on the right.

Any opinion or feedback? cc @julien-c @osanseviero @Pierrci 

(Note: I -almost- didn't change the content but some things should be clarified. Payloads often don't include the headers so either add them everywhere or have a section dedicated to it. Also maybe at some point have different section to group APIs together (e.g. the collection API in one section). Anyway, that's off-topic for now.).

WDYT?

Current docs: https://huggingface.co/docs/hub/api
PR docs: https://moon-ci-docs.huggingface.co/docs/hub/pr_962/en/api