### PR TITLE
[FillMask/TextCls Widget] Fix typo in example validation

### DIFF
--- a/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
+++ b/js/src/lib/components/InferenceWidget/widgets/FillMaskWidget/FillMaskWidget.svelte
@@ -128,7 +128,7 @@
 	}
 
 	function validateExample(sample: WidgetExample): sample is WidgetExampleTextInput<WidgetExampleOutputLabels> {
-		return isTextInput(sample) && (!output || isValidOutputLabels(sample.output));
+		return isTextInput(sample) && (!sample.output || isValidOutputLabels(sample.output));
 	}
 </script>
 


### PR DESCRIPTION
Closes #1083

there was typo from #979
I've also checked that there are no other typos like this on other `validateExample` functions