### PR TITLE
Add section to model card docs about adding base_model metadata to a model card

### DIFF
--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -76,7 +76,7 @@ If it's not specified, the Hub will try to automatically detect the library type
 
 ### Specifying a base model
 
-If your model is a fine-tuned version of a base model, you can specify the base model in the model card metadata section:
+If your model is a fine-tune or adapter of a base model, you can specify the base model in the model card metadata section:
 
 ```yaml
 base_model: HuggingFaceH4/zephyr-7b-beta

--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -85,7 +85,7 @@ base_model: HuggingFaceH4/zephyr-7b-beta
 This metadata will be used to display the base model on the model page. Users can also use this information to filter models by base model or find models that are fine-tuned from a specific base model.
 
 <div class="flex justify-center">
-<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/18f3ec67457320da0fa16b9b0bd4147739b6262d/hub/base-model-ui.png"/>
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base-model-ui.png"/>
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/cb60df56d98240045baf7c822771621000984ac0/hub/base-model-ui-dark.png"/>
 </div>
 
@@ -117,7 +117,7 @@ If a model includes valid eval results, they will be displayed like this:
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/eval-results.png"/>
-<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/eval-results-dark.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base-model-ui-dark.png"/>
 </div>
 
 ### CO<sub>2</sub> Emissions

--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -54,7 +54,7 @@ See the detailed model card metadata specification [here](https://github.com/hug
 
 ### Specifying a library
 
-You can also specify the supported libraries in the model card metadata section. Find more about our supported libraries [here](./models-libraries). The library can be specified with the following order of priority
+You can also specify the supported libraries in the model card metadata section. Find more about our supported libraries [here](./models-libraries). The library can be specified in the following order of priority
 
 1. Specifying `library_name` in the model card (recommended if your model is not a `transformers` model)
 

--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -84,6 +84,14 @@ base_model: HuggingFaceH4/zephyr-7b-beta
 
 This metadata will be used to display the base model on the model page. Users can also use this information to filter models by base model.
 
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/18f3ec67457320da0fa16b9b0bd4147739b6262d/hub/base-model-ui.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/cb60df56d98240045baf7c822771621000984ac0/hub/base-model-ui-dark.png"/>
+</div>
+
+
+
+
 ### Evaluation Results
 
 You can even specify your **model's eval results** in a structured way, which will allow the Hub to parse, display, and even link them to Papers With Code leaderboards. See how to format this data [in the metadata spec](https://github.com/huggingface/hub-docs/blob/main/modelcard.md?plain=1).

--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -82,7 +82,7 @@ If your model is a fine-tune or adapter of a base model, you can specify the bas
 base_model: HuggingFaceH4/zephyr-7b-beta
 ```
 
-This metadata will be used to display the base model on the model page. Users can also use this information to filter models by base model.
+This metadata will be used to display the base model on the model page. Users can also use this information to filter models by base model or find models that are fine-tuned from a specific base model.
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/18f3ec67457320da0fa16b9b0bd4147739b6262d/hub/base-model-ui.png"/>

--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -86,7 +86,7 @@ This metadata will be used to display the base model on the model page. Users ca
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base-model-ui.png"/>
-<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/cb60df56d98240045baf7c822771621000984ac0/hub/base-model-ui-dark.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base-model-ui-dark.png"/>
 </div>
 
 

--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -74,6 +74,15 @@ If it's not specified, the Hub will try to automatically detect the library type
 1. By looking into the presence of files such as `*.nemo` or `*saved_model.pb*`, the Hub can determine if a model is from NeMo or Keras. 
 2. If nothing is detected and there is a `config.json` file, it's assumed the library is `transformers`.
 
+### Specifying a base model
+
+If your model is a fine-tuned version of a base model, you can specify the base model in the model card metadata section:
+
+```yaml
+base_model: HuggingFaceH4/zephyr-7b-beta
+```
+
+This metadata will be used to display the base model on the model page. Users can also use this information to filter models by base model.
 
 ### Evaluation Results
 


### PR DESCRIPTION
Adding a section on specifying base_model metadata. I think this page could do with a more extensive update to:

- refer to the metadata UI for adding many metadata fields
- Explicitly pull out some of the metadata fields more prominently, i.e. why add a `dataset` link.  
- Add a few more questions to the FAQ

I'll add those in a separate PR since that will require more discussion. 

Partially addresses https://github.com/huggingface/hub-docs/issues/1107#issuecomment-1816607846 but will add a separate PR for using this metadata for finding models. 