### PR TITLE
Ignore pycache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 .vscode/
 .idea/
-
+__pycache__/
 .DS_Store


### PR DESCRIPTION
When doing `doc-builder preview hub`, `__pycache__/` is created in the docs/hub folder, but it should be ignored by the git before anyone pushes it by mistake.

Changes: Have added it to the `.gitignore` file.