### PR TITLE
[Widget docs] Add screenshots for `examples outputs`

### DIFF
--- a/docs/hub/models-widgets.md
+++ b/docs/hub/models-widgets.md
@@ -104,6 +104,11 @@ widget:
       text: "Hello my name is Julien"
 ```
 
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/infrence-examples-textgen-light.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/infrence-examples-textgen-dark.png"/>
+</div>
+
 The `output` property should be a YAML dictionary that represents the Inference API output.
 
 For a model that outputs text, see the example above.
@@ -120,6 +125,11 @@ widget:
         score: 0.2
 ```
 
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/infrence-examples-audiocls-light.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/infrence-examples-audiocls-dark.png"/>
+</div>
+
 Finally, for a model that outputs an image, audio, or any other kind of asset, the output should include a `url` property linking to either a file name or path inside the repo or a remote URL. For example, for a text-to-image model:
 
 ```yaml
@@ -129,7 +139,10 @@ widget:
       url: images/tiger.jpg
 ```
 
-<!-- todo(add a screenshot) -->
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/infrence-examples-text2img-light.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/infrence-examples-text2img-dark.png"/>
+</div>
 
 We can also surface the example outputs in the Hugging Face UI, for instance, for a text-to-image model to display a gallery of cool image generations.
 


### PR DESCRIPTION
Follow up to [this comment](https://github.com/huggingface/hub-docs/issues/1010#issuecomment-1789297341), #978