### PR TITLE
Correct `info.json` example contents in Unity Sentis documentation.

### DIFF
--- a/docs/hub/unity-sentis.md
+++ b/docs/hub/unity-sentis.md
@@ -47,9 +47,9 @@ Finally, please provide an ``info.json`` file, which lists your project's files.
 
 ```
 {
-   code: [ “mycode.cs”], 
-   models: [ “model1.sentis”, “model2.sentis”],
-   data: [ “vocab.txt” ]
+   "code": [ "mycode.cs"], 
+   "models": [ "model1.sentis", "model2.sentis"],
+   "data": [ "vocab.txt" ]
 }
 ```
 
@@ -57,8 +57,8 @@ Or if your code sample is external:
 
 ```
 {
-   sampleURL: [ “http://sampleunityproject”], 
-   models: [ “model1.sentis”, “model2.sentis”]
+   "sampleURL": [ "http://sampleunityproject"], 
+   "models": [ "model1.sentis", "model2.sentis"]
 }
 ```
 


### PR DESCRIPTION
A bit of nitpick, but the example contents of `info.json` are valid JSON. They're missing quotation for the keys, and are also using ” (ASCII 8220) instead of ” (ASCII 34) for the string values.