### PR TITLE
Fix link to model widgets enable section

### DIFF
--- a/docs/hub/model-cards.md
+++ b/docs/hub/model-cards.md
@@ -168,7 +168,7 @@ datasets:
 
 ### Specifying a task (`pipeline_tag`)
 
-You can specify the `pipeline_tag` in the model card metadata. The `pipeline_tag` indicates the type of task the model is intended for. This tag will be displayed on the model page and users can filter models on the Hub by task. This tag is also used to determine which [widget](./models-widgets.md#enabling-a-widget) to use for the model and which APIs to use under the hood.
+You can specify the `pipeline_tag` in the model card metadata. The `pipeline_tag` indicates the type of task the model is intended for. This tag will be displayed on the model page and users can filter models on the Hub by task. This tag is also used to determine which [widget](./models-widgets#enabling-a-widget) to use for the model and which APIs to use under the hood.
 
 For `transformers` models, the pipeline tag is automatically inferred from the model's `config.json` file but you can override it in the model card metadata if required. Editing this field in the metadata UI will ensure that the pipeline tag is valid. Some other libraries with Hub integration will also automatically add the pipeline tag to the model card metadata.
 


### PR DESCRIPTION
There was a superfluous `.md` extension in the link which leads the user to a 404 page.

Generated link before fix: https://huggingface.co/docs/hub/models-widgets.md#enabling-a-widget
Correct link: https://huggingface.co/docs/hub/models-widgets#enabling-a-widget