### PR TITLE
docs: Fix link to Paper Pages in Models FAQ

### DIFF
--- a/docs/hub/models-faq.md
+++ b/docs/hub/models-faq.md
@@ -42,4 +42,4 @@ If the model card includes a link to a paper on arXiv, the Hugging Face Hub will
 <img class="hidden dark:block" width="300" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/datasets-arxiv-dark.png"/>
 </div>
 
-Read more about paper pages [here](.paper-pages).
+Read more about paper pages [here](./paper-pages).


### PR DESCRIPTION
Hey,

this PR introduces a small improvement on the Models FAQ page and fixes the link to Paper Pages site.

Last link in [doc preview](https://moon-ci-docs.huggingface.co/docs/hub/pr_1027/en/models-faq) is then working!