### PR TITLE
Run linter

### DIFF
--- a/js/.eslintrc.cjs
+++ b/js/.eslintrc.cjs
@@ -50,7 +50,6 @@ module.exports = {
 					"error",
 					{
 						"newlines-between": "always",
-						"alphabetize": { order: 'asc' },
 						"groups": ["type", "builtin", "external", "parent", "sibling", "index"],
 					},
 				],

--- a/js/.eslintrc.cjs
+++ b/js/.eslintrc.cjs
@@ -50,6 +50,7 @@ module.exports = {
 					"error",
 					{
 						"newlines-between": "always",
+						"alphabetize": { order: 'asc' },
 						"groups": ["type", "builtin", "external", "parent", "sibling", "index"],
 					},
 				],

--- a/js/src/lib/components/InferenceWidget/shared/helpers.ts
+++ b/js/src/lib/components/InferenceWidget/shared/helpers.ts
@@ -185,11 +185,11 @@ export async function getModelLoadInfo(
 	const output = await response.json();
 	if (response.ok && typeof output === "object" && output.loaded !== undefined) {
 		// eslint-disable-next-line @typescript-eslint/naming-convention
-		const {state, compute_type} = output;
-		return {compute_type, state};
+		const { state, compute_type } = output;
+		return { compute_type, state };
 	} else {
 		console.warn(response.status, output.error);
-		return {state: "error" };
+		return { state: "error" };
 	}
 }
 

--- a/js/src/lib/components/InferenceWidget/shared/types.ts
+++ b/js/src/lib/components/InferenceWidget/shared/types.ts
@@ -11,7 +11,6 @@ export interface WidgetProps {
 	isLoggedIn?:        boolean;
 }
 
-
 export type LoadState = "Loadable" | "Loaded" | "TooBig" | "error";
 
 export type ComputeType = "cpu" | "gpu";


### PR DESCRIPTION
Should be merged into branch `why` #974

This PR:
1. Formats the files so that CI passes
2. Add eslint `alphabetize` rule https://github.com/huggingface/hub-docs/pull/975/commits/68c6c5ae044c6804c118013aebca19a7dc808fb4 so that you don't need to manually sort https://github.com/huggingface/hub-docs/pull/974/commits/12a3381b9a8b849cd8d8d93c7fd85e348d6524ec. However, we don't have this `alphabetize` in moon. And we are supposed to align with moon as written in https://github.com/huggingface/hub-docs/pull/924 @krampstudio wdyt?