### PR TITLE
[Hotfix] Enterprise docs

### DIFF
--- a/docs/hub/audit-logs.md
+++ b/docs/hub/audit-logs.md
@@ -1,7 +1,4 @@
-<h1 class="flex items-center gap-3">
-	<svg xmlns="http://www.w3.org/2000/svg" fill="none" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 33 27"><path fill="currentColor" fill-rule="evenodd" d="M13.5.7a8.7 8.7 0 0 0-7.7 5.7L1 20.6c-1 3.1.9 5.7 4.1 5.7h15c3.3 0 6.8-2.6 7.8-5.7l4.6-14.2c1-3.1-.8-5.7-4-5.7h-15Zm1.1 5.7L9.8 20.3h9.8l1-3.1h-5.8l.8-2.5h4.8l1.1-3h-4.8l.8-2.3H23l1-3h-9.5Z" clip-rule="evenodd"></path></svg>
-	Audit Logs
-</h1>
+# Audit Logs
 
 <Tip warning={true}>
 This feature is part of the <a href="https://huggingface.co/enterprise" target="_blank">Enterprise Hub</a>.

--- a/docs/hub/enterprise-hub.md
+++ b/docs/hub/enterprise-hub.md
@@ -1,7 +1,4 @@
-<h1 class="flex items-center gap-3">
-	<svg xmlns="http://www.w3.org/2000/svg" fill="none" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 33 27"><path fill="currentColor" fill-rule="evenodd" d="M13.5.7a8.7 8.7 0 0 0-7.7 5.7L1 20.6c-1 3.1.9 5.7 4.1 5.7h15c3.3 0 6.8-2.6 7.8-5.7l4.6-14.2c1-3.1-.8-5.7-4-5.7h-15Zm1.1 5.7L9.8 20.3h9.8l1-3.1h-5.8l.8-2.5h4.8l1.1-3h-4.8l.8-2.3H23l1-3h-9.5Z" clip-rule="evenodd"></path></svg>
-	Enterprise Hub
-</h1>
+# Enterprise Hub
 
 Enterprise Hub adds advanced capabilities to organizations, enabling safe, compliant and managed collaboration for companies and teams on Hugging Face.
 

--- a/docs/hub/security-sso.md
+++ b/docs/hub/security-sso.md
@@ -1,7 +1,4 @@
-<h1 class="flex items-center gap-3">
-	<svg xmlns="http://www.w3.org/2000/svg" fill="none" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 33 27"><path fill="currentColor" fill-rule="evenodd" d="M13.5.7a8.7 8.7 0 0 0-7.7 5.7L1 20.6c-1 3.1.9 5.7 4.1 5.7h15c3.3 0 6.8-2.6 7.8-5.7l4.6-14.2c1-3.1-.8-5.7-4-5.7h-15Zm1.1 5.7L9.8 20.3h9.8l1-3.1h-5.8l.8-2.5h4.8l1.1-3h-4.8l.8-2.3H23l1-3h-9.5Z" clip-rule="evenodd"></path></svg>
-	Single Sign-On (SSO)
-</h1>
+# Single Sign-On (SSO)
 
 The Hugging Face Hub gives you the ability to implement mandatory Single Sign-On (SSO) for your organization.
 

--- a/docs/hub/storage-regions.md
+++ b/docs/hub/storage-regions.md
@@ -1,7 +1,4 @@
-<h1 class="flex items-center gap-3">
-	<svg xmlns="http://www.w3.org/2000/svg" fill="none" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 33 27"><path fill="currentColor" fill-rule="evenodd" d="M13.5.7a8.7 8.7 0 0 0-7.7 5.7L1 20.6c-1 3.1.9 5.7 4.1 5.7h15c3.3 0 6.8-2.6 7.8-5.7l4.6-14.2c1-3.1-.8-5.7-4-5.7h-15Zm1.1 5.7L9.8 20.3h9.8l1-3.1h-5.8l.8-2.5h4.8l1.1-3h-4.8l.8-2.3H23l1-3h-9.5Z" clip-rule="evenodd"></path></svg>
-	Storage Regions on the Hub
-</h1>
+# Storage Regions on the Hub
 
 Regions let you decide where your org's models and datasets will be stored.
 


### PR DESCRIPTION
At the moment, doc-builder uses markdown headings for creating right-side nav (see attached img for example)

<img width="359" alt="image" src="https://github.com/huggingface/hub-docs/assets/11827707/5f156432-cc8f-4f69-832a-a27648cef61a">


I will work on supporting html headings for right-side nav. Until then, this is a hotfix