### PR TITLE
feat: add link to DataCamp code along

### DIFF
--- a/docs/hub/transformers.md
+++ b/docs/hub/transformers.md
@@ -26,6 +26,8 @@ You can try out the models directly in the browser if you want to test them out 
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/libraries-transformers_widget-dark.png"/>
 </div>
 
+If you prefer an interactive tutorial with an accompanying video, try [this code-along](https://www.datacamp.com/code-along/using-open-source-models-hugging-face) providing an overview of transformers and the Hugging Face ecosystem.
+
 ## Using existing models
 
 All `transformer` models are a line away from being used! Depending on how you want to use them, you can use the high-level API using the `pipeline` function or you can use `AutoModel` for more control.


### PR DESCRIPTION
Hi,

I suggest to add a link to the transformers section, to a free code along on DataCamp about navigating and interacting with the HuggingFace ecosystem. Hope you consider this a relevant resource to add!
Happy to provide more context if you'd like.

Regards,

Filip