### PR TITLE
fix: remove useless token

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -17,5 +17,4 @@ jobs:
       path_to_docs: hub-docs/docs/hub/
       additional_args: --not_python_module
     secrets:
-      token: ${{ secrets.HUGGINGFACE_PUSH }}
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}


### PR DESCRIPTION
This token is not used by your action.
Secret is removed from the repository.