### PR TITLE
Improve gated models doc

### DIFF
--- a/docs/hub/models-gated.md
+++ b/docs/hub/models-gated.md
@@ -128,6 +128,8 @@ Once the access request is sent, there are two possibilities. If the approval me
 
 The model authors have complete control over model access. In particular, they can decide at any time to block your access to the model without prior notice, regardless of approval mechanism or if your request has already been approved.
 
+</Tip>
+
 ### Download files
 
 To download files from a gated model you'll need to be authenticated. In the browser, this is automatic as long as you are logged in with your account. If you are using a script, you will need to provide a [user token](./security-tokens). In the Hugging Face Python ecosystem (`transformers`, `diffusers`, `datasets`, etc.), you can login your machine using the [`huggingface_hub`](https://huggingface.co/docs/huggingface_hub/index) library and running in your terminal:

--- a/docs/hub/models-gated.md
+++ b/docs/hub/models-gated.md
@@ -1,15 +1,14 @@
 # Gated models
 
-To give more control over how models are used, the Hub allows model authors to enable **access requests** for their models. When enabled, users have to agree to share their contact information (username and email address) with the model authors to access the model files. Model authors can configure this request with additional fields. A model with access requests enabled is called a **Gated model**. Access requests are always granted to individual users and not to entire organizations. A common use case of gated models is to provide access to early research models before the wider release.
+To give more control over how models are used, the Hub allows model authors to enable **access requests** for their models. Users must agree to share their contact information (username and email address) with the model authors to access the model files when enabled. Model authors can configure this request with additional fields. A model with access requests enabled is called a **gated model**. Access requests are always granted to individual users rather than to entire organizations. A common use case of gated models is to provide access to early research models before the wider release.
 
 ## Manage gated models as a model author
 
 <a id="manual-approval"></a> <!-- backward compatible anchor -->
 <a id="notifications-settings"></a> <!-- backward compatible anchor -->
 
-### Configure access control
 
-To enable access requests, go to the model settings page. By default the model is not gated. Click on "Enable Access request" on the top-right corner.
+To enable access requests, go to the model settings page. By default, the model is not gated. Click on **Enable Access request** in the top-right corner.
 
 
 <div class="flex justify-center">
@@ -35,14 +34,14 @@ If you want to manually approve which users can access your model, you must set 
 
 ### Review access requests
 
-Once access requests are enabled, you have full control of who can have access to your model or not, no matter if the approval mode is set to manual or automatic. You can review and manage requests either from the UI or via the API.
+Once access requests are enabled, you have full control of who can access your model or not, whether the approval mode is manual or automatic. You can review and manage requests either from the UI or via the API.
 
 ### From the UI
 
 You can review who has access to your gated model from its settings page by clicking on the **Review access requests** button. This will open a modal with 3 lists of users:
-- **pending**: the list of users that are waiting for an approval to access your model. This list is empty unless you've selected **manual approval**. You can either "Accept" or "Reject" the demand. If the demand is rejected, the user cannot access your model and cannot request access again.
-- **accepted**: the complete list of users that have access to your model. You can choose to "Reject" the access at any time for any user, no matter if the approval mode is manual or automatic. You can also "Cancel" the approval, which will move the user to the *pending* list.
-- **rejected**: the list of users that you've manually rejected. Those users cannot access your models. If they go to your model repository, they will see a message *Your request to access this repo has been rejected by the repo's authors.*.
+- **pending**: the list of users waiting for approval to access your model. This list is empty unless you've selected **manual approval**. You can either **Accept** or **Reject** the demand. If the demand is rejected, the user cannot access your model and cannot request access again.
+- **accepted**: the complete list of users with access to your model. You can choose to **Reject** access at any time for any user, whether the approval mode is manual or automatic. You can also **Cancel** the approval, which will move the user to the *pending* list.
+- **rejected**: the list of users you've manually rejected. Those users cannot access your models. If they go to your model repository, they will see a message *Your request to access this repo has been rejected by the repo's authors*.
 
 <div class="flex justify-center">
     <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-enabled-pending-users.png"/>
@@ -78,14 +77,14 @@ You can download a report of all access requests for a gated model with the **do
 
 ### Customize requested information
 
-By default, users landing on your gated model will be asked to share their contact information (email and username) by clicking on the `Agree and send request to access repo` button.
+By default, users landing on your gated model will be asked to share their contact information (email and username) by clicking the **Agree and send request to access repo** button.
 
 <div class="flex justify-center">
     <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-user-side.png"/>
     <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-user-side-dark.png"/>
 </div>
 
-If you want users to provide more information, you can configure additional fields for the user to fill. This information will be accessible from the settings tab to make the decision on whether or not to grant access. To do so, you should add an `extra_gated_fields` property to your [model card metadata](./model-cards#model-card-metadata) containing a list of key/value pairs. The *key* is the name of the field and *value* its type. A field can be either `text` (free text area) or `checkbox`. Finally, you can also personalize the message displayed to the user with the `extra_gated_prompt` extra field.
+If you want to collect more user information, you can configure additional fields. This information will be accessible from the **Settings** tab. To do so, add an `extra_gated_fields` property to your [model card metadata](./model-cards#model-card-metadata) containing a list of key/value pairs. The *key* is the name of the field and *value* its type. A field can be either `text` (free text area) or `checkbox`. Finally, you can also personalize the message displayed to the user with the `extra_gated_prompt` extra field.
 
 Here is an example of customized request form where the user is asked to provide their company name and country and acknowledge that the model is for non-commercial use only.
 
@@ -99,9 +98,8 @@ extra_gated_fields:
 ---
 ```
 
-#### Additional Customization
 
-In some cases, you might also want to modify the text in the heading of the gate as well as the text in the button. For those use cases you can modify `extra_gated_heading` and `extra_gated_button_content` like this:
+In some cases, you might also want to modify the text in the gate heading and the text in the button. For those use cases, you can modify `extra_gated_heading` and `extra_gated_button_content` like this:
 
 ```yaml
 ---
@@ -112,9 +110,8 @@ extra_gated_button_content: "Acknowledge license"
 
 ## Access gated models as a user
 
-### Request access
 
-As a user, if you want to use a gated model, you will need to request access to it. This means that you must be logged in to a Hugging Face user account to access gated models.
+As a user, if you want to use a gated model, you will need to request access to it. This means that you must be logged in to a Hugging Face user account.
 
 Requesting access can only be done from your browser. Go to the model on the Hub and you will be prompted to share your information:
 
@@ -123,11 +120,13 @@ Requesting access can only be done from your browser. Go to the model on the Hub
     <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-user-side-dark.png"/>
 </div>
 
-By clicking on `Agree`, you agree to share your username and email address with the model authors. In some cases, additional fields might be requested. Try to fill the form as accurately as possible to help the model authors decide whether they grant you access or not.
+By clicking on **Agree**, you agree to share your username and email address with the model authors. In some cases, additional fields might be requested. To help the model authors decide whether to grant you access, try to fill out the form as completely as possible.
 
 Once the access request is sent, there are two possibilities. If the approval mechanism is automatic, you immediately get access to the model files. Otherwise, the requests have to be approved manually by the authors, which can take more time. 
 
-**Note:** the model authors have full control on their model. In particular, they can decide at any time to block your access to the model without prior notice, no matter the approval mechanism or if your request has already being approved.
+<Tip warning={true}>
+
+The model authors have complete control over model access. In particular, they can decide at any time to block your access to the model without prior notice, regardless of approval mechanism or if your request has already been approved.
 
 ### Download files
 

--- a/docs/hub/models-gated.md
+++ b/docs/hub/models-gated.md
@@ -25,8 +25,8 @@ By default, access to the model is automatically granted to the user when reques
 </div>
 
 If you want to manually approve which users can access your model, you must set it to **manual approval**. When this is the case, you will notice more options:
-- **Add access** allows you to search for a user and grant them access even if they did not requested it.
-- **Notification frequency** let you configure when to get notified if new users request access. It can be set to once a day or real-time. By default, an email is sent to your primary email address. You can set a different email address in the **Notifications email** field. For models hosted under an organization, emails are sent to the first 5 admins of the organization.
+- **Add access** allows you to search for a user and grant them access even if they did not request it.
+- **Notification frequency** lets you configure when to get notified if new users request access. It can be set to once a day or real-time. By default, an email is sent to your primary email address. You can set a different email address in the **Notifications email** field. For models hosted under an organization, emails are sent to the first 5 admins of the organization.
 
 <div class="flex justify-center">
     <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-manual-approval.png"/>
@@ -39,9 +39,9 @@ Once access requests are enabled, you have full control of who can have access t
 
 ### From the UI
 
-You can review who have access to your gated model from its setting page by clicking on the **Review access requests** button. This will open a modal with 3 lists of users:
+You can review who has access to your gated model from its settings page by clicking on the **Review access requests** button. This will open a modal with 3 lists of users:
 - **pending**: the list of users that are waiting for an approval to access your model. This list is empty unless you've selected **manual approval**. You can either "Accept" or "Reject" the demand. If the demand is rejected, the user cannot access your model and cannot request access again.
-- **accepted**: the complete list of users that have access to your model. You can chose to "Reject" the access at any time for any user, no matter if the approval mode is manual or automatic. You can also "Cancel" the approval which will move the user to the *pending* list.
+- **accepted**: the complete list of users that have access to your model. You can choose to "Reject" the access at any time for any user, no matter if the approval mode is manual or automatic. You can also "Cancel" the approval, which will move the user to the *pending* list.
 - **rejected**: the list of users that you've manually rejected. Those users cannot access your models. If they go to your model repository, they will see a message *Your request to access this repo has been rejected by the repo's authors.*.
 
 <div class="flex justify-center">
@@ -114,7 +114,7 @@ extra_gated_button_content: "Acknowledge license"
 
 ### Request access
 
-As a user, if you want to use a gated model, you will need to request access to it. This mean that only registered users can access gated models.
+As a user, if you want to use a gated model, you will need to request access to it. This means that only registered users can access gated models.
 
 Requesting access can only be done from your browser. Go to the model on the Hub and you will be prompted to share your information:
 
@@ -123,7 +123,7 @@ Requesting access can only be done from your browser. Go to the model on the Hub
     <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-user-side-dark.png"/>
 </div>
 
-By clicking on `Agree`, you agree to share your username and email address to the model authors. In some cases, additional fields might be requested. Try to fill the form as accurately as possible to help the model authors decide on whether they grant you the access or not.
+By clicking on `Agree`, you agree to share your username and email address with the model authors. In some cases, additional fields might be requested. Try to fill the form as accurately as possible to help the model authors decide whether they grant you access or not.
 
 Once the access request is sent, there are two possibilities. If the approval mechanism is automatic, you immediately get access to the model files. Otherwise, the requests have to be approved manually by the authors, which can take more time. 
 
@@ -131,7 +131,7 @@ Once the access request is sent, there are two possibilities. If the approval me
 
 ### Download files
 
-To download files from a gated model you'll need to be authenticated. In the browser, this is automatic as long as you are logged in with your account. If you are using a script, you will need to provide a [user token](./security-tokens). In the Python ecosystem (`transformers`, `diffusers`, `datasets`, etc.), you can login your machine using the [`huggingface_hub`](https://huggingface.co/docs/huggingface_hub/index) library and running in your terminal:
+To download files from a gated model you'll need to be authenticated. In the browser, this is automatic as long as you are logged in with your account. If you are using a script, you will need to provide a [user token](./security-tokens). In the Hugging Face Python ecosystem (`transformers`, `diffusers`, `datasets`, etc.), you can login your machine using the [`huggingface_hub`](https://huggingface.co/docs/huggingface_hub/index) library and running in your terminal:
 
 ```bash
 huggingface-cli login
@@ -144,6 +144,6 @@ Alternatively, you can programmatically login using `login()` in a notebook or a
 >>> login()
 ```
 
-Finally, you can also provide the `token` parameter to any method of the Hugging Face ecosystem (`from_pretrained`, `hf_hub_download`, `load_dataset`, etc.) directly from your scripts.
+You can also provide the `token` parameter to most loading methods in the libraries (`from_pretrained`, `hf_hub_download`, `load_dataset`, etc.), directly from your scripts.
 
 For more details about how to login, check out the [login guide](https://huggingface.co/docs/huggingface_hub/quick-start#login).

--- a/docs/hub/models-gated.md
+++ b/docs/hub/models-gated.md
@@ -114,7 +114,7 @@ extra_gated_button_content: "Acknowledge license"
 
 ### Request access
 
-As a user, if you want to use a gated model, you will need to request access to it. This means that only registered users can access gated models.
+As a user, if you want to use a gated model, you will need to request access to it. This means that you must be logged in to a Hugging Face user account to access gated models.
 
 Requesting access can only be done from your browser. Go to the model on the Hub and you will be prompted to share your information:
 

--- a/docs/hub/models-gated.md
+++ b/docs/hub/models-gated.md
@@ -1,6 +1,6 @@
 # Gated models
 
-To give more control over how models are used, the Hub allows model authors to enable **Access requests** for their models. When enabled, users have to agree to share their contact information (username and email address) with the model authors to access the model files. A model with Access requests enabled is called a **Gated model**. Access requests are always granted to individual users and not to entire organization.
+To give more control over how models are used, the Hub allows model authors to enable **access requests** for their models. When enabled, users have to agree to share their contact information (username and email address) with the model authors to access the model files. Model authors can configure this request with additional fields. A model with Access requests enabled is called a **Gated model**. Access requests are always granted to individual users and not to entire organizations. A common use case of gated models is to provide access to early research models before the wider release.
 
 ## Manage gated models as a model author
 
@@ -64,7 +64,7 @@ By default, users landing on your gated model will be asked to share their conta
 
 ![](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-user-side.png)
 
-If you want to get more information, you can configure additional fields for the user to fill. These information will be accessible from the settings tab to take the decision on whether or not to grant access. To do so, you should add a `extra_gated_fields` property to your [modelcard metadata](./model-cards#model-card-metadata) containing a list of key/value pairs. The *key* is the name of the field and *value* its type. A field can be either `text` (free text area) or `checkbox`. Finally, you can also personalize the message displayed to the user with the `extra_gated_prompt` extra field.
+If you want users to provide more information, you can configure additional fields for the user to fill. This information will be accessible from the settings tab to make the decision on whether or not to grant access. To do so, you should add an `extra_gated_fields` property to your [model card metadata](./model-cards#model-card-metadata) containing a list of key/value pairs. The *key* is the name of the field and *value* its type. A field can be either `text` (free text area) or `checkbox`. Finally, you can also personalize the message displayed to the user with the `extra_gated_prompt` extra field.
 
 Here is an example of customized request form where the user is asked to provide their company name and country and acknowledge that the model is for non-commercial use only.
 
@@ -101,7 +101,7 @@ Requesting access can only be done from your browser. Go to the model on the Hub
 
 By clicking on `Agree`, you agree to share your username and email address to the model authors. In some cases, additional fields might be requested. Try to fill the form as accurately as possible to help the model authors decide on whether they grant you the access or not.
 
-Once the access request is sent, there are two possibilities. If the approval mechanism is automatic and you immediately get access to the model files. Otherwise, the requests have to be approved manually by the authors which can take more time. 
+Once the access request is sent, there are two possibilities. If the approval mechanism is automatic, you immediately get access to the model files. Otherwise, the requests have to be approved manually by the authors, which can take more time. 
 
 **Note:** the model authors have full control on their model. In particular, they can decide at any time to block your access to the model without prior notice, no matter the approval mechanism or if your request has already being approved.
 

--- a/docs/hub/models-gated.md
+++ b/docs/hub/models-gated.md
@@ -21,6 +21,9 @@ By default, access to the model is automatically granted to the user when reques
     <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-enabled-dark.png"/>
 </div>
 
+<a id="manual-approval"></a> <!-- backward compatible anchor -->
+<a id="notifications-settings"></a> <!-- backward compatible anchor -->
+
 If you want to manually approve which users can access your model, you must set it to **manual approval**. When this is the case, you will notice more options:
 - **Add access** allows you to search for a user and grant them access even if they did not requested it.
 - **Notification frequency** let you configure when to get notified if new users request access. It can be set to once a day or real-time. By default, an email is sent to your primary email address. You can set a different email address in the **Notifications email** field. For models hosted under an organization, emails are sent to the first 5 admins of the organization.
@@ -72,6 +75,8 @@ You can download a report of all access requests for a gated model with the **do
 - **time**: datetime when the user initially made the request.
 
 ### Customize requested information
+
+<a id="modifying-the-prompt"></a> <!-- backward compatible anchor -->
 
 By default, users landing on your gated model will be asked to share their contact information (email and username) by clicking on the `Agree and send request to access repo` button.
 

--- a/docs/hub/models-gated.md
+++ b/docs/hub/models-gated.md
@@ -8,17 +8,27 @@ To give more control over how models are used, the Hub allows model authors to e
 
 To enable access requests, go to the model settings page. By default the model is not gated. Click on "Enable Access request" on the top-right corner.
 
-![](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-disabled.png)
+
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-disabled.png"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-disabled-dark.png"/>
+</div>
 
 By default, access to the model is automatically granted to the user when requesting it. This is referred to as **automatic approval**. In this mode, any user can access your model once they've shared their personal information with you.
 
-![](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-enabled.png)
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-enabled.png"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-enabled-dark.png"/>
+</div>
 
 If you want to manually approve which users can access your model, you must set it to **manual approval**. When this is the case, you will notice more options:
 - **Add access** allows you to search for a user and grant them access even if they did not requested it.
 - **Notification frequency** let you configure when to get notified if new users request access. It can be set to once a day or real-time. By default, an email is sent to your primary email address. You can set a different email address in the **Notifications email** field. For models hosted under an organization, emails are sent to the first 5 admins of the organization.
 
-![](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-manual-approval.png)
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-manual-approval.png"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-manual-approval-dark.png"/>
+</div>
 
 ### Review access requests
 
@@ -31,7 +41,10 @@ You can review who have access to your gated model from its setting page by clic
 - **accepted**: the complete list of users that have access to your model. You can chose to "Reject" the access at any time for any user, no matter if the approval mode is manual or automatic. You can also "Cancel" the approval which will move the user to the *pending* list.
 - **rejected**: the list of users that you've manually rejected. Those users cannot access your models. If they go to your model repository, they will see a message *Your request to access this repo has been rejected by the repo's authors.*.
 
-![](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-enabled-pending-users.png)
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-enabled-pending-users.png"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-enabled-pending-users-dark.png"/>
+</div>
 
 #### Via the API
 
@@ -62,7 +75,10 @@ You can download a report of all access requests for a gated model with the **do
 
 By default, users landing on your gated model will be asked to share their contact information (email and username) by clicking on the `Agree and send request to access repo` button.
 
-![](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-user-side.png)
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-user-side.png"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-user-side-dark.png"/>
+</div>
 
 If you want users to provide more information, you can configure additional fields for the user to fill. This information will be accessible from the settings tab to make the decision on whether or not to grant access. To do so, you should add an `extra_gated_fields` property to your [model card metadata](./model-cards#model-card-metadata) containing a list of key/value pairs. The *key* is the name of the field and *value* its type. A field can be either `text` (free text area) or `checkbox`. Finally, you can also personalize the message displayed to the user with the `extra_gated_prompt` extra field.
 
@@ -97,7 +113,10 @@ As a user, if you want to use a gated model, you will need to request access to 
 
 Requesting access can only be done from your browser. Go to the model on the Hub and you will be prompted to share your information:
 
-![](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-user-side.png)
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-user-side.png"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-user-side-dark.png"/>
+</div>
 
 By clicking on `Agree`, you agree to share your username and email address to the model authors. In some cases, additional fields might be requested. Try to fill the form as accurately as possible to help the model authors decide on whether they grant you the access or not.
 

--- a/docs/hub/models-gated.md
+++ b/docs/hub/models-gated.md
@@ -4,6 +4,9 @@ To give more control over how models are used, the Hub allows model authors to e
 
 ## Manage gated models as a model author
 
+<a id="manual-approval"></a> <!-- backward compatible anchor -->
+<a id="notifications-settings"></a> <!-- backward compatible anchor -->
+
 ### Configure access control
 
 To enable access requests, go to the model settings page. By default the model is not gated. Click on "Enable Access request" on the top-right corner.
@@ -20,9 +23,6 @@ By default, access to the model is automatically granted to the user when reques
     <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-enabled.png"/>
     <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-enabled-dark.png"/>
 </div>
-
-<a id="manual-approval"></a> <!-- backward compatible anchor -->
-<a id="notifications-settings"></a> <!-- backward compatible anchor -->
 
 If you want to manually approve which users can access your model, you must set it to **manual approval**. When this is the case, you will notice more options:
 - **Add access** allows you to search for a user and grant them access even if they did not requested it.
@@ -74,9 +74,9 @@ You can download a report of all access requests for a gated model with the **do
 - **email**: email of the user.
 - **time**: datetime when the user initially made the request.
 
-### Customize requested information
-
 <a id="modifying-the-prompt"></a> <!-- backward compatible anchor -->
+
+### Customize requested information
 
 By default, users landing on your gated model will be asked to share their contact information (email and username) by clicking on the `Agree and send request to access repo` button.
 

--- a/docs/hub/models-gated.md
+++ b/docs/hub/models-gated.md
@@ -1,12 +1,12 @@
 # Gated models
 
-To give more control over how models are used, the Hub allows model authors to enable **access requests** for their models. When enabled, users have to agree to share their contact information (username and email address) with the model authors to access the model files. Model authors can configure this request with additional fields. A model with Access requests enabled is called a **Gated model**. Access requests are always granted to individual users and not to entire organizations. A common use case of gated models is to provide access to early research models before the wider release.
+To give more control over how models are used, the Hub allows model authors to enable **access requests** for their models. When enabled, users have to agree to share their contact information (username and email address) with the model authors to access the model files. Model authors can configure this request with additional fields. A model with access requests enabled is called a **Gated model**. Access requests are always granted to individual users and not to entire organizations. A common use case of gated models is to provide access to early research models before the wider release.
 
 ## Manage gated models as a model author
 
 ### Configure access control
 
-To enable Access requests, go to the model settings page. By default the model is not gated. Click on "Enable Access request" on the top-right corner.
+To enable access requests, go to the model settings page. By default the model is not gated. Click on "Enable Access request" on the top-right corner.
 
 ![](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gated-disabled.png)
 
@@ -22,7 +22,7 @@ If you want to manually approve which users can access your model, you must set 
 
 ### Review access requests
 
-Once Access request is enabled, you have full control of who can have access to your model or not, no matter if the approval mode is set to manual or automatic. You can review and manage requests either from the UI or via the API.
+Once access requests are enabled, you have full control of who can have access to your model or not, no matter if the approval mode is set to manual or automatic. You can review and manage requests either from the UI or via the API.
 
 ### From the UI
 
@@ -51,7 +51,7 @@ Those endpoints are not officially supported in `huggingface_hub` or `huggingfac
 
 ### Download access report
 
-You can download a report of all Access requests for a gated model with the **download user access report** button. Click on it to download a json file with a list of users. For each entry, you have:
+You can download a report of all access requests for a gated model with the **download user access report** button. Click on it to download a json file with a list of users. For each entry, you have:
 - **user**: the user id. Example: *julien-c*.
 - **fullname**: name of the user on the Hub. Example: *Julien Chaumond*.
 - **status**: status of the request. Either `"pending"`, `"accepted"` or `"rejected"`.


### PR DESCRIPTION
Related to https://github.com/huggingface/hub-docs/issues/642. 

[**Updated Gated Models docs here.**](https://moon-ci-docs.huggingface.co/docs/hub/pr_1128/en/models-gated)

I spent some time revisiting the docs for gated models. Once reviewed I'll port it to the Gated Datasets page as well. I was even wondering if we wanted to have two different pages given that the content is 95% the same (`sed 's/model/dataset/g'` :smile:).

I followed the plan from https://github.com/huggingface/hub-docs/issues/642#issuecomment-1822807736:
> (nit) for me would be more logical in that order:
> - Intro - why gated models
> - How to manage gated models
> - How to use gated models (just clicking things through form, logging in, etc)

**TODO:**
- [x] gated models
- [ ] gated datasets