### PR TITLE
Update docs about Keras models

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -78,7 +78,7 @@
       - local: keras
         title: Keras
       - local: tf-keras
-        title: TF-Keras
+        title: TF-Keras (legacy)
       - local: ml-agents
         title: ML-Agents
       - local: mlx-image

--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -77,6 +77,8 @@
         title: Flair
       - local: keras
         title: Keras
+      - local: tf-keras
+        title: TF-Keras
       - local: ml-agents
         title: ML-Agents
       - local: mlx-image

--- a/docs/hub/keras.md
+++ b/docs/hub/keras.md
@@ -42,6 +42,35 @@ model.save("hf://your-username/your-model-name")
 
 By default, the repository will contain a minimal model card. Check out the [Model Card guide](https://huggingface.co/docs/hub/model-cards) to learn more about model cards and how to complete them. You can also programmatically update model cards using `huggingface_hub.ModelCard` (see [guide](https://huggingface.co/docs/huggingface_hub/guides/model-cards)).
 
+## Legacy 'tf-keras' (Keras 2)
+
+`tf-keras` is the name given to Keras 2.x version. It is now hosted as a separate GitHub repo [here](https://github.com/keras-team/tf-keras). Though it's a legacy framework, there are still [4.5k+ models](https://huggingface.co/models?library=tf-keras&sort=trending) hosted on the Hub. These models can be loaded using the `huggingface_hub` library. You **must** have either `tf-keras` or `keras<3.x` installed on your machine.
+
+Once installed, you just need to use the `from_pretrained_keras` method to load a model from the Hub. Read more about `from_pretrained_keras` [here](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/mixins#huggingface_hub.from_pretrained_keras).
+
+```py
+from huggingface_hub import from_pretrained_keras
+
+model = from_pretrained_keras("keras-io/mobile-vit-xxs")
+prediction = model.predict(image)
+prediction = tf.squeeze(tf.round(prediction))
+print(f'The image is a {classes[(np.argmax(prediction))]}!')
+
+# The image is a sunflower!
+```
+
+You can also host your `tf-keras` model on the Hub. However, keep in mind that `tf-keras` is a legacy framework. To reach a maximum number of users, we recommend to create your model using Keras 3.x and share it natively as described above. For more details about uploading `tf-keras` models, check out [`push_to_hub_keras` documentation](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/mixins#huggingface_hub.push_to_hub_keras).
+
+```py
+from huggingface_hub import push_to_hub_keras
+
+push_to_hub_keras(model,
+    "your-username/your-model-name",
+    "your-tensorboard-log-directory",
+    tags = ["object-detection", "some_other_tag"],
+    **model_save_kwargs,
+)
+```
 
 ## Additional resources
 

--- a/docs/hub/keras.md
+++ b/docs/hub/keras.md
@@ -1,75 +1,54 @@
 # Using Keras at Hugging Face
 
-`keras` is an open-source machine learning library that uses a consistent and simple API to build models leveraging TensorFlow and its ecosystem.
+Keras is an open-source multi-backend deep learning framework, with support for JAX, TensorFlow, and PyTorch. You can find more details about it on [keras.io](https://keras.io/).
 
 ## Exploring Keras in the Hub
 
 You can find over 200 `keras` models by filtering at the left of the [models page](https://huggingface.co/models?library=keras&sort=downloads).
 
-All models on the Hub come up with useful feature:
-1. An automatically generated model card with a description, a plot of the model, and more.
-2. Metadata tags that help for discoverability and contain information such as license.
-3. If provided by the model owner, TensorBoard logs are hosted on the Keras repositories.
+Keras models on the Hub come up with useful features:
+1. A generated model card with a description, a plot of the model, and more.
+2. A download count to monitor the popularity of a model.
+3. A code snippet to quickly get started with the model.
 
 
 ## Using existing models
 
-The `huggingface_hub` library is a lightweight Python client with utility functions to download models from the Hub.
+Keras is deeply integrated with the Hugging Face Hub. This means you can load and save models on the Hub directly from the library. To do that, you need to install a recent version of Keras and `huggingface_hub`. The `huggingface_hub` library is a lightweight Python client used by Keras to interact with the Hub.
 
 ```
-pip install huggingface_hub["tensorflow"]
+pip install -U keras huggingface_hub
 ```
 
-Once you have the library installed, you just need to use the `from_pretrained_keras` method. Read more about `from_pretrained_keras` [here](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/mixins#huggingface_hub.from_pretrained_keras).
+Once you have the library installed, you just need to use the regular `keras.saving.load_model` method by passing as argument an HF path. An HF path is a `repo_id` prefixed by `hf://` e.g. `"hf://keras-io/weather-prediction"`. Read more about `load_model` in [Keras documentation](https://keras.io/api/models/model_saving_apis/model_saving_and_loading/#load_model-function).
 
 ```py
-from huggingface_hub import from_pretrained_keras
+import keras
 
-model = from_pretrained_keras("keras-io/mobile-vit-xxs")
-prediction = model.predict(image)
-prediction = tf.squeeze(tf.round(prediction))
-print(f'The image is a {classes[(np.argmax(prediction))]}!')
-
-# The image is a sunflower!
+model = keras.saving.load_model("hf://Wauplin/mnist_example")
 ```
 
-If you want to see how to load a specific model, you can click **Use in keras** and you will be given a working snippet that you can load it! 
-
-<div class="flex justify-center">
-<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/libraries-keras_snippet1.png"/>
-<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/libraries-keras_snippet1-dark.png"/>
-</div>
-<div class="flex justify-center">
-<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/libraries-keras_snippet2.png"/>
-<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/libraries-keras_snippet2-dark.png"/>
-</div>
+If you want to see how to load a specific model, you can click **Use this model** on the model page to get a working code snippet! 
 
 ## Sharing your models
 
-You can share your `keras` models by using the `push_to_hub_keras` method. This will generate a model card that includes your model’s hyperparameters, plot of your model and couple of sections related to the usage purpose of your model, model biases and limitations about putting the model in production. This saves the metrics of your model in a JSON file as well. Read more about `push_to_hub_keras` [here](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/mixins#huggingface_hub.push_to_hub_keras).
+Similarly to `load_model`, you can save and share a `keras` model on the Hub using `model.save()` with an HF path. If the repository does not exist on the Hub, it will be created for you. The upload model will contain a model card, a plot of the model, the `metadata.json` and `config.json` files, and a `model.weights.h5` file containing the model weights.
+
 
 ```py
-from huggingface_hub import push_to_hub_keras
-
-push_to_hub_keras(model,
-    "your-username/your-model-name",
-    "your-tensorboard-log-directory",
-    tags = ["object-detection", "some_other_tag"],
-    **model_save_kwargs,
-)
+model = ...
+model.save("hf://your-username/your-model-name")
 ```
-The repository will host your TensorBoard traces like below.
 
-<div class="flex justify-center">
-<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/libraries-keras_tensorboard.png"/>
-<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/libraries-keras_tensorboard-dark.png"/>
-</div>
+By default, the repository will contain a minimal model card. Check out the [Model Card guide](https://huggingface.co/docs/hub/model-cards) to learn more about model cards and how to complete them. You can also programmatically update model cards using `huggingface_hub.ModelCard` (see [guide](https://huggingface.co/docs/huggingface_hub/guides/model-cards)).
 
 
 ## Additional resources
 
 * Keras Developer [Guides](https://keras.io/guides/).
 * Keras [examples](https://keras.io/examples/).
-* Keras [examples on 🤗 Hub](https://huggingface.co/keras-io).
-* Keras [learning resources](https://keras.io/getting_started/learning_resources/#moocs)
-* For more capabilities of the Keras integration, check out [Putting Keras on 🤗 Hub for Collaborative Training and Reproducibility](https://merveenoyan.medium.com/putting-keras-on-hub-for-collaborative-training-and-reproducibility-9018301de877) tutorial.
+* Keras [examples](https://keras.io/examples/).
+
+<!-- Resources below are outdated -->
+<!-- * Keras [examples on 🤗 Hub](https://huggingface.co/keras-io). -->
+<!-- * For more capabilities of the Keras integration, check out [Putting Keras on 🤗 Hub for Collaborative Training and Reproducibility](https://merveenoyan.medium.com/putting-keras-on-hub-for-collaborative-training-and-reproducibility-9018301de877) tutorial. -->

--- a/docs/hub/keras.md
+++ b/docs/hub/keras.md
@@ -4,9 +4,9 @@ Keras is an open-source multi-backend deep learning framework, with support for 
 
 ## Exploring Keras in the Hub
 
-You can find over 200 `keras` models by filtering at the left of the [models page](https://huggingface.co/models?library=keras&sort=downloads).
+You can list `keras` models on the Hub by filtering by library name on the [models page](https://huggingface.co/models?library=keras&sort=downloads).
 
-Keras models on the Hub come up with useful features:
+Keras models on the Hub come up with useful features when uploaded directly from the Keras library:
 1. A generated model card with a description, a plot of the model, and more.
 2. A download count to monitor the popularity of a model.
 3. A code snippet to quickly get started with the model.

--- a/docs/hub/keras.md
+++ b/docs/hub/keras.md
@@ -20,7 +20,7 @@ Keras is deeply integrated with the Hugging Face Hub. This means you can load an
 pip install -U keras huggingface_hub
 ```
 
-Once you have the library installed, you just need to use the regular `keras.saving.load_model` method by passing as argument an HF path. An HF path is a `repo_id` prefixed by `hf://` e.g. `"hf://keras-io/weather-prediction"`. Read more about `load_model` in [Keras documentation](https://keras.io/api/models/model_saving_apis/model_saving_and_loading/#load_model-function).
+Once you have the library installed, you just need to use the regular `keras.saving.load_model` method by passing as argument a Hugging Face path. An HF path is a `repo_id` prefixed by `hf://` e.g. `"hf://keras-io/weather-prediction"`. Read more about `load_model` in [Keras documentation](https://keras.io/api/models/model_saving_apis/model_saving_and_loading/#load_model-function).
 
 ```py
 import keras

--- a/docs/hub/keras.md
+++ b/docs/hub/keras.md
@@ -46,4 +46,3 @@ By default, the repository will contain a minimal model card. Check out the [Mod
 
 * Keras Developer [Guides](https://keras.io/guides/).
 * Keras [examples](https://keras.io/examples/).
-* Keras [examples](https://keras.io/examples/).

--- a/docs/hub/keras.md
+++ b/docs/hub/keras.md
@@ -32,7 +32,7 @@ If you want to see how to load a specific model, you can click **Use this model*
 
 ## Sharing your models
 
-Similarly to `load_model`, you can save and share a `keras` model on the Hub using `model.save()` with an HF path. If the repository does not exist on the Hub, it will be created for you. The upload model will contain a model card, a plot of the model, the `metadata.json` and `config.json` files, and a `model.weights.h5` file containing the model weights.
+Similarly to `load_model`, you can save and share a `keras` model on the Hub using `model.save()` with an HF path:
 
 
 ```py
@@ -40,7 +40,15 @@ model = ...
 model.save("hf://your-username/your-model-name")
 ```
 
+If the repository does not exist on the Hub, it will be created for you. The uploaded model contains a model card, a plot of the model, the `metadata.json` and `config.json` files, and a `model.weights.h5` file containing the model weights.
+
 By default, the repository will contain a minimal model card. Check out the [Model Card guide](https://huggingface.co/docs/hub/model-cards) to learn more about model cards and how to complete them. You can also programmatically update model cards using `huggingface_hub.ModelCard` (see [guide](https://huggingface.co/docs/huggingface_hub/guides/model-cards)).
+
+<Tip>
+
+You might be already familiar with `.keras` files. In fact, a `.keras` file is simply a zip file containing the `.json` and `model.weights.h5` files. When pushed to the Hub, the model is saved as an unzipped folder in order to let you navigate through the files. Note that if you manually upload a `.keras` file to a model repository on the Hub, the repository will automatically be tagged as `keras` but you won't be able to load it using `keras.saving.load_model`.
+
+</Tip>
 
 ## Additional resources
 

--- a/docs/hub/keras.md
+++ b/docs/hub/keras.md
@@ -42,42 +42,8 @@ model.save("hf://your-username/your-model-name")
 
 By default, the repository will contain a minimal model card. Check out the [Model Card guide](https://huggingface.co/docs/hub/model-cards) to learn more about model cards and how to complete them. You can also programmatically update model cards using `huggingface_hub.ModelCard` (see [guide](https://huggingface.co/docs/huggingface_hub/guides/model-cards)).
 
-## TF-Keras (legacy)
-
-`tf-keras` is the name given to Keras 2.x version. It is now hosted as a separate GitHub repo [here](https://github.com/keras-team/tf-keras). Though it's a legacy framework, there are still [4.5k+ models](https://huggingface.co/models?library=tf-keras&sort=trending) hosted on the Hub. These models can be loaded using the `huggingface_hub` library. You **must** have either `tf-keras` or `keras<3.x` installed on your machine.
-
-Once installed, you just need to use the `from_pretrained_keras` method to load a model from the Hub. Read more about `from_pretrained_keras` [here](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/mixins#huggingface_hub.from_pretrained_keras).
-
-```py
-from huggingface_hub import from_pretrained_keras
-
-model = from_pretrained_keras("keras-io/mobile-vit-xxs")
-prediction = model.predict(image)
-prediction = tf.squeeze(tf.round(prediction))
-print(f'The image is a {classes[(np.argmax(prediction))]}!')
-
-# The image is a sunflower!
-```
-
-You can also host your `tf-keras` model on the Hub. However, keep in mind that `tf-keras` is a legacy framework. To reach a maximum number of users, we recommend to create your model using Keras 3.x and share it natively as described above. For more details about uploading `tf-keras` models, check out [`push_to_hub_keras` documentation](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/mixins#huggingface_hub.push_to_hub_keras).
-
-```py
-from huggingface_hub import push_to_hub_keras
-
-push_to_hub_keras(model,
-    "your-username/your-model-name",
-    "your-tensorboard-log-directory",
-    tags = ["object-detection", "some_other_tag"],
-    **model_save_kwargs,
-)
-```
-
 ## Additional resources
 
 * Keras Developer [Guides](https://keras.io/guides/).
 * Keras [examples](https://keras.io/examples/).
 * Keras [examples](https://keras.io/examples/).
-
-<!-- Resources below are outdated -->
-<!-- * Keras [examples on 🤗 Hub](https://huggingface.co/keras-io). -->
-<!-- * For more capabilities of the Keras integration, check out [Putting Keras on 🤗 Hub for Collaborative Training and Reproducibility](https://merveenoyan.medium.com/putting-keras-on-hub-for-collaborative-training-and-reproducibility-9018301de877) tutorial. -->

--- a/docs/hub/keras.md
+++ b/docs/hub/keras.md
@@ -42,7 +42,7 @@ model.save("hf://your-username/your-model-name")
 
 By default, the repository will contain a minimal model card. Check out the [Model Card guide](https://huggingface.co/docs/hub/model-cards) to learn more about model cards and how to complete them. You can also programmatically update model cards using `huggingface_hub.ModelCard` (see [guide](https://huggingface.co/docs/huggingface_hub/guides/model-cards)).
 
-## Legacy 'tf-keras' (Keras 2)
+## TF-Keras (legacy)
 
 `tf-keras` is the name given to Keras 2.x version. It is now hosted as a separate GitHub repo [here](https://github.com/keras-team/tf-keras). Though it's a legacy framework, there are still [4.5k+ models](https://huggingface.co/models?library=tf-keras&sort=trending) hosted on the Hub. These models can be loaded using the `huggingface_hub` library. You **must** have either `tf-keras` or `keras<3.x` installed on your machine.
 

--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -100,7 +100,7 @@ tags:
 
 If it's not specified, the Hub will try to automatically detect the library type. Unless your model is from `transformers`, this approach is discouraged and repo creators should use the explicit `library_name` as much as possible. 
 
-1. By looking into the presence of files such as `*.nemo` or `*saved_model.pb*`, the Hub can determine if a model is from NeMo or Keras. 
+1. By looking into the presence of files such as `*.nemo` or `*.mlmodel`, the Hub can determine if a model is from NeMo or CoreML.
 2. If nothing is detected and there is a `config.json` file, it's assumed the library is `transformers`.
 
 ### Specifying a base model

--- a/docs/hub/models-libraries.md
+++ b/docs/hub/models-libraries.md
@@ -14,7 +14,8 @@ The table below summarizes the supported libraries and their level of integratio
 | [docTR](https://github.com/mindee/doctr)                                    | Models and datasets for OCR-related tasks in PyTorch & TensorFlow                    | ✅ | ✅ | ✅ | ❌ |
 | [ESPnet](./espnet)                                  | End-to-end speech processing toolkit (e.g. TTS)                                      | ✅ | ✅ | ✅ | ❌ |
 | [fastai](./fastai)                                  | Library to train fast and accurate models with state-of-the-art outputs.             | ✅ | ✅ | ✅ | ✅ |
-| [Keras](https://huggingface.co/docs/hub/keras)                              | Library that uses a consistent and simple API to build models leveraging TensorFlow and its ecosystem. | ❌ | ❌ | ✅ | ✅ |
+| [Keras](./keras)                              | Open-source multi-backend deep learning framework, with support for JAX, TensorFlow, and PyTorch. | ❌ | ❌ | ✅ | ✅ |
+| [KerasNLP](https://keras.io/guides/keras_nlp/upload/)                              | Natural language processing library built on top of Keras that works natively with TensorFlow, JAX, or PyTorch. | ❌ | ❌ | ✅ | ✅ |
 | [Flair](./flair)                                  | Very simple framework for state-of-the-art NLP.                                      | ✅ | ✅ | ✅ | ✅ |
 | [MBRL-Lib](https://github.com/facebookresearch/mbrl-lib)                    | PyTorch implementations of MBRL Algorithms.                                          | ❌ | ❌ | ✅ | ✅ |
 | [MidiTok](https://github.com/Natooz/MidiTok)                                | Tokenizers for symbolic music / MIDI files.                                          | ❌ | ❌ | ✅ | ✅ |

--- a/docs/hub/models-libraries.md
+++ b/docs/hub/models-libraries.md
@@ -16,6 +16,7 @@ The table below summarizes the supported libraries and their level of integratio
 | [fastai](./fastai)                                  | Library to train fast and accurate models with state-of-the-art outputs.             | ✅ | ✅ | ✅ | ✅ |
 | [Keras](./keras)                              | Open-source multi-backend deep learning framework, with support for JAX, TensorFlow, and PyTorch. | ❌ | ❌ | ✅ | ✅ |
 | [KerasNLP](https://keras.io/guides/keras_nlp/upload/)                              | Natural language processing library built on top of Keras that works natively with TensorFlow, JAX, or PyTorch. | ❌ | ❌ | ✅ | ✅ |
+| [TF-Keras](./keras#tf-keras-legacy) (legacy)                              | Legacy library that uses a consistent and simple API to build models leveraging TensorFlow and its ecosystem. | ❌ | ❌ | ✅ | ✅ |
 | [Flair](./flair)                                  | Very simple framework for state-of-the-art NLP.                                      | ✅ | ✅ | ✅ | ✅ |
 | [MBRL-Lib](https://github.com/facebookresearch/mbrl-lib)                    | PyTorch implementations of MBRL Algorithms.                                          | ❌ | ❌ | ✅ | ✅ |
 | [MidiTok](https://github.com/Natooz/MidiTok)                                | Tokenizers for symbolic music / MIDI files.                                          | ❌ | ❌ | ✅ | ✅ |

--- a/docs/hub/spaces-sdks-docker-first-demo.md
+++ b/docs/hub/spaces-sdks-docker-first-demo.md
@@ -202,7 +202,7 @@ textGenForm.addEventListener("submit", async (event) => {
 
 5. Grant permissions to the right directories
 
-As discussed in the [Permissions Section](./spaces-sdks-docker#permissions), the container runs with user ID 1000. That means that the Space might face permission issues. For example, `transformers` downloads and caches the models in the path under the `HUGGINGFACE_HUB_CACHE` path. The easiest way to solve this is to create a user with righ permissions and use it to run the container application. We can do this by adding the following lines to the `Dockerfile`.
+As discussed in the [Permissions Section](./spaces-sdks-docker#permissions), the container runs with user ID 1000. That means that the Space might face permission issues. For example, `transformers` downloads and caches the models in the path under the `HF_HOME` path. The easiest way to solve this is to create a user with righ permissions and use it to run the container application. We can do this by adding the following lines to the `Dockerfile`.
 
 ```Dockerfile
 # Switch to the "user" user

--- a/docs/hub/tf-keras.md
+++ b/docs/hub/tf-keras.md
@@ -1,0 +1,36 @@
+## TF-Keras (legacy)
+
+`tf-keras` is the name given to Keras 2.x version. It is now hosted as a separate GitHub repo [here](https://github.com/keras-team/tf-keras). Though it's a legacy framework, there are still [4.5k+ models](https://huggingface.co/models?library=tf-keras&sort=trending) hosted on the Hub. These models can be loaded using the `huggingface_hub` library. You **must** have either `tf-keras` or `keras<3.x` installed on your machine.
+
+If you are interested in Keras 3.x support, check out [this guide](./keras.md).
+
+Once installed, you just need to use the `from_pretrained_keras` method to load a model from the Hub. Read more about `from_pretrained_keras` [here](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/mixins#huggingface_hub.from_pretrained_keras).
+
+```py
+from huggingface_hub import from_pretrained_keras
+
+model = from_pretrained_keras("keras-io/mobile-vit-xxs")
+prediction = model.predict(image)
+prediction = tf.squeeze(tf.round(prediction))
+print(f'The image is a {classes[(np.argmax(prediction))]}!')
+
+# The image is a sunflower!
+```
+
+You can also host your `tf-keras` model on the Hub. However, keep in mind that `tf-keras` is a legacy framework. To reach a maximum number of users, we recommend to create your model using Keras 3.x and share it natively as described above. For more details about uploading `tf-keras` models, check out [`push_to_hub_keras` documentation](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/mixins#huggingface_hub.push_to_hub_keras).
+
+```py
+from huggingface_hub import push_to_hub_keras
+
+push_to_hub_keras(model,
+    "your-username/your-model-name",
+    "your-tensorboard-log-directory",
+    tags = ["object-detection", "some_other_tag"],
+    **model_save_kwargs,
+)
+```
+
+## Additional resources
+
+- [GitHub repo](https://github.com/keras-team/tf-keras)
+* Blog post [Putting Keras on 🤗 Hub for Collaborative Training and Reproducibility](https://merveenoyan.medium.com/putting-keras-on-hub-for-collaborative-training-and-reproducibility-9018301de877) (April 2022)


### PR DESCRIPTION
Related to https://github.com/keras-team/keras/pull/19854, https://github.com/huggingface/huggingface.js/pull/774 and https://github.com/huggingface/moon-landing/pull/10501 (private).

This PR updates the doc page about Keras to explain how to load/save models to the Hub using Keras nativly. For now we don't have proper examples yet but it's still better than the current outdated one. 

For review, see:
- https://moon-ci-docs.huggingface.co/docs/hub/pr_1320/en/keras
- https://moon-ci-docs.huggingface.co/docs/hub/pr_1320/en/tf-keras