### PR TITLE
[Widgets] Handle display logic

### DIFF
--- a/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
@@ -78,9 +78,6 @@
 		"zero-shot-image-classification": ZeroShotImageClassificationWidget,
 	};
 
-	const hasExampleWithOutput = model.widgetData?.some(sample => !!sample.output);
-	$: modelTooBig = $modelLoadStates[model.id]?.state === "TooBig";
-
 	$: widgetComponent = WIDGET_COMPONENTS[model.pipeline_tag ?? ""];
 
 	// prettier-ignore

--- a/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
@@ -27,7 +27,7 @@
 	import VisualQuestionAnsweringWidget from "./widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte";
 	import ZeroShotClassificationWidget from "./widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte";
 	import ZeroShotImageClassificationWidget from "./widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte";
-	
+
 	export let apiToken: WidgetProps["apiToken"] = undefined;
 	export let callApiOnMount = false;
 	export let apiUrl = "https://api-inference.huggingface.co";

--- a/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
@@ -27,8 +27,7 @@
 	import VisualQuestionAnsweringWidget from "./widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte";
 	import ZeroShotClassificationWidget from "./widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte";
 	import ZeroShotImageClassificationWidget from "./widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte";
-	import { modelLoadStates } from "./stores";
-
+	
 	export let apiToken: WidgetProps["apiToken"] = undefined;
 	export let callApiOnMount = false;
 	export let apiUrl = "https://api-inference.huggingface.co";

--- a/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/InferenceWidget.svelte
@@ -3,9 +3,6 @@
 	import type { PipelineType } from "../../interfaces/Types";
 	import type { WidgetProps } from "./shared/types";
 
-	import { InferenceDisplayability } from "../../interfaces/InferenceDisplayability";
-	import IconInfo from "../Icons/IconInfo.svelte";
-
 	import AudioClassificationWidget from "./widgets/AudioClassificationWidget/AudioClassificationWidget.svelte";
 	import AudioToAudioWidget from "./widgets/AudioToAudioWidget/AudioToAudioWidget.svelte";
 	import AutomaticSpeechRecognitionWidget from "./widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte";
@@ -30,7 +27,6 @@
 	import VisualQuestionAnsweringWidget from "./widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte";
 	import ZeroShotClassificationWidget from "./widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte";
 	import ZeroShotImageClassificationWidget from "./widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte";
-	import WidgetHeader from "./shared/WidgetHeader/WidgetHeader.svelte";
 	import { modelLoadStates } from "./stores";
 
 	export let apiToken: WidgetProps["apiToken"] = undefined;
@@ -101,62 +97,5 @@
 </script>
 
 {#if widgetComponent}
-	{#if (model.inference === InferenceDisplayability.Yes || model.pipeline_tag === "reinforcement-learning") && !modelTooBig}
-		<svelte:component this={WIDGET_COMPONENTS[model.pipeline_tag ?? ""]} {...widgetProps} />
-	{:else}
-		<!-- All the cases why inference widget is disabled -->
-		{#if !hasExampleWithOutput}
-			<WidgetHeader pipeline={model.pipeline_tag} noTitle={true} />
-		{/if}
-		{#if model.inference === InferenceDisplayability.ExplicitOptOut}
-			<span class="text-sm text-gray-500">Inference API has been turned off for this model.</span>
-		{:else if model.inference === InferenceDisplayability.CustomCode}
-			<span class="text-sm text-gray-500">Inference API does not yet support model repos that contain custom code.</span
-			>
-		{:else if model.inference === InferenceDisplayability.LibraryNotDetected}
-			<span class="text-sm text-gray-500">
-				Unable to determine this model's library. Check the
-				<a class="color-inherit" href="/docs/hub/model-cards#specifying-a-library">
-					docs <IconInfo classNames="inline" />
-				</a>.
-			</span>
-		{:else if model.inference === InferenceDisplayability.PipelineNotDetected}
-			<span class="text-sm text-gray-500">
-				Unable to determine this model’s pipeline type. Check the
-				<a class="color-inherit" href="/docs/hub/models-widgets#enabling-a-widget">
-					docs <IconInfo classNames="inline" />
-				</a>.
-			</span>
-		{:else if model.inference === InferenceDisplayability.PipelineLibraryPairNotSupported}
-			<span class="text-sm text-gray-500">
-				Inference API does not yet support {model.library_name} models for this pipeline type.
-			</span>
-		{:else if modelTooBig}
-			<span class="text-sm text-gray-500">
-				Model is too large to load onto the free Inference API. To try the model, launch it on <a
-					class="underline"
-					href="https://ui.endpoints.huggingface.co/new?repository={encodeURIComponent(model.id)}"
-					>Inference Endpoints</a
-				>
-				instead.
-			</span>
-		{:else}
-			<!-- added as a failsafe but this case cannot currently happen -->
-			<span class="text-sm text-gray-500">
-				Inference API is disabled for an unknown reason. Please open a
-				<a class="color-inherit underline" href="/{model.id}/discussions/new">Discussion in the Community tab</a>.
-			</span>
-		{/if}
-
-		<!-- If there is an example with output, then show the widget with disabled interaction -->
-		{#if hasExampleWithOutput}
-			<span class="text-sm text-gray-500">
-				However, you can still play with
-				<a class="color-inherit underline" href="/docs/hub/models-widgets#example-outputs"
-					>examples that have an output</a
-				>.
-			</span>
-			<svelte:component this={WIDGET_COMPONENTS[model.pipeline_tag ?? ""]} {...widgetProps} isDisabled={true} />
-		{/if}
-	{/if}
+	<svelte:component this={WIDGET_COMPONENTS[model.pipeline_tag ?? ""]} {...widgetProps} />
 {/if}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetAddSentenceBtn/WidgetAddSentenceBtn.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetAddSentenceBtn/WidgetAddSentenceBtn.svelte
@@ -4,6 +4,9 @@
 	export let onClick: (e: MouseEvent) => void;
 </script>
 
-<button class="btn-widget h-10 w-full px-5" disabled={isDisabled} on:click|preventDefault={onClick} type="submit">
-	{label}
-</button>
+{#if !isDisabled}
+	<!-- content here -->
+	<button class="btn-widget h-10 w-full px-5" disabled={isDisabled} on:click|preventDefault={onClick} type="submit">
+		{label}
+	</button>
+{/if}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetDropzone/WidgetDropzone.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetDropzone/WidgetDropzone.svelte
@@ -57,7 +57,8 @@
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <div
 	class="relative cursor-pointer rounded border-2 border-dashed px-3 py-7 text-center
-		{isDragging ? 'border-green-300 bg-green-50 text-green-500' : 'text-gray-500'} 
+		{isDisabled ? 'pointer-events-none' : ''}
+		{isDragging ? 'border-green-300 bg-green-50 text-green-500' : 'text-gray-500'}
 		{classNames}"
 	on:click={() => {
 		fileInput.click();
@@ -71,7 +72,7 @@
 	on:dragover|preventDefault
 	on:drop|preventDefault={onDrop}
 >
-	{#if !imgSrc}
+	{#if !imgSrc && !isDisabled}
 		<span class="pointer-events-none text-sm">{label}</span>
 	{:else}
 		<div class={isDragging ? "pointer-events-none" : ""}>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetDropzone/WidgetDropzone.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetDropzone/WidgetDropzone.svelte
@@ -5,6 +5,7 @@
 	export let accept = "image/*";
 	export let classNames = "";
 	export let isLoading = false;
+	export let isDisabled = false;
 	export let imgSrc = "";
 	export let label = "Drag image file here or click to browse from your device";
 	export let onSelectFile: (file: File | Blob) => void;
@@ -45,7 +46,14 @@
 	}
 </script>
 
-<input {accept} bind:this={fileInput} on:change={onChange} disabled={isLoading} style="display: none;" type="file" />
+<input
+	{accept}
+	bind:this={fileInput}
+	on:change={onChange}
+	disabled={isLoading || isDisabled}
+	style="display: none;"
+	type="file"
+/>
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <div
 	class="relative cursor-pointer rounded border-2 border-dashed px-3 py-7 text-center

--- a/js/src/lib/components/InferenceWidget/shared/WidgetFileInput/WidgetFileInput.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetFileInput/WidgetFileInput.svelte
@@ -20,35 +20,37 @@
 	}
 </script>
 
-<div
-	class={classNames}
-	on:dragenter={() => {
-		isDragging = true;
-	}}
-	on:dragover|preventDefault
-	on:dragleave={() => {
-		isDragging = false;
-	}}
-	on:drop|preventDefault={e => {
-		isDragging = false;
-		fileInput.files = e.dataTransfer?.files ?? null;
-		onChange();
-	}}
->
-	<label class="btn-widget {isDragging ? 'ring' : ''} {isLoading ? 'text-gray-600' : ''}">
-		{#if isLoading}
-			<IconSpin classNames="-ml-1 mr-1.5 text-gray-600 animate-spin" />
-		{:else}
-			<IconFile classNames="-ml-1 mr-1.5" />
-		{/if}
-		<input
-			{accept}
-			bind:this={fileInput}
-			on:change={onChange}
-			disabled={isLoading || isDisabled}
-			style="display: none;"
-			type="file"
-		/>
-		{label}
-	</label>
-</div>
+{#if !isDisabled}
+	<div
+		class={classNames}
+		on:dragenter={() => {
+			isDragging = true;
+		}}
+		on:dragover|preventDefault
+		on:dragleave={() => {
+			isDragging = false;
+		}}
+		on:drop|preventDefault={e => {
+			isDragging = false;
+			fileInput.files = e.dataTransfer?.files ?? null;
+			onChange();
+		}}
+	>
+		<label class="btn-widget {isDragging ? 'ring' : ''} {isLoading ? 'text-gray-600' : ''}">
+			{#if isLoading}
+				<IconSpin classNames="-ml-1 mr-1.5 text-gray-600 animate-spin" />
+			{:else}
+				<IconFile classNames="-ml-1 mr-1.5" />
+			{/if}
+			<input
+				{accept}
+				bind:this={fileInput}
+				on:change={onChange}
+				disabled={isLoading || isDisabled}
+				style="display: none;"
+				type="file"
+			/>
+			{label}
+		</label>
+	</div>
+{/if}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetFileInput/WidgetFileInput.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetFileInput/WidgetFileInput.svelte
@@ -5,6 +5,7 @@
 	export let accept: string | undefined;
 	export let classNames = "";
 	export let isLoading = false;
+	export let isDisabled = false;
 	export let label = "Browse for file";
 	export let onSelectFile: (file: File | Blob) => void;
 
@@ -44,7 +45,7 @@
 			{accept}
 			bind:this={fileInput}
 			on:change={onChange}
-			disabled={isLoading}
+			disabled={isLoading || isDisabled}
 			style="display: none;"
 			type="file"
 		/>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetFooter/WidgetFooter.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetFooter/WidgetFooter.svelte
@@ -4,21 +4,24 @@
 
 	export let onClickMaximizeBtn: () => void;
 	export let outputJson: string;
+	export let isDisabled = false;
 
 	let isOutputJsonVisible = false;
 </script>
 
 <div class="mt-auto flex items-center pt-4 text-xs text-gray-500">
-	<button
-		class="flex items-center {outputJson ? '' : 'cursor-not-allowed text-gray-300'}"
-		disabled={!outputJson}
-		on:click={() => {
-			isOutputJsonVisible = !isOutputJsonVisible;
-		}}
-	>
-		<IconCode classNames="mr-1" />
-		JSON Output
-	</button>
+	{#if !isDisabled}
+		<button
+			class="flex items-center {outputJson ? '' : 'cursor-not-allowed text-gray-300'}"
+			disabled={!outputJson}
+			on:click={() => {
+				isOutputJsonVisible = !isOutputJsonVisible;
+			}}
+		>
+			<IconCode classNames="mr-1" />
+			JSON Output
+		</button>
+	{/if}
 	<button class="ml-auto flex items-center" on:click|preventDefault={onClickMaximizeBtn}>
 		<IconMaximize classNames="mr-1" />
 		Maximize

--- a/js/src/lib/components/InferenceWidget/shared/WidgetHeader/WidgetHeader.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetHeader/WidgetHeader.svelte
@@ -10,6 +10,7 @@
 	export let noTitle = false;
 	export let title: string | null = null;
 	export let pipeline: PipelineType | undefined;
+	export let isDisabled = false;
 
 	$: task = pipeline ? getPipelineTask(pipeline) : undefined;
 </script>
@@ -22,10 +23,14 @@
 			</div>
 		{:else}
 			<div class="flex items-center text-lg">
-				<IconLightning classNames="-ml-1 mr-1 text-yellow-500" />
-				Hosted inference API
+				{#if !isDisabled}
+					<IconLightning classNames="-ml-1 mr-1 text-yellow-500" />
+					Inference API
+				{:else}
+					Inference Examples
+				{/if}
 			</div>
-			<a target="_blank" href="https://huggingface.co/docs/api-inference">
+			<a target="_blank" href="https://huggingface.co/docs/hub/models-widgets#example-outputs">
 				<IconInfo classNames="ml-1.5 text-sm text-gray-400 hover:text-black" />
 			</a>
 		{/if}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetInfo/WidgetInfo.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetInfo/WidgetInfo.svelte
@@ -9,8 +9,7 @@
 	export let computeTime: string;
 	export let error: string;
 	export let modelLoadInfo: ModelLoadInfo | undefined = undefined;
-
-	$: modelTooBig = false; // TODO
+	export let modelTooBig = false;
 
 	const state = {
 		Loadable: "This model can be loaded on the Inference API on-demand.",

--- a/js/src/lib/components/InferenceWidget/shared/WidgetQuickInput/WidgetQuickInput.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetQuickInput/WidgetQuickInput.svelte
@@ -3,6 +3,7 @@
 
 	export let flatTop = false;
 	export let isLoading: boolean;
+	export let isDisabled = false;
 	export let onClickSubmitBtn: (e?: MouseEvent) => void;
 	export let placeholder = "Your sentence here...";
 	export let submitButtonLabel: string | undefined = undefined;
@@ -16,11 +17,12 @@
 		{placeholder}
 		required={true}
 		type="text"
-		disabled={isLoading}
+		disabled={isLoading || isDisabled}
 	/>
 	<WidgetSubmitBtn
 		classNames="rounded-l-none border-l-0 {flatTop ? 'rounded-t-none' : ''}"
 		{isLoading}
+		{isDisabled}
 		label={submitButtonLabel}
 		onClick={onClickSubmitBtn}
 	/>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetQuickInput/WidgetQuickInput.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetQuickInput/WidgetQuickInput.svelte
@@ -14,7 +14,7 @@
 	<input
 		bind:value
 		class="form-input-alt min-w-0 flex-1 rounded-r-none {flatTop ? 'rounded-t-none' : ''}"
-		{placeholder}
+		placeholder={isDisabled ? "" : placeholder}
 		required={true}
 		type="text"
 		disabled={isLoading || isDisabled}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetShortcutRunLabel/WidgetShortcutRunLabel.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetShortcutRunLabel/WidgetShortcutRunLabel.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from "svelte";
 
 	export let isLoading: boolean;
+	export let isDisabled = false;
 
 	let shortcutLabel = "";
 
@@ -11,9 +12,11 @@
 	});
 </script>
 
-<kbd
-	class="hidden rounded border border-gray-200 bg-gray-100 py-0.5 px-1.5 text-xs leading-none text-gray-700 dark:bg-gray-800 dark:text-gray-300 md:inline {isLoading
-		? 'opacity-40'
-		: 'opacity-70'}"
-	>{shortcutLabel}
-</kbd>
+{#if !isDisabled}
+	<kbd
+		class="hidden rounded border border-gray-200 bg-gray-100 py-0.5 px-1.5 text-xs leading-none text-gray-700 dark:bg-gray-800 dark:text-gray-300 md:inline {isLoading
+			? 'opacity-40'
+			: 'opacity-70'}"
+		>{shortcutLabel}
+	</kbd>
+{/if}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetSubmitBtn/WidgetSubmitBtn.svelte
@@ -8,7 +8,7 @@
 	export let onClick: () => void;
 
 	function onKeyDown(e: KeyboardEvent) {
-		if (isLoading) {
+		if (isLoading || isDisabled) {
 			return;
 		}
 		// run inference on cmd+Enter
@@ -21,15 +21,17 @@
 
 <svelte:window on:keydown={onKeyDown} />
 
-<button
-	class="btn-widget h-10 w-24 px-5 {classNames}"
-	disabled={isDisabled || isLoading}
-	on:click|preventDefault={onClick}
-	type="submit"
->
-	{#if isLoading}
-		<IconSpin classNames="text-gray-600 animate-spin" />
-	{:else}
-		{label}
-	{/if}
-</button>
+{#if !isDisabled}
+	<button
+		class="btn-widget h-10 w-24 px-5 {classNames}"
+		disabled={isDisabled || isLoading}
+		on:click|preventDefault={onClick}
+		type="submit"
+	>
+		{#if isLoading}
+			<IconSpin classNames="text-gray-600 animate-spin" />
+		{:else}
+			{label}
+		{/if}
+	</button>
+{/if}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTableInput/WidgetTableInput.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTableInput/WidgetTableInput.svelte
@@ -12,6 +12,7 @@
 	export let canAddRow = true;
 	export let canAddCol = true;
 	export let isLoading = false;
+	export let isDisabled = false;
 
 	let initialTable: (string | number)[][] = [[]];
 	let tableContainerEl: HTMLElement;
@@ -64,7 +65,7 @@
 				<tr>
 					{#each table[0] as header, x}
 						<th
-							contenteditable={canAddCol && !isLoading}
+							contenteditable={canAddCol && !isLoading && !isDisabled}
 							class="h-6 border-2 border-gray-100"
 							on:keydown={onKeyDown}
 							on:input={e => editCell(e, [x, 0])}
@@ -80,7 +81,7 @@
 						{#each row as cell, x}
 							<td
 								class={(highlighted[`${y}-${x}`] ?? "border-gray-100") + " h-6 border-2"}
-								contenteditable={!isLoading}
+								contenteditable={!isLoading && !isDisabled}
 								on:keydown={onKeyDown}
 								on:input={e => editCell(e, [x, y + 1])}>{cell}</td
 							>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextInput/WidgetTextInput.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextInput/WidgetTextInput.svelte
@@ -12,7 +12,7 @@
 		<input
 			bind:value
 			class="{label ? 'mt-1.5' : ''} form-input-alt block w-full"
-			{placeholder}
+			placeholder={isDisabled ? "" : placeholder}
 			disabled={isDisabled}
 			type="text"
 		/>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextInput/WidgetTextInput.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextInput/WidgetTextInput.svelte
@@ -3,11 +3,18 @@
 
 	export let label: string | undefined = undefined;
 	export let placeholder: string = "Your sentence here...";
+	export let isDisabled = false;
 	export let value: string;
 </script>
 
 <WidgetLabel {label}>
 	<svelte:fragment slot="after">
-		<input bind:value class="{label ? 'mt-1.5' : ''} form-input-alt block w-full" {placeholder} type="text" />
+		<input
+			bind:value
+			class="{label ? 'mt-1.5' : ''} form-input-alt block w-full"
+			{placeholder}
+			disabled={isDisabled}
+			type="text"
+		/>
 	</svelte:fragment>
 </WidgetLabel>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -88,7 +88,7 @@
 				: 'min-h-[144px]'} inline-block max-h-[500px] whitespace-pre-wrap rounded-lg border border-gray-200 shadow-inner outline-none focus:shadow-inner focus:ring focus:ring-blue-200 dark:bg-gray-925"
 			role="textbox"
 			contenteditable={!isLoading && !isDisabled}
-			style="--placeholder: '{placeholder}'"
+			style="--placeholder: '{isDisabled ? '' : placeholder}'"
 			spellcheck="false"
 			dir="auto"
 			bind:this={containerSpanEl}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTextarea/WidgetTextarea.svelte
@@ -8,6 +8,7 @@
 	export let placeholder: string = "Your sentence here...";
 	export let value: string;
 	export let isLoading = false;
+	export let isDisabled = false;
 	export let size: "small" | "big" = "small";
 
 	let containerSpanEl: HTMLSpanElement;
@@ -82,13 +83,11 @@
 	<svelte:fragment slot="after">
 		<!-- `whitespace-pre-wrap inline-block` are needed to get correct newlines from `el.textContent` on Chrome -->
 		<span
-			class="{isLoading ? 'pointer-events-none' : ''} {label
-				? 'mt-1.5'
-				: ''} block w-full resize-y overflow-auto py-2 px-3 {size === 'small'
+			class="{label ? 'mt-1.5' : ''} block w-full resize-y overflow-auto py-2 px-3 {size === 'small'
 				? 'min-h-[42px]'
 				: 'min-h-[144px]'} inline-block max-h-[500px] whitespace-pre-wrap rounded-lg border border-gray-200 shadow-inner outline-none focus:shadow-inner focus:ring focus:ring-blue-200 dark:bg-gray-925"
 			role="textbox"
-			contenteditable
+			contenteditable={!isLoading && !isDisabled}
 			style="--placeholder: '{placeholder}'"
 			spellcheck="false"
 			dir="auto"

--- a/js/src/lib/components/InferenceWidget/shared/WidgetTimer/WidgetTimer.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetTimer/WidgetTimer.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { onDestroy } from "svelte";
 
+	export let isDisabled = false;
+
 	let counterSeconds = 0.0;
 	let interval: ReturnType<typeof setInterval>;
 	let shouldDisplay = false;
@@ -28,6 +30,6 @@
 	onDestroy(() => stop());
 </script>
 
-{#if shouldDisplay}
+{#if shouldDisplay && !isDisabled}
 	<span class="font-mono text-xs text-gray-500">{counterHuman}</span>
 {/if}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -39,8 +39,8 @@
 	let isMaximized = false;
 	let modelLoadInfo: ModelLoadInfo | undefined = undefined;
 	let selectedInputGroup: string;
+	let modelTooBig = false;
 
-	$: modelTooBig = $modelLoadStates[model.id]?.state === "TooBig";
 	$: isDisabled =
 		(model.inference !== InferenceDisplayability.Yes && model.pipeline_tag !== "reinforcement-learning") || modelTooBig;
 
@@ -53,8 +53,7 @@
 			...sample,
 		}));
 
-	// todo: here
-	const hasExampleWithOutput = !!inputSamples.length;
+	const hasExampleWithOutput = inputSamples.some(sample => !!sample.output);
 
 	const inputGroups: {
 		group: string;
@@ -74,6 +73,7 @@
 	onMount(() => {
 		(async () => {
 			modelLoadInfo = await getModelLoadInfo(apiUrl, model.id, includeCredentials);
+			modelTooBig = modelLoadInfo?.state === "TooBig";
 			$modelLoadStates[model.id] = modelLoadInfo;
 
 			const exampleFromQueryParams = {} as TWidgetExample;
@@ -103,7 +103,7 @@
 
 {#if isDisabled && !hasExampleWithOutput}
 	<WidgetHeader pipeline={model.pipeline_tag} noTitle={true} />
-	<WidgetInfo {model} {computeTime} {error} {modelLoadInfo} />
+	<WidgetInfo {model} {computeTime} {error} {modelLoadInfo} {modelTooBig} />
 {:else}
 	<div
 		class="flex w-full max-w-full flex-col
@@ -136,7 +136,7 @@
 			{/if}
 		</WidgetHeader>
 		<slot name="top" />
-		<WidgetInfo {model} {computeTime} {error} {modelLoadInfo} />
+		<WidgetInfo {model} {computeTime} {error} {modelLoadInfo} {modelTooBig} />
 		{#if modelLoading.isLoading}
 			<WidgetModelLoading estimatedTime={modelLoading.estimatedTime} />
 		{/if}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -97,46 +97,36 @@
 	{isMaximized ? 'fixed inset-0 z-20 bg-white p-12' : ''}
 	{!modelLoadInfo ? 'hidden' : ''}"
 >
-	{#if modelLoadInfo?.state === "TooBig"}
-		<p class="text-sm text-gray-500">
-			Model is supported, but too large to load onto the free Inference API. To try the model, launch it on <a
-				class="underline"
-				href="https://ui.endpoints.huggingface.co/new?repository={encodeURIComponent(model.id)}">Inference Endpoints</a
-			>
-			instead.
-		</p>
-	{:else}
-		{#if isMaximized}
-			<button class="absolute right-12 top-6" on:click={onClickMaximizeBtn}>
-				<IconCross classNames="text-xl text-gray-500 hover:text-black" />
-			</button>
-		{/if}
-		<WidgetHeader {noTitle} pipeline={model.pipeline_tag}>
-			{#if !!inputGroups.length}
-				<div class="ml-auto flex gap-x-1">
-					<!-- Show samples selector when there are more than one sample -->
-					{#if inputGroups.length > 1}
-						<WidgetInputSamplesGroup
-							bind:selectedInputGroup
-							{isLoading}
-							inputGroups={inputGroups.map(({ group }) => group)}
-						/>
-					{/if}
-					<WidgetInputSamples
-						classNames={!selectedInputSamples ? "opacity-50 pointer-events-none" : ""}
-						{isLoading}
-						inputSamples={selectedInputSamples?.inputSamples ?? []}
-						{applyInputSample}
-					/>
-				</div>
-			{/if}
-		</WidgetHeader>
-		<slot name="top" />
-		<WidgetInfo {model} {computeTime} {error} {modelLoadInfo} />
-		{#if modelLoading.isLoading}
-			<WidgetModelLoading estimatedTime={modelLoading.estimatedTime} />
-		{/if}
-		<slot name="bottom" />
-		<WidgetFooter {onClickMaximizeBtn} {outputJson} />
+	{#if isMaximized}
+		<button class="absolute right-12 top-6" on:click={onClickMaximizeBtn}>
+			<IconCross classNames="text-xl text-gray-500 hover:text-black" />
+		</button>
 	{/if}
+	<WidgetHeader {noTitle} pipeline={model.pipeline_tag}>
+		{#if !!inputGroups.length}
+			<div class="ml-auto flex gap-x-1">
+				<!-- Show samples selector when there are more than one sample -->
+				{#if inputGroups.length > 1}
+					<WidgetInputSamplesGroup
+						bind:selectedInputGroup
+						{isLoading}
+						inputGroups={inputGroups.map(({ group }) => group)}
+					/>
+				{/if}
+				<WidgetInputSamples
+					classNames={!selectedInputSamples ? "opacity-50 pointer-events-none" : ""}
+					{isLoading}
+					inputSamples={selectedInputSamples?.inputSamples ?? []}
+					{applyInputSample}
+				/>
+			</div>
+		{/if}
+	</WidgetHeader>
+	<slot name="top" />
+	<WidgetInfo {model} {computeTime} {error} {modelLoadInfo} />
+	{#if modelLoading.isLoading}
+		<WidgetModelLoading estimatedTime={modelLoading.estimatedTime} />
+	{/if}
+	<slot name="bottom" />
+	<WidgetFooter {onClickMaximizeBtn} {outputJson} />
 </div>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -47,7 +47,7 @@
 		inputSamples: TWidgetExample[];
 	}
 
-	const inputSamplesAll = (model.widgetData ?? [])
+	const allInputSamples = (model.widgetData ?? [])
 		.filter(validateExample)
 		.sort((sample1, sample2) => (sample2.example_title ? 1 : 0) - (sample1.example_title ? 1 : 0))
 		.map((sample, idx) => ({
@@ -55,7 +55,7 @@
 			group: "Group 1",
 			...sample,
 		}));
-	let inputSamples = !isDisabled ? inputSamplesAll : inputSamplesAll.filter(sample => sample.output !== undefined);
+	let inputSamples = !isDisabled ? allInputSamples : allInputSamples.filter(sample => sample.output !== undefined);
 	let inputGroups = getExamplesGroups();
 
 	$: selectedInputSamples =
@@ -82,7 +82,7 @@
 			if (modelTooBig) {
 				// disable the widget
 				isDisabled = true;
-				inputSamples = inputSamplesAll.filter(sample => sample.output !== undefined);
+				inputSamples = allInputSamples.filter(sample => sample.output !== undefined);
 				inputGroups = getExamplesGroups();
 			}
 

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -33,6 +33,7 @@
 	export let applyInputSample: (sample: TWidgetExample, opts?: ExampleRunOpts) => void = () => {};
 	export let validateExample: (sample: WidgetExample) => sample is TWidgetExample;
 	export let exampleQueryParams: QueryParam[] = [];
+	export let isDisabled = false;
 
 	let isMaximized = false;
 	let modelLoadInfo: ModelLoadInfo | undefined = undefined;
@@ -128,5 +129,5 @@
 		<WidgetModelLoading estimatedTime={modelLoading.estimatedTime} />
 	{/if}
 	<slot name="bottom" />
-	<WidgetFooter {onClickMaximizeBtn} {outputJson} />
+	<WidgetFooter {onClickMaximizeBtn} {outputJson} {isDisabled} />
 </div>

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -34,9 +34,8 @@
 	export let applyInputSample: (sample: TWidgetExample, opts?: ExampleRunOpts) => void = () => {};
 	export let validateExample: (sample: WidgetExample) => sample is TWidgetExample;
 	export let exampleQueryParams: QueryParam[] = [];
-	export let isDisabled = false;
-	isDisabled = model.inference !== InferenceDisplayability.Yes && model.pipeline_tag !== "reinforcement-learning";
 
+	let isDisabled = model.inference !== InferenceDisplayability.Yes && model.pipeline_tag !== "reinforcement-learning";
 	let isMaximized = false;
 	let modelLoadInfo: ModelLoadInfo | undefined = undefined;
 	let selectedInputGroup: string;
@@ -145,7 +144,7 @@
 				</div>
 			{/if}
 		</WidgetHeader>
-		<slot name="top" />
+		<slot name="top" {isDisabled} />
 		<WidgetInfo {model} {computeTime} {error} {modelLoadInfo} {modelTooBig} />
 		{#if modelLoading.isLoading}
 			<WidgetModelLoading estimatedTime={modelLoading.estimatedTime} />

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -64,8 +64,8 @@
 	function getExamplesGroups(): ExamplesGroup[] {
 		const inputGroups: ExamplesGroup[] = [];
 		for (const inputSample of inputSamples) {
-			const isExist = inputGroups.find(({ group }) => group === inputSample.group);
-			if (!isExist) {
+			const groupExists = inputGroups.find(({ group }) => group === inputSample.group);
+			if (!groupExists) {
 				inputGroups.push({ group: inputSample.group as string, inputSamples: [] });
 			}
 			inputGroups.find(({ group }) => group === inputSample.group)?.inputSamples.push(inputSample);

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -115,7 +115,7 @@
 				<IconCross classNames="text-xl text-gray-500 hover:text-black" />
 			</button>
 		{/if}
-		<WidgetHeader {noTitle} pipeline={model.pipeline_tag}>
+		<WidgetHeader {noTitle} pipeline={model.pipeline_tag} {isDisabled}>
 			{#if !!inputGroups.length}
 				<div class="ml-auto flex gap-x-1">
 					<!-- Show samples selector when there are more than one sample -->

--- a/js/src/lib/components/InferenceWidget/shared/helpers.ts
+++ b/js/src/lib/components/InferenceWidget/shared/helpers.ts
@@ -1,3 +1,4 @@
+import { InferenceDisplayability } from "../../../interfaces/InferenceDisplayability";
 import type { ModelData } from "../../../interfaces/Types";
 import { randomItem, parseJSON } from "../../../utils/ViewUtils";
 import type { WidgetExample } from "./WidgetExample";

--- a/js/src/lib/components/InferenceWidget/shared/helpers.ts
+++ b/js/src/lib/components/InferenceWidget/shared/helpers.ts
@@ -1,4 +1,3 @@
-import { InferenceDisplayability } from "../../../interfaces/InferenceDisplayability";
 import type { ModelData } from "../../../interfaces/Types";
 import { randomItem, parseJSON } from "../../../utils/ViewUtils";
 import type { WidgetExample } from "./WidgetExample";

--- a/js/src/lib/components/InferenceWidget/shared/types.ts
+++ b/js/src/lib/components/InferenceWidget/shared/types.ts
@@ -10,6 +10,7 @@ export interface WidgetProps {
 	shouldUpdateUrl:    boolean;
 	includeCredentials: boolean;
 	isLoggedIn?:        boolean;
+	isDisabled?:        boolean;
 }
 
 export interface InferenceRunOpts<TOutput = WidgetExampleOutput> {

--- a/js/src/lib/components/InferenceWidget/shared/types.ts
+++ b/js/src/lib/components/InferenceWidget/shared/types.ts
@@ -10,7 +10,6 @@ export interface WidgetProps {
 	shouldUpdateUrl:    boolean;
 	includeCredentials: boolean;
 	isLoggedIn?:        boolean;
-	isDisabled?:        boolean;
 }
 
 export interface InferenceRunOpts<TOutput = WidgetExampleOutput> {

--- a/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
@@ -18,7 +18,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -164,7 +164,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
@@ -18,6 +18,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -163,6 +164,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -171,7 +173,7 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<div class="flex flex-wrap items-center">
+			<div class="flex flex-wrap items-center {isDisabled ? 'pointer-events-none opacity-50' : ''}">
 				<WidgetFileInput accept="audio/*" classNames="mt-1.5 mr-2" {onSelectFile} />
 				<span class="mr-2 mt-1.5">or</span>
 				<WidgetRecorder classNames="mt-1.5" {onRecordStart} onRecordStop={onSelectFile} onError={onRecordError} />
@@ -181,7 +183,7 @@
 			{/if}
 			<WidgetSubmitBtn
 				classNames="mt-2"
-				isDisabled={isRecording}
+				isDisabled={isRecording || isDisabled}
 				{isLoading}
 				onClick={() => {
 					getOutput();

--- a/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
@@ -173,7 +173,7 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<div class="flex flex-wrap items-center {isDisabled ? 'pointer-events-none opacity-50' : ''}">
+			<div class="flex flex-wrap items-center {isDisabled ? 'pointer-events-none hidden opacity-50' : ''}">
 				<WidgetFileInput accept="audio/*" classNames="mt-1.5 mr-2" {onSelectFile} />
 				<span class="mr-2 mt-1.5">or</span>
 				<WidgetRecorder classNames="mt-1.5" {onRecordStart} onRecordStop={onSelectFile} onError={onRecordError} />

--- a/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioClassificationWidget/AudioClassificationWidget.svelte
@@ -164,14 +164,13 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
 	{outputJson}
 	{validateExample}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form>
 			<div class="flex flex-wrap items-center {isDisabled ? 'pointer-events-none hidden opacity-50' : ''}">
 				<WidgetFileInput accept="audio/*" classNames="mt-1.5 mr-2" {onSelectFile} />

--- a/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -16,6 +16,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -151,6 +152,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -159,7 +161,7 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<div class="flex flex-wrap items-center">
+			<div class="flex flex-wrap items-center {isDisabled ? 'pointer-events-none opacity-50' : ''}">
 				<WidgetFileInput accept="audio/*" classNames="mt-1.5 mr-2" {onSelectFile} />
 				<span class="mr-2 mt-1.5">or</span>
 				<WidgetRecorder classNames="mt-1.5" {onRecordStart} onRecordStop={onSelectFile} onError={onRecordError} />
@@ -169,7 +171,7 @@
 			{/if}
 			<WidgetSubmitBtn
 				classNames="mt-2"
-				isDisabled={isRecording}
+				isDisabled={isRecording || isDisabled}
 				{isLoading}
 				onClick={() => {
 					getOutput();

--- a/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -16,7 +16,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -152,7 +152,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -152,14 +152,13 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
 	{outputJson}
 	validateExample={isAssetInput}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form>
 			<div class="flex flex-wrap items-center {isDisabled ? 'pointer-events-none hidden opacity-50' : ''}">
 				<WidgetFileInput accept="audio/*" classNames="mt-1.5 mr-2" {onSelectFile} />

--- a/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AudioToAudioWidget/AudioToAudioWidget.svelte
@@ -161,7 +161,7 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<div class="flex flex-wrap items-center {isDisabled ? 'pointer-events-none opacity-50' : ''}">
+			<div class="flex flex-wrap items-center {isDisabled ? 'pointer-events-none hidden opacity-50' : ''}">
 				<WidgetFileInput accept="audio/*" classNames="mt-1.5 mr-2" {onSelectFile} />
 				<span class="mr-2 mt-1.5">or</span>
 				<WidgetRecorder classNames="mt-1.5" {onRecordStart} onRecordStop={onSelectFile} onError={onRecordError} />

--- a/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -169,14 +169,13 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
 	{outputJson}
 	{validateExample}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form>
 			<div class="flex flex-wrap items-center {isDisabled ? 'pointer-events-none hidden opacity-50' : ''}">
 				{#if !isRealtimeRecording}

--- a/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -178,7 +178,7 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<div class="flex flex-wrap items-center {isDisabled ? 'pointer-events-none opacity-50' : ''}">
+			<div class="flex flex-wrap items-center {isDisabled ? 'pointer-events-none hidden opacity-50' : ''}">
 				{#if !isRealtimeRecording}
 					<WidgetFileInput accept="audio/*" classNames="mt-1.5" {onSelectFile} />
 					<span class="mx-2 mt-1.5">or</span>

--- a/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -19,7 +19,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -169,7 +169,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/AutomaticSpeechRecognitionWidget/AutomaticSpeechRecognitionWidget.svelte
@@ -19,6 +19,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -168,6 +169,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -176,7 +178,7 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<div class="flex flex-wrap items-center">
+			<div class="flex flex-wrap items-center {isDisabled ? 'pointer-events-none opacity-50' : ''}">
 				{#if !isRealtimeRecording}
 					<WidgetFileInput accept="audio/*" classNames="mt-1.5" {onSelectFile} />
 					<span class="mx-2 mt-1.5">or</span>
@@ -203,7 +205,7 @@
 				{/if}
 				<WidgetSubmitBtn
 					classNames="mt-2"
-					isDisabled={isRecording}
+					isDisabled={isRecording || isDisabled}
 					{isLoading}
 					onClick={() => {
 						getOutput();

--- a/js/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
@@ -15,6 +15,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	interface Conversation {
 		generated_responses: string[];
@@ -160,6 +161,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -174,6 +176,7 @@
 				bind:value={text}
 				flatTop={true}
 				{isLoading}
+				{isDisabled}
 				onClickSubmitBtn={() => {
 					getOutput();
 				}}

--- a/js/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
@@ -15,7 +15,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	interface Conversation {
 		generated_responses: string[];
@@ -161,7 +161,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
@@ -161,7 +161,6 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -169,7 +168,7 @@
 	validateExample={isTextInput}
 	exampleQueryParams={["text"]}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<WidgetOutputConvo modelId={model.id} {output} />
 		<form>
 			<WidgetQuickInput

--- a/js/src/lib/components/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
@@ -129,7 +129,6 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -137,7 +136,7 @@
 	validateExample={isTextInput}
 	exampleQueryParams={["text"]}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form>
 			<WidgetQuickInput
 				bind:value={text}

--- a/js/src/lib/components/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
@@ -16,7 +16,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -129,7 +129,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FeatureExtractionWidget/FeatureExtractionWidget.svelte
@@ -16,6 +16,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -128,6 +129,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -140,6 +142,7 @@
 			<WidgetQuickInput
 				bind:value={text}
 				{isLoading}
+				{isDisabled}
 				onClickSubmitBtn={() => {
 					getOutput();
 				}}

--- a/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
@@ -17,6 +17,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -139,6 +140,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -153,10 +155,11 @@
 					Mask token: <code>{model.mask_token}</code>
 				</div>
 			{/if}
-			<WidgetTextarea bind:value={text} bind:setValue={setTextAreaValue} />
+			<WidgetTextarea bind:value={text} bind:setValue={setTextAreaValue} {isDisabled} />
 			<WidgetSubmitBtn
 				classNames="mt-2"
 				{isLoading}
+				{isDisabled}
 				onClick={() => {
 					getOutput();
 				}}

--- a/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
@@ -140,7 +140,6 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -148,7 +147,7 @@
 	{validateExample}
 	exampleQueryParams={["text"]}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form>
 			{#if model.pipeline_tag === "fill-mask"}
 				<div class="mb-1.5 text-sm text-gray-500">

--- a/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
@@ -17,7 +17,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -140,7 +140,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -16,7 +16,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -126,7 +126,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -16,6 +16,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -125,6 +126,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -133,7 +135,14 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<WidgetDropzone classNames="no-hover:hidden" {isLoading} {imgSrc} {onSelectFile} onError={e => (error = e)}>
+			<WidgetDropzone
+				classNames="no-hover:hidden"
+				{isLoading}
+				{isDisabled}
+				{imgSrc}
+				{onSelectFile}
+				onError={e => (error = e)}
+			>
 				{#if imgSrc}
 					<img src={imgSrc} class="pointer-events-none mx-auto max-h-44 shadow" alt="" />
 				{/if}
@@ -150,6 +159,7 @@
 				accept="image/*"
 				classNames="mr-2 md:hidden"
 				{isLoading}
+				{isDisabled}
 				label="Browse for image"
 				{onSelectFile}
 			/>

--- a/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageClassificationWidget/ImageClassificationWidget.svelte
@@ -126,14 +126,13 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
 	{outputJson}
 	{validateExample}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form>
 			<WidgetDropzone
 				classNames="no-hover:hidden"

--- a/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
@@ -21,6 +21,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	const maskOpacity = Math.floor(255 * 0.6);
 	const colorToRgb = COLORS.reduce((acc, clr) => {
@@ -236,6 +237,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -244,7 +246,14 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<WidgetDropzone classNames="hidden md:block" {isLoading} {imgSrc} {onSelectFile} onError={e => (error = e)}>
+			<WidgetDropzone
+				classNames="hidden md:block"
+				{isLoading}
+				{isDisabled}
+				{imgSrc}
+				{onSelectFile}
+				onError={e => (error = e)}
+			>
 				{#if imgSrc}
 					<Canvas {imgSrc} {highlightIndex} {mousemove} {mouseout} {output} />
 				{/if}
@@ -257,6 +266,7 @@
 				accept="image/*"
 				classNames="mr-2 md:hidden"
 				{isLoading}
+				{isDisabled}
 				label="Browse for image"
 				{onSelectFile}
 			/>

--- a/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
@@ -237,14 +237,13 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
 	{outputJson}
 	validateExample={isAssetInput}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form>
 			<WidgetDropzone
 				classNames="hidden md:block"

--- a/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageSegmentationWidget/ImageSegmentationWidget.svelte
@@ -21,7 +21,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	const maskOpacity = Math.floor(255 * 0.6);
 	const colorToRgb = COLORS.reduce((acc, clr) => {
@@ -237,7 +237,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToImageWidget/ImageToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToImageWidget/ImageToImageWidget.svelte
@@ -16,6 +16,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -141,6 +142,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -149,7 +151,14 @@
 >
 	<svelte:fragment slot="top">
 		<form class="space-y-2">
-			<WidgetDropzone classNames="hidden md:block" {isLoading} {imgSrc} {onSelectFile} onError={e => (error = e)}>
+			<WidgetDropzone
+				classNames="hidden md:block"
+				{isLoading}
+				{isDisabled}
+				{imgSrc}
+				{onSelectFile}
+				onError={e => (error = e)}
+			>
 				{#if imgSrc}
 					<img src={imgSrc} class="pointer-events-none mx-auto max-h-44 shadow" alt="" />
 				{/if}
@@ -166,16 +175,19 @@
 				accept="image/*"
 				classNames="mr-2 md:hidden"
 				{isLoading}
+				{isDisabled}
 				label="Browse for image"
 				{onSelectFile}
 			/>
 			<WidgetTextInput
 				bind:value={prompt}
+				{isDisabled}
 				label="(Optional) Text-guidance if the model has support for it"
 				placeholder="Your prompt here..."
 			/>
 			<WidgetSubmitBtn
 				{isLoading}
+				{isDisabled}
 				onClick={() => {
 					getOutput();
 				}}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToImageWidget/ImageToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToImageWidget/ImageToImageWidget.svelte
@@ -16,7 +16,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -142,7 +142,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToImageWidget/ImageToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToImageWidget/ImageToImageWidget.svelte
@@ -142,14 +142,13 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
 	{outputJson}
 	validateExample={isAssetAndPromptInput}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form class="space-y-2">
 			<WidgetDropzone
 				classNames="hidden md:block"

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
@@ -113,14 +113,13 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
 	{outputJson}
 	validateExample={isAssetInput}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form>
 			<WidgetDropzone
 				classNames="hidden md:block"

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
@@ -15,6 +15,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -112,6 +113,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -120,7 +122,14 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<WidgetDropzone classNames="hidden md:block" {isLoading} {imgSrc} {onSelectFile} onError={e => (error = e)}>
+			<WidgetDropzone
+				classNames="hidden md:block"
+				{isLoading}
+				{isDisabled}
+				{imgSrc}
+				{onSelectFile}
+				onError={e => (error = e)}
+			>
 				{#if imgSrc}
 					<img src={imgSrc} class="pointer-events-none mx-auto max-h-44 shadow" alt="" />
 				{/if}
@@ -137,6 +146,7 @@
 				accept="image/*"
 				classNames="mr-2 md:hidden"
 				{isLoading}
+				{isDisabled}
 				label="Browse for image"
 				{onSelectFile}
 			/>

--- a/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ImageToTextWidget/ImageToTextWidget.svelte
@@ -15,7 +15,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -113,7 +113,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
@@ -19,7 +19,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -150,7 +150,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
@@ -150,14 +150,13 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
 	{outputJson}
 	validateExample={isAssetInput}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form>
 			<WidgetDropzone
 				classNames="hidden md:block"

--- a/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte
@@ -19,6 +19,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -149,6 +150,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -157,7 +159,14 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<WidgetDropzone classNames="hidden md:block" {isLoading} {imgSrc} {onSelectFile} onError={e => (error = e)}>
+			<WidgetDropzone
+				classNames="hidden md:block"
+				{isLoading}
+				{isDisabled}
+				{imgSrc}
+				{onSelectFile}
+				onError={e => (error = e)}
+			>
 				{#if imgSrc}
 					<BoundingBoxes {imgSrc} {mouseover} {mouseout} {output} {highlightIndex} />
 				{/if}
@@ -170,6 +179,7 @@
 				accept="image/*"
 				classNames="mr-2 md:hidden"
 				{isLoading}
+				{isDisabled}
 				label="Browse for image"
 				{onSelectFile}
 			/>

--- a/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
@@ -20,7 +20,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let context = "";
 	let computeTime = "";
@@ -137,7 +137,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
@@ -137,7 +137,6 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -145,7 +144,7 @@
 	{validateExample}
 	exampleQueryParams={["context", "text"]}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form class="space-y-2">
 			<WidgetQuickInput
 				bind:value={question}

--- a/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/QuestionAnsweringWidget/QuestionAnsweringWidget.svelte
@@ -20,6 +20,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let context = "";
 	let computeTime = "";
@@ -136,6 +137,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -148,6 +150,7 @@
 			<WidgetQuickInput
 				bind:value={question}
 				{isLoading}
+				{isDisabled}
 				onClickSubmitBtn={() => {
 					getOutput();
 				}}
@@ -155,6 +158,7 @@
 			<WidgetTextarea
 				bind:value={context}
 				bind:setValue={setTextAreaValue}
+				{isDisabled}
 				placeholder="Please input some context..."
 				label="Context"
 			/>

--- a/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
@@ -155,13 +155,13 @@
 				bind:value={sourceSentence}
 				{isDisabled}
 				label="Source Sentence"
-				placeholder="Your sentence here..."
+				placeholder={isDisabled ? "" : "Your sentence here..."}
 			/>
 			<WidgetTextInput
 				bind:value={comparisonSentences[0]}
 				{isDisabled}
 				label="Sentences to compare to"
-				placeholder="Your sentence here..."
+				placeholder={isDisabled ? "" : "Your sentence here..."}
 			/>
 			{#each Array(nComparisonSentences - 1) as _, idx}
 				<WidgetTextInput bind:value={comparisonSentences[idx + 1]} {isDisabled} placeholder="Your sentence here..." />

--- a/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
@@ -16,7 +16,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let sourceSentence = "";
 	let comparisonSentences: Array<string> = [];
@@ -142,7 +142,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
@@ -16,6 +16,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let sourceSentence = "";
 	let comparisonSentences: Array<string> = [];
@@ -141,6 +142,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -149,23 +151,30 @@
 >
 	<svelte:fragment slot="top">
 		<form class="flex flex-col space-y-2">
-			<WidgetTextInput bind:value={sourceSentence} label="Source Sentence" placeholder="Your sentence here..." />
+			<WidgetTextInput
+				bind:value={sourceSentence}
+				{isDisabled}
+				label="Source Sentence"
+				placeholder="Your sentence here..."
+			/>
 			<WidgetTextInput
 				bind:value={comparisonSentences[0]}
+				{isDisabled}
 				label="Sentences to compare to"
 				placeholder="Your sentence here..."
 			/>
 			{#each Array(nComparisonSentences - 1) as _, idx}
-				<WidgetTextInput bind:value={comparisonSentences[idx + 1]} placeholder="Your sentence here..." />
+				<WidgetTextInput bind:value={comparisonSentences[idx + 1]} {isDisabled} placeholder="Your sentence here..." />
 			{/each}
 			<WidgetAddSentenceBtn
-				isDisabled={nComparisonSentences === maxComparisonSentences}
+				isDisabled={nComparisonSentences === maxComparisonSentences || isDisabled}
 				onClick={() => {
 					nComparisonSentences++;
 				}}
 			/>
 			<WidgetSubmitBtn
 				{isLoading}
+				{isDisabled}
 				onClick={() => {
 					getOutput();
 				}}

--- a/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SentenceSimilarityWidget/SentenceSimilarityWidget.svelte
@@ -142,14 +142,13 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
 	{outputJson}
 	validateExample={isSentenceSimilarityInput}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form class="flex flex-col space-y-2">
 			<WidgetTextInput
 				bind:value={sourceSentence}

--- a/js/src/lib/components/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
@@ -16,6 +16,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -111,6 +112,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -120,9 +122,10 @@
 >
 	<svelte:fragment slot="top">
 		<form class="space-y-2">
-			<WidgetTextarea bind:value={text} bind:setValue={setTextAreaValue} />
+			<WidgetTextarea bind:value={text} bind:setValue={setTextAreaValue} {isDisabled} />
 			<WidgetSubmitBtn
 				{isLoading}
+				{isDisabled}
 				onClick={() => {
 					getOutput();
 				}}

--- a/js/src/lib/components/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
@@ -16,7 +16,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -112,7 +112,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/SummarizationWidget/SummarizationWidget.svelte
@@ -112,7 +112,6 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -120,7 +119,7 @@
 	validateExample={isTextInput}
 	exampleQueryParams={["text"]}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form class="space-y-2">
 			<WidgetTextarea bind:value={text} bind:setValue={setTextAreaValue} {isDisabled} />
 			<WidgetSubmitBtn

--- a/js/src/lib/components/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
@@ -162,7 +162,6 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -170,7 +169,7 @@
 	validateExample={isTextAndTableInput}
 	exampleQueryParams={["text", "table"]}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form>
 			<WidgetQuickInput
 				bind:value={query}

--- a/js/src/lib/components/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
@@ -28,6 +28,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -161,6 +162,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -173,6 +175,7 @@
 			<WidgetQuickInput
 				bind:value={query}
 				{isLoading}
+				{isDisabled}
 				onClickSubmitBtn={() => {
 					getOutput();
 				}}
@@ -183,7 +186,7 @@
 				<WidgetOutputTableQA {output} {isAnswerOnlyOutput} />
 			{/if}
 			{#if table.length > 1 || table[0].length > 1}
-				<WidgetTableInput {highlighted} onChange={onChangeTable} {table} />
+				<WidgetTableInput {highlighted} onChange={onChangeTable} {table} {isDisabled} />
 			{/if}
 		</div>
 	</svelte:fragment>

--- a/js/src/lib/components/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TableQuestionAnsweringWidget/TableQuestionAnsweringWidget.svelte
@@ -28,7 +28,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -162,7 +162,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/TabularDataWidget/TabularDataWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TabularDataWidget/TabularDataWidget.svelte
@@ -186,7 +186,6 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -194,7 +193,7 @@
 	validateExample={isStructuredDataInput}
 	exampleQueryParams={["structured_data"]}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form>
 			<div class="mt-4">
 				{#if table.length > 1 || table[1]?.length > 1}

--- a/js/src/lib/components/InferenceWidget/widgets/TabularDataWidget/TabularDataWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TabularDataWidget/TabularDataWidget.svelte
@@ -22,6 +22,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	const widgetData = model?.widgetData?.[0] as WidgetExampleStructuredDataInput<WidgetExampleOutputLabels> | undefined;
 	const columns: string[] = Object.keys(widgetData?.structured_data ?? {});
@@ -185,6 +186,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -199,6 +201,7 @@
 					<WidgetTableInput
 						{highlighted}
 						{isLoading}
+						{isDisabled}
 						onChange={onChangeTable}
 						table={tableWithOutput}
 						canAddCol={false}
@@ -208,6 +211,7 @@
 			</div>
 			<WidgetSubmitBtn
 				{isLoading}
+				{isDisabled}
 				onClick={() => {
 					getOutput();
 				}}

--- a/js/src/lib/components/InferenceWidget/widgets/TabularDataWidget/TabularDataWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TabularDataWidget/TabularDataWidget.svelte
@@ -22,7 +22,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	const widgetData = model?.widgetData?.[0] as WidgetExampleStructuredDataInput<WidgetExampleOutputLabels> | undefined;
 	const columns: string[] = Object.keys(widgetData?.structured_data ?? {});
@@ -186,7 +186,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -231,7 +231,7 @@
 				/>
 				<WidgetShortcutRunLabel {isLoading} {isDisabled} />
 				<div class="ml-auto self-start">
-					<WidgetTimer bind:this={inferenceTimer} />
+					<WidgetTimer bind:this={inferenceTimer} {isDisabled} />
 				</div>
 			</div>
 			{#if warning}

--- a/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -229,7 +229,7 @@
 						getOutput({ useCache });
 					}}
 				/>
-				<WidgetShortcutRunLabel {isLoading} />
+				<WidgetShortcutRunLabel {isLoading} {isDisabled} />
 				<div class="ml-auto self-start">
 					<WidgetTimer bind:this={inferenceTimer} />
 				</div>

--- a/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -200,7 +200,6 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -208,7 +207,7 @@
 	{validateExample}
 	exampleQueryParams={["text"]}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form class="space-y-2">
 			<WidgetTextarea
 				bind:value={text}

--- a/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -22,6 +22,7 @@
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
 	export let isLoggedIn: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	const isBloomLoginRequired = isLoggedIn === false && model.id === "bigscience/bloom";
 
@@ -199,6 +200,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -212,6 +214,7 @@
 				bind:value={text}
 				bind:setValue={setTextAreaValue}
 				{isLoading}
+				{isDisabled}
 				size="big"
 				bind:renderTypingEffect
 			/>
@@ -221,6 +224,7 @@
 			<div class="flex items-center gap-x-2 {isBloomLoginRequired ? 'pointer-events-none opacity-50' : ''}">
 				<WidgetSubmitBtn
 					{isLoading}
+					{isDisabled}
 					onClick={() => {
 						getOutput({ useCache });
 					}}

--- a/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte
@@ -22,7 +22,7 @@
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
 	export let isLoggedIn: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	const isBloomLoginRequired = isLoggedIn === false && model.id === "bigscience/bloom";
 
@@ -200,7 +200,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
@@ -15,6 +15,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -124,6 +125,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -133,7 +135,7 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<WidgetQuickInput bind:value={text} {isLoading} onClickSubmitBtn={() => getOutput()} />
+			<WidgetQuickInput bind:value={text} {isLoading} {isDisabled} onClickSubmitBtn={() => getOutput()} />
 		</form>
 	</svelte:fragment>
 	<svelte:fragment slot="bottom">

--- a/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
@@ -125,7 +125,6 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -133,7 +132,7 @@
 	{validateExample}
 	exampleQueryParams={["text"]}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form>
 			<WidgetQuickInput bind:value={text} {isLoading} {isDisabled} onClickSubmitBtn={() => getOutput()} />
 		</form>

--- a/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToImageWidget/TextToImageWidget.svelte
@@ -15,7 +15,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -125,7 +125,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
@@ -16,7 +16,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -111,7 +111,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
@@ -111,7 +111,6 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -119,7 +118,7 @@
 	validateExample={isTextInput}
 	exampleQueryParams={["text"]}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form>
 			<WidgetTextarea bind:value={text} bind:setValue={setTextAreaValue} {isDisabled} />
 			<WidgetSubmitBtn

--- a/js/src/lib/components/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TextToSpeechWidget/TextToSpeechWidget.svelte
@@ -16,6 +16,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -110,6 +111,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -119,10 +121,11 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<WidgetTextarea bind:value={text} bind:setValue={setTextAreaValue} />
+			<WidgetTextarea bind:value={text} bind:setValue={setTextAreaValue} {isDisabled} />
 			<WidgetSubmitBtn
 				classNames="mt-2"
 				{isLoading}
+				{isDisabled}
 				onClick={() => {
 					getOutput();
 				}}

--- a/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
@@ -31,7 +31,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -231,7 +231,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
@@ -231,7 +231,6 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -239,7 +238,7 @@
 	validateExample={isTextInput}
 	exampleQueryParams={["text"]}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form>
 			<WidgetTextarea bind:value={text} bind:setValue={setTextAreaValue} {isDisabled} />
 			<WidgetSubmitBtn

--- a/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/TokenClassificationWidget/TokenClassificationWidget.svelte
@@ -31,6 +31,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -230,6 +231,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -239,10 +241,11 @@
 >
 	<svelte:fragment slot="top">
 		<form>
-			<WidgetTextarea bind:value={text} bind:setValue={setTextAreaValue} />
+			<WidgetTextarea bind:value={text} bind:setValue={setTextAreaValue} {isDisabled} />
 			<WidgetSubmitBtn
 				classNames="mt-2"
 				{isLoading}
+				{isDisabled}
 				onClick={() => {
 					getOutput();
 				}}

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -16,6 +16,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -149,6 +150,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -157,7 +159,14 @@
 >
 	<svelte:fragment slot="top">
 		<form class="space-y-2">
-			<WidgetDropzone classNames="hidden md:block" {isLoading} {imgSrc} {onSelectFile} onError={e => (error = e)}>
+			<WidgetDropzone
+				classNames="hidden md:block"
+				{isLoading}
+				{isDisabled}
+				{imgSrc}
+				{onSelectFile}
+				onError={e => (error = e)}
+			>
 				{#if imgSrc}
 					<img src={imgSrc} class="pointer-events-none mx-auto max-h-44 shadow" alt="" />
 				{/if}
@@ -174,12 +183,14 @@
 				accept="image/*"
 				classNames="mr-2 md:hidden"
 				{isLoading}
+				{isDisabled}
 				label="Browse for image"
 				{onSelectFile}
 			/>
 			<WidgetQuickInput
 				bind:value={question}
 				{isLoading}
+				{isDisabled}
 				onClickSubmitBtn={() => {
 					getOutput();
 				}}

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -16,7 +16,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let computeTime = "";
 	let error: string = "";
@@ -150,7 +150,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/VisualQuestionAnsweringWidget/VisualQuestionAnsweringWidget.svelte
@@ -150,14 +150,13 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
 	{outputJson}
 	validateExample={isAssetAndTextInput}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form class="space-y-2">
 			<WidgetDropzone
 				classNames="hidden md:block"

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
@@ -19,6 +19,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let candidateLabels = "";
 	let computeTime = "";
@@ -164,6 +165,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -172,7 +174,14 @@
 >
 	<svelte:fragment slot="top">
 		<form class="space-y-2">
-			<WidgetDropzone classNames="hidden md:block" {isLoading} {imgSrc} {onSelectFile} onError={e => (error = e)}>
+			<WidgetDropzone
+				classNames="hidden md:block"
+				{isLoading}
+				{isDisabled}
+				{imgSrc}
+				{onSelectFile}
+				onError={e => (error = e)}
+			>
 				{#if imgSrc}
 					<img src={imgSrc} class="pointer-events-none mx-auto max-h-44 shadow" alt="" />
 				{/if}
@@ -189,16 +198,19 @@
 				accept="image/*"
 				classNames="mr-2 md:hidden"
 				{isLoading}
+				{isDisabled}
 				label="Browse for image"
 				{onSelectFile}
 			/>
 			<WidgetTextInput
 				bind:value={candidateLabels}
+				{isDisabled}
 				label="Possible class names (comma-separated)"
 				placeholder="Possible class names..."
 			/>
 			<WidgetSubmitBtn
 				{isLoading}
+				{isDisabled}
 				onClick={() => {
 					getOutput();
 				}}

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
@@ -165,14 +165,13 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
 	{outputJson}
 	validateExample={isAssetAndZeroShotInput}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form class="space-y-2">
 			<WidgetDropzone
 				classNames="hidden md:block"

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShotImageClassificationWidget/ZeroShotImageClassificationWidget.svelte
@@ -19,7 +19,7 @@
 	export let model: WidgetProps["model"];
 	export let noTitle: WidgetProps["noTitle"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let candidateLabels = "";
 	let computeTime = "";
@@ -165,7 +165,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
@@ -146,7 +146,6 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -154,7 +153,7 @@
 	validateExample={isZeroShotTextInput}
 	exampleQueryParams={["candidate_labels", "multi_class", "text"]}
 >
-	<svelte:fragment slot="top">
+	<svelte:fragment slot="top" let:isDisabled>
 		<form class="flex flex-col space-y-2">
 			<WidgetTextarea
 				bind:value={text}

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
@@ -18,7 +18,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
-	export let isDisabled: WidgetProps["isDisabled"] = false;
+	let isDisabled = false;
 
 	let candidateLabels = "";
 	let computeTime = "";
@@ -146,7 +146,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
-	{isDisabled}
+	bind:isDisabled
 	{model}
 	{modelLoading}
 	{noTitle}

--- a/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/ZeroShowClassificationWidget/ZeroShotClassificationWidget.svelte
@@ -18,6 +18,7 @@
 	export let noTitle: WidgetProps["noTitle"];
 	export let shouldUpdateUrl: WidgetProps["shouldUpdateUrl"];
 	export let includeCredentials: WidgetProps["includeCredentials"];
+	export let isDisabled: WidgetProps["isDisabled"] = false;
 
 	let candidateLabels = "";
 	let computeTime = "";
@@ -145,6 +146,7 @@
 	{computeTime}
 	{error}
 	{isLoading}
+	{isDisabled}
 	{model}
 	{modelLoading}
 	{noTitle}
@@ -154,15 +156,22 @@
 >
 	<svelte:fragment slot="top">
 		<form class="flex flex-col space-y-2">
-			<WidgetTextarea bind:value={text} bind:setValue={setTextAreaValue} placeholder="Text to classify..." />
+			<WidgetTextarea
+				bind:value={text}
+				bind:setValue={setTextAreaValue}
+				{isDisabled}
+				placeholder="Text to classify..."
+			/>
 			<WidgetTextInput
 				bind:value={candidateLabels}
+				{isDisabled}
 				label="Possible class names (comma-separated)"
 				placeholder="Possible class names..."
 			/>
 			<WidgetCheckbox bind:checked={multiClass} label="Allow multiple true classes" />
 			<WidgetSubmitBtn
 				{isLoading}
+				{isDisabled}
 				onClick={() => {
 					getOutput();
 				}}

--- a/js/src/lib/interfaces/Types.ts
+++ b/js/src/lib/interfaces/Types.ts
@@ -1,4 +1,5 @@
 import type { WidgetExample } from "../components/InferenceWidget/shared/WidgetExample";
+import type { InferenceDisplayability } from "./InferenceDisplayability";
 
 // Warning: order of modalities here determine how they are listed on the /tasks page
 export const MODALITIES = ["cv", "nlp", "audio", "tabular", "multimodal", "rl", "other"] as const;
@@ -667,6 +668,10 @@ export interface ModelData {
 	 * Kept for backward compatibility
 	 */
 	modelId?:          string;
+	/**
+	 * Whether or not to enable inference widget for this model
+	 */
+	inference:         InferenceDisplayability;
 	/**
 	 * is this model private?
 	 */

--- a/js/src/routes/index.svelte
+++ b/js/src/routes/index.svelte
@@ -3,27 +3,33 @@
 
 	import InferenceWidget from "../lib/components/InferenceWidget/InferenceWidget.svelte";
 	import ModeSwitcher from "../lib/components/DemoThemeSwitcher/DemoThemeSwitcher.svelte";
+	import { InferenceDisplayability } from "../lib/interfaces/InferenceDisplayability";
 
 	const models: ModelData[] = [
 		{
 			id: "WizardLM/WizardLM-70B-V1.0",
 			pipeline_tag: "text-generation",
+			inference: InferenceDisplayability.Yes,
 		},
 		{
 			id: "openai/clip-vit-base-patch16",
 			pipeline_tag: "zero-shot-image-classification",
+			inference: InferenceDisplayability.Yes,
 		},
 		{
 			id: "lllyasviel/sd-controlnet-canny",
 			pipeline_tag: "image-to-image",
+			inference: InferenceDisplayability.Yes,
 		},
 		{
 			id: "ydshieh/vit-gpt2-coco-en",
 			pipeline_tag: "image-to-text",
+			inference: InferenceDisplayability.Yes,
 		},
 		{
 			id: "impira/layoutlm-document-qa",
 			pipeline_tag: "document-question-answering",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					text: "What is the invoice number?",
@@ -38,10 +44,12 @@
 		{
 			id: "skops/hf_hub_example-bdc26c1f-7e82-42eb-9657-0318315f2df0",
 			pipeline_tag: "tabular-classification",
+			inference: InferenceDisplayability.Yes,
 		},
 		{
 			id: "dandelin/vilt-b32-finetuned-vqa",
 			pipeline_tag: "visual-question-answering",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					text: "What animal is it?",
@@ -56,6 +64,7 @@
 		{
 			id: "roberta-large-mnli",
 			pipeline_tag: "text-classification",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					text: "I like you. I love you.",
@@ -76,10 +85,12 @@
 		{
 			id: "edbeeching/decision-transformer-gym-hopper-medium-replay",
 			pipeline_tag: "reinforcement-learning",
+			inference: InferenceDisplayability.Yes,
 		},
 		{
 			id: "sgugger/resnet50d",
 			pipeline_tag: "image-classification",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					src: "https://huggingface.co/datasets/mishig/sample_images/resolve/main/tiger.jpg",
@@ -120,24 +131,29 @@
 		{
 			id: "facebook/detr-resnet-50",
 			pipeline_tag: "object-detection",
+			inference: InferenceDisplayability.Yes,
 		},
 		{
 			id: "facebook/detr-resnet-50-panoptic",
 			pipeline_tag: "image-segmentation",
+			inference: InferenceDisplayability.Yes,
 		},
 		{
 			id: "julien-c/distilbert-feature-extraction",
 			pipeline_tag: "feature-extraction",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [{ text: "Hello world" }],
 		},
 		{
 			id: "sentence-transformers/distilbert-base-nli-stsb-mean-tokens",
 			pipeline_tag: "feature-extraction",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [{ text: "Hello, world" }],
 		},
 		{
 			id: "dbmdz/bert-large-cased-finetuned-conll03-english",
 			pipeline_tag: "token-classification",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{ text: "My name is Wolfgang and I live in Berlin" },
 				{ text: "My name is Sarah and I live in London" },
@@ -147,6 +163,7 @@
 		{
 			id: "distilbert-base-uncased-distilled-squad",
 			pipeline_tag: "question-answering",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					text: "Which name is also used to describe the Amazon rainforest in English?",
@@ -157,11 +174,13 @@
 		{
 			id: "t5-base",
 			pipeline_tag: "translation",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [{ text: "My name is Wolfgang and I live in Berlin" }],
 		},
 		{
 			id: "facebook/bart-large-cnn",
 			pipeline_tag: "summarization",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					text: "The tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building, and the tallest structure in Paris. Its base is square, measuring 125 metres (410 ft) on each side. During its construction, the Eiffel Tower surpassed the Washington Monument to become the tallest man-made structure in the world, a title it held for 41 years until the Chrysler Building in New York City was finished in 1930. It was the first structure to reach a height of 300 metres. Due to the addition of a broadcasting aerial at the top of the tower in 1957, it is now taller than the Chrysler Building by 5.2 metres (17 ft). Excluding transmitters, the Eiffel Tower is the second tallest free-standing structure in France after the Millau Viaduct.",
@@ -171,6 +190,7 @@
 		{
 			id: "gpt2",
 			pipeline_tag: "text-generation",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{ text: "My name is Julien and I like to", output: { text: " code cool products with my friends." } },
 				{ text: "My name is Thomas and my main" },
@@ -182,6 +202,7 @@
 		{
 			id: "bigscience/bloom",
 			pipeline_tag: "text-generation",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{ text: "My name is Julien and I like to" },
 				{ text: "My name is Thomas and my main" },
@@ -194,11 +215,13 @@
 			id: "distilroberta-base",
 			pipeline_tag: "fill-mask",
 			mask_token: "<mask>",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [{ text: "Paris is the <mask> of France." }, { text: "The goal of life is <mask>." }],
 		},
 		{
 			id: "facebook/bart-large-mnli",
 			pipeline_tag: "zero-shot-classification",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					text: "I have a problem with my iphone that needs to be resolved asap!!",
@@ -210,6 +233,7 @@
 		{
 			id: "google/tapas-base-finetuned-wtq",
 			pipeline_tag: "table-question-answering",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					text: "How many stars does the transformers repository have?",
@@ -225,6 +249,7 @@
 		{
 			id: "microsoft/tapex-base-finetuned-wtq",
 			pipeline_tag: "table-question-answering",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					text: "How many stars does the transformers repository have?",
@@ -240,6 +265,7 @@
 		{
 			id: "julien-c/wine-quality",
 			pipeline_tag: "tabular-classification",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					structured_data: {
@@ -261,15 +287,18 @@
 		{
 			id: "bigscience/T0pp",
 			pipeline_tag: "text2text-generation",
+			inference: InferenceDisplayability.Yes,
 		},
 		{
 			id: "facebook/blenderbot-400M-distill",
 			pipeline_tag: "conversational",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [{ text: "Hey my name is Julien! How are you?" }],
 		},
 		{
 			id: "osanseviero/BigGAN-deep-128",
 			pipeline_tag: "text-to-image",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					text: "a tiger",
@@ -282,11 +311,13 @@
 		{
 			id: "julien-c/kan-bayashi_csmsc_tacotron2",
 			pipeline_tag: "text-to-speech",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [{ text: "请您说得慢些好吗" }],
 		},
 		{
 			id: "superb/wav2vec2-base-superb-sid",
 			pipeline_tag: "audio-classification",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					example_title: "Librispeech sample 1",
@@ -319,10 +350,12 @@
 		{
 			id: "julien-c/mini_an4_asr_train_raw_bpe_valid",
 			pipeline_tag: "automatic-speech-recognition",
+			inference: InferenceDisplayability.Yes,
 		},
 		{
 			id: "facebook/wav2vec2-base-960h",
 			pipeline_tag: "automatic-speech-recognition",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					example_title: "Librispeech sample 1",
@@ -336,6 +369,7 @@
 		{
 			id: "facebook/wav2vec2-large-xlsr-53-french",
 			pipeline_tag: "automatic-speech-recognition",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					example_title: "Librispeech sample 1",
@@ -346,6 +380,7 @@
 		{
 			id: "manandey/wav2vec2-large-xlsr-mongolian",
 			pipeline_tag: "automatic-speech-recognition",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					example_title: "Librispeech sample 1",
@@ -356,6 +391,7 @@
 		{
 			id: "osanseviero/full-sentence-distillroberta2",
 			pipeline_tag: "sentence-similarity",
+			inference: InferenceDisplayability.Yes,
 			widgetData: [
 				{
 					source_sentence: "That is a happy person",
@@ -367,6 +403,7 @@
 			id: "speechbrain/mtl-mimic-voicebank",
 			private: false,
 			pipeline_tag: "audio-to-audio",
+			inference: InferenceDisplayability.Yes,
 			tags: ["speech-enhancement"],
 			widgetData: [],
 		},
@@ -374,6 +411,7 @@
 			id: "speechbrain/sepformer-wham",
 			private: false,
 			pipeline_tag: "audio-to-audio",
+			inference: InferenceDisplayability.Yes,
 			tags: ["audio-source-separation"],
 			widgetData: [],
 		},
@@ -381,25 +419,144 @@
 			id: "julien-c/DPRNNTasNet-ks16_WHAM_sepclean",
 			private: false,
 			pipeline_tag: "audio-to-audio",
+			inference: InferenceDisplayability.Yes,
 			tags: ["audio-source-separation"],
 			widgetData: [],
 		},
 	];
+
+	const modelsDisabled: ModelData[] = [
+		{
+			id: "gpt2",
+			pipeline_tag: "text-generation",
+			inference: InferenceDisplayability.CustomCode,
+		},
+		{
+			id: "gpt2",
+			pipeline_tag: "text-generation",
+			inference: InferenceDisplayability.ExplicitOptOut,
+		},
+		{
+			id: "gpt2",
+			pipeline_tag: "text-generation",
+			inference: InferenceDisplayability.LibraryNotDetected,
+		},
+		{
+			id: "gpt2",
+			pipeline_tag: "text-generation",
+			inference: InferenceDisplayability.PipelineLibraryPairNotSupported,
+		},
+		{
+			id: "gpt2",
+			pipeline_tag: "text-generation",
+			inference: InferenceDisplayability.PipelineNotDetected,
+		},
+		{
+			id: "Phind/Phind-CodeLlama-34B-v1",
+			pipeline_tag: "text-generation",
+			inference: InferenceDisplayability.Yes,
+		},
+	];
+
+	const modelsDisabledWithExamples: ModelData[] = [
+		{
+			id: "superb/wav2vec2-base-superb-sid",
+			pipeline_tag: "audio-classification",
+			inference: InferenceDisplayability.CustomCode,
+			widgetData: [
+				{
+					example_title: "Librispeech sample 1",
+					src: "https://cdn-media.huggingface.co/speech_samples/sample1.flac",
+					output: [
+						{
+							score: 1,
+							label: "id10003",
+						},
+						{
+							score: 3.958137817505758e-9,
+							label: "id10912",
+						},
+					],
+				},
+			],
+		},
+		{
+			id: "osanseviero/BigGAN-deep-128",
+			pipeline_tag: "text-to-image",
+			inference: InferenceDisplayability.LibraryNotDetected,
+			widgetData: [
+				{
+					text: "a tiger",
+					output: {
+						url: "https://huggingface.co/datasets/mishig/sample_images/resolve/main/tiger.jpg",
+					},
+				},
+			],
+		},
+		{
+			id: "gpt2",
+			pipeline_tag: "text-generation",
+			inference: InferenceDisplayability.PipelineNotDetected,
+			widgetData: [
+				// the widget should only show sample with output here
+				{ text: "My name is Julien and I like to", output: { text: " code cool products with my friends." } },
+				{ text: "My name is Thomas and my main" },
+				{ text: "My name is Mariama, my favorite" },
+				{ text: "My name is Clara and I am" },
+				{ text: "Once upon a time," },
+			],
+		},
+	];
 </script>
 
-<div class="py-24">
+<div class="space-y-12 py-24">
 	<ModeSwitcher />
 
-	<div class="mx-4 space-y-4 lg:grid lg:grid-cols-2 lg:gap-4 lg:space-y-0 xl:grid-cols-3">
-		{#each models as model}
-			<div>
-				<a class="mb-3 block text-xs text-gray-300" href="/{model.id}">
-					<code>{model.id}</code>
-				</a>
-				<div class="max-w-md rounded-xl bg-white p-5 shadow-sm">
-					<InferenceWidget {model} />
+	<div class="mx-4">
+		<h1 class="mb-8 text-4xl font-semibold">Showcase of all types of disabled inference</h1>
+		<div class="space-y-4 lg:grid lg:grid-cols-2 lg:gap-4 lg:space-y-0 xl:grid-cols-3">
+			{#each modelsDisabled as model}
+				<div>
+					<a class="mb-3 block text-xs text-gray-300" href="/{model.id}">
+						<code>{model.id}</code>
+					</a>
+					<div class="max-w-md rounded-xl bg-white p-5 shadow-sm">
+						<InferenceWidget {model} />
+					</div>
 				</div>
-			</div>
-		{/each}
+			{/each}
+		</div>
+	</div>
+
+	<div class="mx-4">
+		<h1 class="mb-8 text-4xl font-semibold">Showcase of all types of disabled inference with example outputs</h1>
+		<div class="space-y-4 lg:grid lg:grid-cols-2 lg:gap-4 lg:space-y-0 xl:grid-cols-3">
+			{#each modelsDisabledWithExamples as model}
+				<div>
+					<a class="mb-3 block text-xs text-gray-300" href="/{model.id}">
+						<code>{model.id}</code>
+					</a>
+					<div class="max-w-md rounded-xl bg-white p-5 shadow-sm">
+						<InferenceWidget {model} />
+					</div>
+				</div>
+			{/each}
+		</div>
+	</div>
+
+	<div class="mx-4">
+		<h1 class="mb-8 text-4xl font-semibold">Showcase of all types of inference widgets running</h1>
+		<div class="space-y-4 lg:grid lg:grid-cols-2 lg:gap-4 lg:space-y-0 xl:grid-cols-3">
+			{#each models as model}
+				<div>
+					<a class="mb-3 block text-xs text-gray-300" href="/{model.id}">
+						<code>{model.id}</code>
+					</a>
+					<div class="max-w-md rounded-xl bg-white p-5 shadow-sm">
+						<InferenceWidget {model} />
+					</div>
+				</div>
+			{/each}
+		</div>
 	</div>
 </div>


### PR DESCRIPTION
Closes https://github.com/huggingface/hub-docs/issues/1010

## Description

### This is how it looks like, when an inference api is disabled for a model.

<img width="800" alt="image" src="https://github.com/huggingface/hub-docs/assets/11827707/2774841d-0f48-4cf7-8d38-1c6119c51011">

### This is how it looks like, when an inference api is disabled for a model BUT there is an example with output (#979).
Detailed description:
1. There will be message that says `However, you can still play with [examples that have an output](hf.co/docs/hub/models-widgets#example-outputs)`
2. All the input elements are disabled (you can't enter text, the compute button is greyed out)
3. As a user, you only see examples that have outputs. If in the readme, there was an example without output, it is being filtered out.
4. In the current implementation, when you click an example with an output, it tries to call an inference-api. This should be fixed with #1017

<img width="800" alt="image" src="https://github.com/huggingface/hub-docs/assets/11827707/1360b19b-770a-48fe-8214-1b018c336f83">


### How to test

```
cd js
npm ci
npm run dev -- --open
```
and the command above should open a webpage

### Order of merge operations
1. Merge #1023 
2. Then merge #1063 
3. Then merge #1019 (this PR)
