### PR TITLE
Add quotes so that a git command works on fish shell too

### DIFF
--- a/docs/hub/repositories-pull-requests-discussions.md
+++ b/docs/hub/repositories-pull-requests-discussions.md
@@ -143,7 +143,7 @@ You can tweak your local **refspec** to fetch all Pull requests:
 1. Fetch
 
 ```bash
-git fetch origin refs/pr/*:refs/remotes/origin/pr/*
+git fetch origin "refs/pr/*:refs/remotes/origin/pr/*"
 ```
 
 2. create a local branch tracking the ref


### PR DESCRIPTION
This is a pretty small change. But it could make the page a little more smooth.

This new quoted version works in both bash and fish.