### PR TITLE
Change Maximize text to Minimize when it is already maximized

### DIFF
--- a/js/src/lib/components/InferenceWidget/shared/WidgetFooter/WidgetFooter.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetFooter/WidgetFooter.svelte
@@ -3,6 +3,7 @@
 	import IconMaximize from "../../../Icons/IconMaximize.svelte";
 
 	export let onClickMaximizeBtn: () => void;
+	export let isMaximized = false;
 	export let outputJson: string;
 	export let isDisabled = false;
 
@@ -24,7 +25,11 @@
 	{/if}
 	<button class="ml-auto flex items-center" on:click|preventDefault={onClickMaximizeBtn}>
 		<IconMaximize classNames="mr-1" />
-		Maximize
+		{#if !isMaximized}
+			Maximize
+		{:else}
+			Minimize
+		{/if}
 	</button>
 </div>
 {#if outputJson && isOutputJsonVisible}

--- a/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/js/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -149,6 +149,6 @@
 			<WidgetModelLoading estimatedTime={modelLoading.estimatedTime} />
 		{/if}
 		<slot name="bottom" />
-		<WidgetFooter {onClickMaximizeBtn} {outputJson} {isDisabled} />
+		<WidgetFooter {onClickMaximizeBtn} {isMaximized} {outputJson} {isDisabled} />
 	</div>
 {/if}


### PR DESCRIPTION
Change the text from `Maximize` to `Minimize` in the model cards when they are already Maximized.

Minimized Card:
![image](https://github.com/huggingface/hub-docs/assets/43399374/52e19963-52c2-4a21-b06a-79bfc5431b54)

Maximized Card: 
![image](https://github.com/huggingface/hub-docs/assets/43399374/caa0925f-ed83-41cd-92b8-a7e1ff1fc505)

> Whereas in the maximized version, the button should have text of `Minimize`

(Example Link: https://huggingface.co/facebook/musicgen-stereo-large?text=peaceful+music+for+studying)
