### PR TITLE
docs: fix link name to example TensorBoard

### DIFF
--- a/docs/hub/tensorboard.md
+++ b/docs/hub/tensorboard.md
@@ -4,7 +4,7 @@ TensorBoard provides tooling for tracking and visualizing metrics as well as vis
 
 ## Exploring TensorBoard models on the Hub
 
-Over 6,000 repositories have TensorBoard traces on the Hub. You can find them by filtering at the left of the [models page](https://huggingface.co/models?filter=tensorboard). As an example, if you go to the [pyannote/embedding](https://huggingface.co/aubmindlab/bert-base-arabertv02) repository, there is a **Metrics** tab. If you select it, you'll view a TensorBoard instance.
+Over 6,000 repositories have TensorBoard traces on the Hub. You can find them by filtering at the left of the [models page](https://huggingface.co/models?filter=tensorboard). As an example, if you go to the [aubmindlab/bert-base-arabertv02](https://huggingface.co/aubmindlab/bert-base-arabertv02) repository, there is a **Metrics** tab. If you select it, you'll view a TensorBoard instance.
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/libraries-tensorflow.png"/>


### PR DESCRIPTION
Hi,

this PR introduces a minor fix for the link name of the example TensorBoard. The link name `aubmindlab/bert-base-arabertv02` now aligns with the actual TensorBoard example.