### PR TITLE
Add reminder for model card consistency

### DIFF
--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -30,4 +30,3 @@ jobs:
           token: ${{ secrets.comment_bot_token }}
           body-include: It looks like you've updated documentation related to model or dataset cards in this PR.
           number: 1186
-          #     # issue-number: ${{ steps.github-context.outputs.pr_number }}

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -28,5 +28,5 @@ jobs:
               - [datasetcard.md](https://github.com/huggingface/hub-docs/blob/main/datasetcard.md)
               - [docs/hub/datasets-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/datasets-cards.md)
           token: ${{ secrets.comment_bot_token }}
-          body-include: It looks like you've updated documentation related to model or dataset cards in this PR.
+          body-include: '<!-- Created by actions-cool/maintain-one-comment -->'
           number: 1186

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -14,8 +14,8 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - name: Create comment
-        uses: peter-evans/create-or-update-comment@v3
+      - name: maintain-comment
+        uses: actions-cool/maintain-one-comment@v3
         with:
           body: |
             It looks like you've updated documentation related to model or dataset cards in this PR.
@@ -28,6 +28,11 @@ jobs:
               - [datasetcard.md](https://github.com/huggingface/hub-docs/blob/main/datasetcard.md)
               - [docs/hub/datasets-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/datasets-cards.md)
           token: ${{ secrets.comment_bot_token }}
-          issue-number: 1186
+          body-include: It looks like you've updated documentation related to model or dataset cards in this PR.
+          number: 1186
+      # - name: Create comment
+      #   uses: peter-evans/create-or-update-comment@v3
+      #   with:
 
-          # issue-number: ${{ steps.github-context.outputs.pr_number }}
+      #     issue-number: 1186
+      #     # issue-number: ${{ steps.github-context.outputs.pr_number }}

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -1,7 +1,7 @@
 name: Model and Dataset Card consistency reminder
 
 on:
-  push: // temporary trigger for testing purposes
+  push: # temporary trigger for testing purposes
   pull_request:
     paths:
       - modelcard.md

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -28,5 +28,4 @@ jobs:
               - [src/.../repocard.py](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/repocard.py) (`huggingface_hub` repo)
               - [datasetcard.md](https://github.com/huggingface/hub-docs/blob/main/datasetcard.md)
               - [docs/hub/datasets-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/datasets-cards.md)
-          pr_number: ${{ steps.github-context.outputs.pr_number }}
-          GITHUB_TOKEN: ${{ secrets.comment_bot_token }}
+          token: ${{ secrets.comment_bot_token }}

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -14,19 +14,11 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - name: Find doc comment
-        uses: peter-evans/find-comment@v2
-        id: find_comment
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v3
         with:
           issue-number: ${{ steps.github-context.outputs.pr_number }}
-          body-includes: docs for this PR
-
-      - name: Add doc comment if not present
-        uses: thollander/actions-comment-pull-request@v2
-        if: steps.find_comment.outputs.comment-id == ''
-
-        with:
-          message: |
+          body: |
             It looks like you've updated documentation related to model or dataset cards in this PR.
             Please make sure that the following files stay consistent:
               - [modelcard.md](https://github.com/huggingface/hub-docs/blob/main/modelcard.md)

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -30,9 +30,4 @@ jobs:
           token: ${{ secrets.comment_bot_token }}
           body-include: It looks like you've updated documentation related to model or dataset cards in this PR.
           number: 1186
-      # - name: Create comment
-      #   uses: peter-evans/create-or-update-comment@v3
-      #   with:
-
-      #     issue-number: 1186
-      #     # issue-number: ${{ steps.github-context.outputs.pr_number }}
+          #     # issue-number: ${{ steps.github-context.outputs.pr_number }}

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -3,7 +3,9 @@ name: Model and Dataset Card consistency reminder
 on:
   pull_request:
     paths:
-      - docs/hub/datasets-cards.md.md
+      - modelcard.md
+      - datasetcard.md
+      - docs/hub/datasets-cards.md
       - docs/hub/model-cards.md
       - docs/hub/model-card-annotated.md
 
@@ -26,10 +28,12 @@ jobs:
           message: |
             It looks like you've updated documentation related to model or dataset cards in this PR.
             Please make sure that the following files stay consistent between them:
-              - [datasets-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/datasets-cards.md)
-              - [model-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/model-cards.md)
-              - [model-card-annotated.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/model-card-annotated.md)
-              - [modelcard_template.md](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/templates/modelcard_template.md) (`huggingface_hub` repo)
-              - [repocard.py](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/repocard.py) (`huggingface_hub` repo)
+              - [modelcard.md](https://github.com/huggingface/hub-docs/blob/main/modelcard.md)
+              - [docs/hub/model-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/model-cards.md)
+              - [docs/hub/model-card-annotated.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/model-card-annotated.md)
+              - [src/.../modelcard_template.md](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/templates/modelcard_template.md) (`huggingface_hub` repo)
+              - [src/.../repocard.py](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/repocard.py) (`huggingface_hub` repo)
+              - [datasetcard.md](https://github.com/huggingface/hub-docs/blob/main/datasetcard.md)
+              - [docs/hub/datasets-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/datasets-cards.md)
           pr_number: ${{ steps.github-context.outputs.pr_number }}
           GITHUB_TOKEN: ${{ secrets.comment_bot_token }}

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -29,4 +29,5 @@ jobs:
               - [docs/hub/datasets-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/datasets-cards.md)
           token: ${{ secrets.comment_bot_token }}
           issue-number: 1186
+
           # issue-number: ${{ steps.github-context.outputs.pr_number }}

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -18,7 +18,8 @@ jobs:
         with:
           body: |
             It looks like you've updated documentation related to model or dataset cards in this PR.
-            Please make sure that the following files stay consistent:
+
+            Some content is duplicated among the following files. Please make sure that everything stays consistent.
               - [modelcard.md](https://github.com/huggingface/hub-docs/blob/main/modelcard.md)
               - [docs/hub/model-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/model-cards.md)
               - [docs/hub/model-card-annotated.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/model-card-annotated.md)

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -28,4 +28,5 @@ jobs:
               - [datasetcard.md](https://github.com/huggingface/hub-docs/blob/main/datasetcard.md)
               - [docs/hub/datasets-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/datasets-cards.md)
           token: ${{ secrets.comment_bot_token }}
-          issue-number: ${{ steps.github-context.outputs.pr_number }}
+          issue-number: 1186
+          # issue-number: ${{ steps.github-context.outputs.pr_number }}

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -1,0 +1,35 @@
+name: Model and Dataset Card consistency reminder
+
+on:
+  pull_request:
+    paths:
+      - docs/hub/datasets-cards.md.md
+      - docs/hub/model-cards.md
+      - docs/hub/model-card-annotated.md
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find doc comment
+        uses: peter-evans/find-comment@v2
+        id: find_comment
+        with:
+          issue-number: ${{ steps.github-context.outputs.pr_number }}
+          body-includes: docs for this PR
+
+      - name: Add doc comment if not present
+        uses: thollander/actions-comment-pull-request@v2
+        if: steps.find_comment.outputs.comment-id == ''
+
+        with:
+          message: |
+            It looks like you've updated documentation related to model or dataset cards in this PR.
+            Please make sure that the following files stay consistent between them:
+              - [datasets-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/datasets-cards.md)
+              - [model-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/model-cards.md)
+              - [model-card-annotated.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/model-card-annotated.md)
+              - [modelcard_template.md](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/templates/modelcard_template.md) (`huggingface_hub` repo)
+              - [repocard.py](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/repocard.py) (`huggingface_hub` repo)
+          pr_number: ${{ steps.github-context.outputs.pr_number }}
+          GITHUB_TOKEN: ${{ secrets.comment_bot_token }}

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -1,6 +1,7 @@
 name: Model and Dataset Card consistency reminder
 
 on:
+  push: // temporary trigger for testing purposes
   pull_request:
     paths:
       - modelcard.md
@@ -27,7 +28,7 @@ jobs:
         with:
           message: |
             It looks like you've updated documentation related to model or dataset cards in this PR.
-            Please make sure that the following files stay consistent between them:
+            Please make sure that the following files stay consistent:
               - [modelcard.md](https://github.com/huggingface/hub-docs/blob/main/modelcard.md)
               - [docs/hub/model-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/model-cards.md)
               - [docs/hub/model-card-annotated.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/model-card-annotated.md)

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -28,5 +28,5 @@ jobs:
               - [datasetcard.md](https://github.com/huggingface/hub-docs/blob/main/datasetcard.md)
               - [docs/hub/datasets-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/datasets-cards.md)
           token: ${{ secrets.comment_bot_token }}
-          body-include: '<!-- Created by actions-cool/maintain-one-comment -->'
           number: 1186
+          body-include: '<!-- Created by actions-cool/maintain-one-comment -->'

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -1,7 +1,6 @@
 name: Model and Dataset Card consistency reminder
 
 on:
-  push: # temporary trigger for testing purposes
   pull_request:
     paths:
       - modelcard.md
@@ -28,5 +27,4 @@ jobs:
               - [datasetcard.md](https://github.com/huggingface/hub-docs/blob/main/datasetcard.md)
               - [docs/hub/datasets-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/datasets-cards.md)
           token: ${{ secrets.comment_bot_token }}
-          number: 1186
           body-include: '<!-- Created by actions-cool/maintain-one-comment -->'

--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v3
         with:
-          issue-number: ${{ steps.github-context.outputs.pr_number }}
           body: |
             It looks like you've updated documentation related to model or dataset cards in this PR.
             Please make sure that the following files stay consistent:
@@ -29,3 +28,4 @@ jobs:
               - [datasetcard.md](https://github.com/huggingface/hub-docs/blob/main/datasetcard.md)
               - [docs/hub/datasets-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/datasets-cards.md)
           token: ${{ secrets.comment_bot_token }}
+          issue-number: ${{ steps.github-context.outputs.pr_number }}


### PR DESCRIPTION
Following several discussions in slack.
Model Card documentation is scattered in several files that must be kept consistent between themselves (especially `model-card.md`, `model-card-annotated.md` and the model card template in `huggingface_hub`). As it's easy to forget one, this simple bot should comment on PRs that update one of those files to remind the PR author and reviewers to check the consistency. No need to build a more advanced tool IMO (a simple reminder should be enough).

As an example, I've recently updated modelcard.md in https://github.com/huggingface/hub-docs/pull/1144 and forgot the annotated one (fixed by @meg-huggingface in https://github.com/huggingface/hub-docs/pull/1178).

@mishig25 I pinged you as well as the master of github workflows. I reused parts of "build pr documentation" workflow.

~~(**note:** I did not test this PR. Not sure we can easily test it.)~~

this is how it looks like:
<img width="500" alt="image" src="https://github.com/huggingface/hub-docs/assets/11827707/73cd5533-71e5-4f1e-867a-d13f8260317a">
