### PR TITLE
Add udm to Language.ts

### DIFF
--- a/js/src/lib/interfaces/Language.ts
+++ b/js/src/lib/interfaces/Language.ts
@@ -1241,4 +1241,9 @@ export const LANGUAGES: Record<string, Language> = {
 		name:       "Literary Chinese",
 		nativeName: "文言",
 	},
+	udm: {
+		code:       "udm",
+		name:       "Udmurt",
+		nativeName: "удмурт кыл",
+	},
 };


### PR DESCRIPTION
I recently noticed that the Udmurt language is not in the list of languages, although Komi, Mari and other related languages are already there. Therefore, I think it’s right to add the Udmurt language to this list.

Language code info: https://iso639-3.sil.org/code/udm
Used in dataset: https://huggingface.co/datasets/udmurtNLP/udmurt-bible-parallel-corpora