### PR TITLE
use `base_model` to encode that a model is a quantized version of another model

### DIFF
--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -110,7 +110,7 @@ If it's not specified, the Hub will try to automatically detect the library type
 
 ### Specifying a base model
 
-If your model is a fine-tune, an adapter, or a quantized version of a base model, you can specify the base model in the model card metadata section. This information can also be used to indicate if your model is a merge of multiple existing models. The `base_model` field can either be a single model ID, or a list of one or more base_models (specified by their Hub identifier). 
+If your model is a fine-tune, an adapter, or a quantized version of a base model, you can specify the base model in the model card metadata section. This information can also be used to indicate if your model is a merge of multiple existing models. The `base_model` field can either be a single model ID, or a list of one or more base_models (specified by their Hub identifiers). 
 
 ```yaml
 base_model: HuggingFaceH4/zephyr-7b-beta

--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -110,24 +110,17 @@ If it's not specified, the Hub will try to automatically detect the library type
 
 ### Specifying a base model
 
-If your model is a fine-tune, an adapter, or a quantized version of a base model, you can specify the base model in the model card metadata section. This information can also be used to indicate if your model is a merge of multiple existing models. The `base_model` field can either be a single model ID, or a list of one or more base_models (specified by their Hub identifiers). 
+If your model is a fine-tune, an adapter, or a quantized version of a base model, you can specify the base model in the model card metadata section. This information can also be used to indicate if your model is a merge of multiple existing models. Hence, the `base_model` field can either be a single model ID, or a list of one or more base_models (specified by their Hub identifiers). 
 
 ```yaml
 base_model: HuggingFaceH4/zephyr-7b-beta
 ```
 
-This metadata will be used to display the base model on the model page. Users can also use this information to filter models by base model or find models that are fine-tuned from a specific base model.
+This metadata will be used to display the base model on the model page. Users can also use this information to filter models by base model or find models that are fine-tuned from a specific base model:
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base-model-ui.png"/>
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base-model-ui-dark.png"/>
-</div>
-
-For a merge of two or more models:
-
-<div class="flex justify-center">
-<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base_model_merge.png"/>
-<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base_model_merge-dark.png"/>
 </div>
 
 For an adapter (LoRA, PEFT, etc):
@@ -143,6 +136,21 @@ For a quantized version of another model:
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base_model_quantized.png"/>
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base_model_quantized-dark.png"/>
 </div>
+
+Finally, for a merge of two or more models:
+
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base_model_merge.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base_model_merge-dark.png"/>
+</div>
+
+In the merge case, you specify a list of two or more base_models:
+
+```yaml
+base_model:
+- Endevor/InfinityRP-v1-7B
+- l3utterfly/mistral-7b-v0.1-layla-v4
+```
 
 ### Specifying a dataset
 

--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -123,6 +123,27 @@ This metadata will be used to display the base model on the model page. Users ca
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base-model-ui-dark.png"/>
 </div>
 
+For a merge of two or more models:
+
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base_model_merge.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base_model_merge-dark.png"/>
+</div>
+
+For an adapter (LoRA, PEFT, etc):
+
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base_model_adapter.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base_model_adapter-dark.png"/>
+</div>
+
+For a quantized version of another model:
+
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base_model_quantized.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/base_model_quantized-dark.png"/>
+</div>
+
 ### Specifying a dataset
 
 You can specify the datasets used to train your model in the model card metadata section. The datasets will be displayed on the model page and users will be able to filter models by dataset. You should use the Hub dataset identifier, which is the same as the dataset's repo name as the identifier:

--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -33,7 +33,7 @@ The metadata you add to the model card supports discovery and easier use of your
 
 * Allowing users to filter models at https://huggingface.co/models.
 * Displaying the model's license.
-* Adding datasets to the metadata will add a message reading `Datasets used to train:` to your model card and link the relevant datasets, if they're available on the Hub.
+* Adding datasets to the metadata will add a message reading `Datasets used to train:` to your model page and link the relevant datasets, if they're available on the Hub.
 
 Dataset, metric, and language identifiers are those listed on the [Datasets](https://huggingface.co/datasets), [Metrics](https://huggingface.co/metrics) and [Languages](https://huggingface.co/languages) pages.
 
@@ -110,7 +110,7 @@ If it's not specified, the Hub will try to automatically detect the library type
 
 ### Specifying a base model
 
-If your model is a fine-tune or adapter of a base model, you can specify the base model in the model card metadata section. This information can also be used to indicate if your model is a merge of multiple existing models. The `base_model` field can either be a single model ID, or a list of one or more base_models (specified by their Hub identifier). 
+If your model is a fine-tune, an adapter, or a quantized version of a base model, you can specify the base model in the model card metadata section. This information can also be used to indicate if your model is a merge of multiple existing models. The `base_model` field can either be a single model ID, or a list of one or more base_models (specified by their Hub identifier). 
 
 ```yaml
 base_model: HuggingFaceH4/zephyr-7b-beta

--- a/docs/hub/peft.md
+++ b/docs/hub/peft.md
@@ -18,7 +18,7 @@ $ pip install peft
 
 ## Using existing models
 
-All PEFT models can be loaded from the Hub. To use a PEFT model you also need to load the base model that was fine-tuned, as shown below. Every fine-tuned model has the base model in it's model card.
+All PEFT models can be loaded from the Hub. To use a PEFT model you also need to load the base model that was fine-tuned, as shown below. Every fine-tuned model has the base model in its model card.
 
 ```py
 from transformers import AutoModelForCausalLM, AutoTokenizer


### PR DESCRIPTION
## screenshots

<img width="674" alt="base_model_quantized" src="https://github.com/huggingface/hub-docs/assets/326577/a5d3abd2-247c-419a-9f6e-12823f5a47d1">
<img width="662" alt="base_model_quantized-dark" src="https://github.com/huggingface/hub-docs/assets/326577/88a4f19c-9470-49d5-9936-5a6e9c0ccd42">

## Credits

idea from @PrithivirajDamodaran