### PR TITLE
Integrate SetFit library

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -87,6 +87,8 @@
         title: Sample Factory
       - local: sentence-transformers
         title: Sentence Transformers
+      - local: setfit
+        title: SetFit
       - local: spacy
         title: spaCy
       - local: span_marker

--- a/docs/hub/models-libraries.md
+++ b/docs/hub/models-libraries.md
@@ -29,6 +29,7 @@ The table below summarizes the supported libraries and their level of integratio
 | [RL-Baselines3-Zoo](https://github.com/DLR-RM/rl-baselines3-zoo)            | Training framework for Reinforcement Learning, using [Stable Baselines3](https://github.com/DLR-RM/stable-baselines3).| ❌ | ✅ | ✅ | ✅ |
 | [Sample Factory](https://github.com/alex-petrenko/sample-factory)           | Codebase for high throughput asynchronous reinforcement learning.                    | ❌ | ✅ | ✅ | ✅ |
 | [Sentence Transformers](https://github.com/UKPLab/sentence-transformers)    | Compute dense vector representations for sentences, paragraphs, and images.          | ✅ | ✅ | ✅ | ✅ |
+| [SetFit](https://github.com/huggingface/setfit)                             | Efficient few-shot text classification with Sentence Transformers                    | ✅ | ✅ | ✅ | ✅ |
 | [spaCy](https://github.com/explosion/spaCy)                                 | Advanced Natural Language Processing in Python and Cython.                           | ✅ | ✅ | ✅ | ✅ |
 | [SpanMarker](https://github.com/tomaarsen/SpanMarkerNER)                    | Familiar, simple and state-of-the-art Named Entity Recognition.                      | ✅ | ✅ | ✅ | ✅ |
 | [Scikit Learn (using skops)](https://skops.readthedocs.io/en/stable/)       | Machine Learning in Python.                                                          | ✅ | ✅ | ✅ | ✅ |

--- a/docs/hub/setfit.md
+++ b/docs/hub/setfit.md
@@ -4,7 +4,7 @@ SetFit is an efficient and prompt-free framework for few-shot fine-tuning of [Se
 
 Compared to other few-shot learning methods, SetFit has several unique features:
 
-* 🗣 **No prompts or verbalisers:** Current techniques for few-shot fine-tuning require handcrafted prompts or verbalisers to convert examples into a format that's suitable for the underlying language model. SetFit dispenses with prompts altogether by generating rich embeddings directly from text examples.
+* 🗣 **No prompts or verbalizers:** Current techniques for few-shot fine-tuning require handcrafted prompts or verbalizers to convert examples into a format suitable for the underlying language model. SetFit dispenses with prompts altogether by generating rich embeddings directly from text examples.
 * 🏎 **Fast to train:** SetFit doesn't require large-scale models like T0 or GPT-3 to achieve high accuracy. As a result, it is typically an order of magnitude (or more) faster to train and run inference with.
 * 🌎 **Multilingual support**: SetFit can be used with any [Sentence Transformer](https://huggingface.co/models?library=sentence-transformers&sort=downloads) on the Hub, which means you can classify text in multiple languages by simply fine-tuning a multilingual checkpoint.
 
@@ -40,14 +40,14 @@ Once loaded, you can use [`SetFitModel.predict`](https://huggingface.co/docs/set
 ```py
 model.predict("Amelia Earhart flew her single engine Lockheed Vega 5B across the Atlantic to Paris.")
 ```
-```py
+```bash
 ['positive', 'negative']
 ```
 
 If you want to load a specific SpanMarker model, you can click `Use in SetFit` and you will be given a working snippet!
 
 ## Additional resources
-
+* [All SetFit models available on Hub](https://huggingface.co/models?library=setfit)
 * SetFit [repository](https://github.com/huggingface/setfit)
 * SetFit [docs](https://huggingface.co/docs/setfit)
 * SetFit [paper](https://arxiv.org/abs/2209.11055)

--- a/docs/hub/setfit.md
+++ b/docs/hub/setfit.md
@@ -1,0 +1,53 @@
+# Using SetFit with Hugging Face
+
+SetFit is an efficient and prompt-free framework for few-shot fine-tuning of [Sentence Transformers](https://sbert.net/). It achieves high accuracy with little labeled data - for instance, with only 8 labeled examples per class on the Customer Reviews sentiment dataset, SetFit is competitive with fine-tuning RoBERTa Large on the full training set of 3k examples 🤯!
+
+Compared to other few-shot learning methods, SetFit has several unique features:
+
+* 🗣 **No prompts or verbalisers:** Current techniques for few-shot fine-tuning require handcrafted prompts or verbalisers to convert examples into a format that's suitable for the underlying language model. SetFit dispenses with prompts altogether by generating rich embeddings directly from text examples.
+* 🏎 **Fast to train:** SetFit doesn't require large-scale models like T0 or GPT-3 to achieve high accuracy. As a result, it is typically an order of magnitude (or more) faster to train and run inference with.
+* 🌎 **Multilingual support**: SetFit can be used with any [Sentence Transformer](https://huggingface.co/models?library=sentence-transformers&sort=downloads) on the Hub, which means you can classify text in multiple languages by simply fine-tuning a multilingual checkpoint.
+
+## Exploring SetFit on the Hub
+
+You can find SetFit models by filtering at the left of the [models page](https://huggingface.co/models?library=setfit).
+
+All models on the Hub come with these useful features:
+1. An automatically generated model card with a brief description.
+2. An interactive widget you can use to play with the model directly in the browser.
+3. An Inference API that allows you to make inference requests.
+
+## Installation
+
+To get started, you can follow the [SetFit installation guide](https://huggingface.co/docs/setfit/installation). You can also use the following one-line install through pip:
+
+```
+pip install -U setfit
+```
+
+## Using existing models
+
+All `setfit` models can easily be loaded from the Hub.
+
+```py
+from setfit import SetFitModel
+
+model = SetFitModel.from_pretrained("tomaarsen/setfit-paraphrase-mpnet-base-v2-sst2-8-shot")
+```
+
+Once loaded, you can use [`SetFitModel.predict`](https://huggingface.co/docs/setfit/reference/main#setfit.SetFitModel.predict) to perform inference.
+
+```py
+model.predict("Amelia Earhart flew her single engine Lockheed Vega 5B across the Atlantic to Paris.")
+```
+```py
+['positive', 'negative']
+```
+
+If you want to load a specific SpanMarker model, you can click `Use in SetFit` and you will be given a working snippet!
+
+## Additional resources
+
+* SetFit [repository](https://github.com/huggingface/setfit)
+* SetFit [docs](https://huggingface.co/docs/setfit)
+* SetFit [paper](https://arxiv.org/abs/2209.11055)

--- a/docs/hub/setfit.md
+++ b/docs/hub/setfit.md
@@ -44,10 +44,10 @@ model.predict("Amelia Earhart flew her single engine Lockheed Vega 5B across the
 ['positive', 'negative']
 ```
 
-If you want to load a specific SpanMarker model, you can click `Use in SetFit` and you will be given a working snippet!
+If you want to load a specific SetFit model, you can click `Use in SetFit` and you will be given a working snippet!
 
 ## Additional resources
-* [All SetFit models available on Hub](https://huggingface.co/models?library=setfit)
+* [All SetFit models available on the Hub](https://huggingface.co/models?library=setfit)
 * SetFit [repository](https://github.com/huggingface/setfit)
 * SetFit [docs](https://huggingface.co/docs/setfit)
 * SetFit [paper](https://arxiv.org/abs/2209.11055)

--- a/docs/hub/setfit.md
+++ b/docs/hub/setfit.md
@@ -5,7 +5,7 @@ SetFit is an efficient and prompt-free framework for few-shot fine-tuning of [Se
 Compared to other few-shot learning methods, SetFit has several unique features:
 
 * 🗣 **No prompts or verbalizers:** Current techniques for few-shot fine-tuning require handcrafted prompts or verbalizers to convert examples into a format suitable for the underlying language model. SetFit dispenses with prompts altogether by generating rich embeddings directly from text examples.
-* 🏎 **Fast to train:** SetFit doesn't require large-scale models like T0 or GPT-3 to achieve high accuracy. As a result, it is typically an order of magnitude (or more) faster to train and run inference with.
+* 🏎 **Fast to train:** SetFit doesn't require large-scale models like [T0](https://huggingface.co/bigscience/T0) or GPT-3 to achieve high accuracy. As a result, it is typically an order of magnitude (or more) faster to train and run inference with.
 * 🌎 **Multilingual support**: SetFit can be used with any [Sentence Transformer](https://huggingface.co/models?library=sentence-transformers&sort=downloads) on the Hub, which means you can classify text in multiple languages by simply fine-tuning a multilingual checkpoint.
 
 ## Exploring SetFit on the Hub


### PR DESCRIPTION
Hello!

## Pull Request overview
* Integrate with the [SetFit](https://github.com/huggingface/setfit) library for Text Classification.

## Details
[SetFit](https://github.com/huggingface/setfit) is a library for text classification with ~1200 models on the Hub at the time of writing. A v1.0.0 release is upcoming, and it's a good time to add this widget support, etc. It can be used like so:
```python
from setfit import SetFitModel

model = SetFitModel.from_pretrained("tomaarsen/span-marker-bert-base-fewnerd-fine-super")
```
```
model.predict(["That was an awful movie"])
# => ["negative"]
```

I've followed the documentation [here](https://huggingface.co/docs/hub/models-adding-libraries), but it seems to be a bit outdated compared to the last time that I added an integration. It still mentions to edit `model-libraries.ts` with a snippet like
```js
const asteroid = (model: ModelData) =>
`from asteroid.models import BaseModel
  
model = BaseModel.from_pretrained("${model.id}")`;
```
But that type of data isn't in that file anymore. (cc: @coyotte508 ?)
Presumably I also have to update that in huggingface.js?

Note: Some of the links, e.g. https://huggingface.co/docs/setfit/reference/main#setfit.SetFitModel.predict, do not currently work, but will start working when [SetFit v1.0.0](https://github.com/huggingface/setfit/pull/439) releases next week. 

Related PRs:
* https://github.com/huggingface/api-inference-community/pull/359
* https://github.com/huggingface/huggingface.js/pull/387

- Tom Aarsen