### PR TITLE
docs: add info about HF pipelines multi-threading in SageMaker inference

### DIFF
--- a/docs/sagemaker/inference.md
+++ b/docs/sagemaker/inference.md
@@ -200,6 +200,8 @@ To deploy a model directly from the 🤗 Hub to SageMaker, define two environmen
 - `HF_MODEL_ID` defines the model ID which is automatically loaded from [huggingface.co/models](http://huggingface.co/models) when you create a SageMaker endpoint. Access 10,000+ models on he 🤗 Hub through this environment variable.
 - `HF_TASK` defines the task for the 🤗 Transformers `pipeline`. A complete list of tasks can be found [here](https://huggingface.co/docs/transformers/main_classes/pipelines).
 
+> ⚠️ ** Pipelines are not optimized for parallelism (multi-threading) and tend to consume a lot of RAM. For example, on a GPU-based instance, the pipeline operates on a single vCPU. When this vCPU becomes saturated with the inference requests preprocessing, it can create a bottleneck, preventing the GPU from being fully utilized for model inference. Learn more [here](https://huggingface.co/docs/transformers/en/pipeline_webserver#using-pipelines-for-a-webserver)
+
 ```python
 from sagemaker.huggingface.model import HuggingFaceModel
 


### PR DESCRIPTION
Hi,

This PR updates the inference documentation for hugging face on sagemaker. This adds a note about Pipelines lack of multi-threading support, which can represent a CPU bottleneck in sagemaker inference endpoints.