### PR TITLE
Warn about truncation when listing collections

### DIFF
--- a/docs/hub/api.md
+++ b/docs/hub/api.md
@@ -299,8 +299,13 @@ List collections from the Hub, based on some criteria. The supported parameters 
 
 If no parameter is set, all collections are returned.
 
-The returned result is paginated. To get all collections, you must follow the
 The response is paginated. To get all collections, you must follow the [`Link` header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#link-header).
+
+<Tip warning={true}>
+
+When listing collections, the items list per collection is truncated to 4 items maximum. To retrieve all items from a collection, you need to make an additional call using its collection slug.
+
+</Tip>
 
 Payload:
 


### PR DESCRIPTION
Related to [slack thread](https://huggingface.slack.com/archives/C02EMARJ65P/p1701172683580399) (internal).

`GET /api/collections` do not return complete objects. Collections are truncated to keep only 4 items for performance reasons. This PR adds a warning in the `api.md` documentation.