### PR TITLE
add forgotten link in modelcard consistency check

### DIFF
--- a/.github/workflows/model_card_consistency_reminder.yml
+++ b/.github/workflows/model_card_consistency_reminder.yml
@@ -24,6 +24,7 @@ jobs:
               - [docs/hub/model-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/model-cards.md)
               - [docs/hub/model-card-annotated.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/model-card-annotated.md)
               - [src/.../modelcard_template.md](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/templates/modelcard_template.md) (`huggingface_hub` repo)
+              - [src/.../datasetcard_template.md](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/templates/datasetcard_template.md) (`huggingface_hub` repo)
               - [src/.../repocard.py](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/repocard.py) (`huggingface_hub` repo)
               - [datasetcard.md](https://github.com/huggingface/hub-docs/blob/main/datasetcard.md)
               - [docs/hub/datasets-cards.md](https://github.com/huggingface/hub-docs/blob/main/docs/hub/datasets-cards.md)


### PR DESCRIPTION
Related to https://github.com/huggingface/hub-docs/pull/1186 and https://github.com/huggingface/huggingface_hub/pull/1979. I realized I forgot to link to the datasetcard template in the message posted on the PR. This PR fixes this.