### PR TITLE
Fix `/api/repos/move` documentation in api.md

### DIFF
--- a/docs/hub/api.md
+++ b/docs/hub/api.md
@@ -170,7 +170,7 @@ Payload:
 
 ```js
 payload = {
-    "type":"type",
+    "type":"model",
     "name":"name",
     "organization": "organization",
     "private":"private",
@@ -193,7 +193,7 @@ Payload:
 
 ```js
 payload = {
-    "type": "type",
+    "type": "model",
     "name": "name",
     "organization": "organization",
 }
@@ -219,13 +219,18 @@ This is equivalent to `huggingface_hub.update_repo_visibility()`.
 
 Move a repository (rename within the same namespace or transfer from user to organization).
 
+Parameters:
+- `fromRepo`: repo to rename.
+- `toRepo`: new name of the repo.
+- `type`: Type of repo (dataset or space; model by default).
+
 Payload:
 
 ```js
 payload = {
     "fromRepo" : "namespace/repo_name",
     "toRepo" : "namespace2/repo_name2",
-    "type": "dataset",
+    "type": "model",
 }
 ```
 

--- a/docs/hub/api.md
+++ b/docs/hub/api.md
@@ -224,7 +224,8 @@ Payload:
 ```js
 payload = {
     "fromRepo" : "namespace/repo_name",
-    "toRepo" : "namespace2/repo_name2"
+    "toRepo" : "namespace2/repo_name2",
+    "type": "dataset",
 }
 ```
 


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/issues/1813.

In `/api/repos/move`, we (I? :smile:) forgot to mention the `type` parameter to specify the repo type.

cc @enzostvs you would have to update the API Playground as well to add this parameter. Thanks in advance!

**EDIT:** see PR documentation [here](https://moon-ci-docs.huggingface.co/docs/hub/pr_1095/en/api#post-apireposmove)