### PR TITLE
index.md - Add "🤗 Hugging Face Hub - Table of Contents" above un-labeled colored boxes.

### DIFF
--- a/docs/hub/index.md
+++ b/docs/hub/index.md
@@ -2,6 +2,8 @@
 
 The Hugging Face Hub is a platform with over 350k models, 75k datasets, and 150k demo apps (Spaces), all open source and publicly available, in an online platform where people can easily collaborate and build ML together. The Hub works as a central place where anyone can explore, experiment, collaborate, and build technology with Machine Learning. Are you ready to join the path towards open source Machine Learning? 🤗
 
+## 🤗 Hugging Face Hub - Table of Contents
+
 <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 md:mt-10">
 
 <div class="group flex flex-col space-y-2 rounded-xl border border-orange-100 bg-gradient-to-br from-orange-50 dark:bg-none px-6 py-4 transition-colors hover:shadow dark:border-orange-700">


### PR DESCRIPTION
**=== What ===**
- Add `## 🤗 Hugging Face Hub - Table of Contents` <br> below the intro paragraph <br> but above the colorful boxes for the table of contents in the middle of the page.

**=== Motivation ===**
It's not obvious to a first time visitor that the flex grid in the middle is the same set of information in the sidebar.

By adding information that these colored boxes are the table of contents (and not micellaneous out-links as some viewers might think), it becomes clearer, more orienting, and less overwhelming.

**=== Mockup ===**

**Before PR**
![huggingface co_docs_hub_index (1 before PR)](https://github.com/huggingface/hub-docs/assets/65138515/ccba5128-97dc-4c77-b938-1e0de30e8536)

**After PR**
![huggingface co_docs_hub_index (2 after PR)](https://github.com/huggingface/hub-docs/assets/65138515/09a14e0c-893d-45e6-b75f-3876237ab266)

