### PR TITLE
API docs mini tweaks

### DIFF
--- a/docs/hub/api.md
+++ b/docs/hub/api.md
@@ -115,7 +115,6 @@ Get information from all Spaces in the Hub. The response is paginated, use the [
 - `direction`: Direction in which to sort, such as `-1` for descending, and anything else for ascending.
 - `limit`: Limit the number of models fetched.
 - `full`: Whether to fetch most model data, such as all tags, the files, etc.
-- `config`: Whether to also fetch the repo config.
 
 Payload:
 

--- a/docs/hub/api.md
+++ b/docs/hub/api.md
@@ -4,13 +4,13 @@ We have open endpoints that you can use to retrieve information from the Hub as 
 
 The base URL for those endpoints below is `https://huggingface.co`. For example, to construct the `/api/models` call below, one can call the URL [https://huggingface.co/api/models](https://huggingface.co/api/models)
 
-## Search API
+## Repo listing API
 
 The following endpoints help get information about models, datasets, Spaces, and metrics stored on the Hub.
 
 ### GET /api/models
 
-Get information from all models in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the following pages. You can specify additional parameters to have more specific results.
+Get information from all models in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the next pages. You can specify additional parameters to have more specific results.
 - `search`: Filter based on substrings for repos and their usernames, such as `resnet` or `microsoft`
 - `author`: Filter models by an author or organization, such as `huggingface` or `microsoft`
 - `filter`: Filter based on tags, such as `text-classification` or `spacy`.
@@ -51,7 +51,7 @@ This is equivalent to `huggingface_hub.get_model_tags()`.
 
 ### GET /api/datasets
 
-Get information from all datasets in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the following pages. You can specify additional parameters to have more specific results.
+Get information from all datasets in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the next pages. You can specify additional parameters to have more specific results.
 - `search`: Filter based on substrings for repos and their usernames, such as `pets` or `microsoft`
 - `author`: Filter datasets by an author or organization, such as `huggingface` or `microsoft`
 - `filter`: Filter based on tags, such as `task_categories:text-classification` or `languages:en`.
@@ -107,7 +107,7 @@ This is equivalent to `huggingface_hub.get_dataset_tags()`.
 
 ### GET /api/spaces
 
-Get information from all Spaces in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the following pages. You can specify additional parameters to have more specific results.
+Get information from all Spaces in the Hub. The response is paginated, use the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header) to get the next pages. You can specify additional parameters to have more specific results.
 - `search`: Filter based on substrings for repos and their usernames, such as `resnet` or `microsoft`
 - `author`: Filter models by an author or organization, such as `huggingface` or `microsoft`
 - `filter`: Filter based on tags, such as `text-classification` or `spacy`.
@@ -139,11 +139,6 @@ Get all information for a specific model.
 
 This is equivalent to `huggingface_hub.space_info(repo_id, revision)`.
 
-### GET /api/metrics
-
-Get information from all metrics in the Hub.
-
-This is equivalent to `huggingface_hub.list_metrics()`.
 
 ## Repo API
 
@@ -237,7 +232,7 @@ headers = { "authorization" :  "Bearer $token" }
 
 This is equivalent to `huggingface_hub.whoami()`.
 
-## Collection API
+## Collections API
 
 Use Collections to group repositories from the Hub (Models, Datasets, Spaces and Papers) on a dedicated page.
 

--- a/docs/hub/doi.md
+++ b/docs/hub/doi.md
@@ -36,7 +36,7 @@ If ever there’s a new version of a model or dataset, a new DOI can easily be a
 
 You just need to click on "Generate new DOI" and tadaam!🎉 a new DOI is assigned for the current revision of your model or dataset.
 
-## Why is there 'locked by DOI' message on delete, rename and change visibility action on my model or dataset?
+## Why is there a 'locked by DOI' message on delete, rename and change visibility action on my model or dataset?
 
 DOIs make finding information about a model or dataset easier and sharing them with the world via a permanent link that will never expire or change. As such, datasets/models with DOIs are intended to persist perpetually and may only be deleted, renamed and changed their visibility upon filing a request with our support (website at huggingface.co)
 

--- a/docs/hub/paper-pages.md
+++ b/docs/hub/paper-pages.md
@@ -21,7 +21,7 @@ If the repository card (`README.md`) includes a link to a paper on arXiv, the Hu
 
 ## Claiming authorship to a Paper
 
-The Hub will automatically match paper to users based on their email. 
+The Hub will attempt to automatically match paper to users based on their email. 
 
 <div class="flex justify-center">
 <img class="block dark:hidden" width="300" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/papers-authors.png"/>
@@ -40,7 +40,7 @@ If your paper is not linked to your account, you can click in your name in the c
 
 ### Can I control which Paper pages show in my profile?
 
-Yes! You can visit your Papers in [settings](https://huggingface.co/settings/papers), where you will see a list of verified paper. There, you can click the "Show on profile" checkbox to hide/show it in your profile. 
+Yes! You can visit your Papers in [settings](https://huggingface.co/settings/papers), where you will see a list of verified papers. There, you can click the "Show on profile" checkbox to hide/show it in your profile. 
 
 ### Do you support ACL anthology?
 


### PR DESCRIPTION
very minor tweaks, the main one was that i didn't really like `Search API` (confusing with the Hub full text search)