### PR TITLE
docs: update stats of available models with TensorBoards

### DIFF
--- a/docs/hub/tensorboard.md
+++ b/docs/hub/tensorboard.md
@@ -4,7 +4,7 @@ TensorBoard provides tooling for tracking and visualizing metrics as well as vis
 
 ## Exploring TensorBoard models on the Hub
 
-Over 6,000 repositories have TensorBoard traces on the Hub. You can find them by filtering at the left of the [models page](https://huggingface.co/models?filter=tensorboard). As an example, if you go to the [aubmindlab/bert-base-arabertv02](https://huggingface.co/aubmindlab/bert-base-arabertv02) repository, there is a **Metrics** tab. If you select it, you'll view a TensorBoard instance.
+Over 52k repositories have TensorBoard traces on the Hub. You can find them by filtering at the left of the [models page](https://huggingface.co/models?filter=tensorboard). As an example, if you go to the [aubmindlab/bert-base-arabertv02](https://huggingface.co/aubmindlab/bert-base-arabertv02) repository, there is a **Metrics** tab. If you select it, you'll view a TensorBoard instance.
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/libraries-tensorflow.png"/>


### PR DESCRIPTION
Hi,

this is a follow-up MR for #1016 and addresses a MR review comment from @Wauplin: the number of models with TensorBoard traces is updated now:

![image](https://github.com/huggingface/hub-docs/assets/20651387/61adf4e8-417c-43fc-9e5f-d02ed330d0fb)