### PR TITLE
add '(or subset)' after config

### DIFF
--- a/datasetcard.md
+++ b/datasetcard.md
@@ -34,7 +34,7 @@ task_ids:
 - {subtask_1}  # Example: multi-class-image-classification
 paperswithcode_id: {paperswithcode_id}  # Dataset id on PapersWithCode (from the URL). Example for SQuAD: squad
 configs:  # Optional. This can be used to pass additional parameters to the dataset loader, such as `data_files`, `data_dir`, and any builder-specific parameters  
-- config_name: {config_name_0}  # Name of the configuration (or subset). Example: default
+- config_name: {config_name_0}  # Name of the dataset subset, if applicable. Example: default
   data_files:
   - split: {split_name_0}  # Example: train
     path: {file_path_0}  # Example: data.csv

--- a/datasetcard.md
+++ b/datasetcard.md
@@ -40,7 +40,7 @@ configs:  # Optional. This can be used to pass additional parameters to the data
     path: {file_path_0}  # Example: data.csv
   - split: {split_name_1}  # Example: test
     path: {file_path_1}   # Example: holdout.csv
-- config_name: {config_name_1}  # Name of the configuration (or subset). Example: processed
+- config_name: {config_name_1}  # Name of the dataset subset. Example: processed
   data_files:
   - split: {split_name_3}  # Example: train
     path: {file_path_3}  # Example: data_processed.csv
@@ -69,7 +69,7 @@ dataset_info:
     #       dtype: string
     #     - name: answer_start
     #       dtype: int32
-  config_name: {config_name}  # Name of the configuration (or subset). Example for glue: sst2
+  config_name: {config_name}  # Name of the dataset subset. Example for glue: sst2
   splits:
     - name: {split_name_0}                  # Example: train
       num_bytes: {split_num_bytes_0}        # Example for SQuAD: 79317110
@@ -98,7 +98,7 @@ extra_gated_prompt: {extra_gated_prompt}  # Example for speech datasets: By clic
 
 # Optional. Add this if you want to encode a train and evaluation info in a structured way for AutoTrain or Evaluation on the Hub
 train-eval-index:
-  - config: {config_name}           # The dataset config name to use. Example for datasets without configs: default. Example for glue: sst2
+  - config: {config_name}           # The dataset subset name to use. Example for datasets without subsets: default. Example for glue: sst2
     task: {task_name}               # The task category name (same as task_category). Example: question-answering
     task_id: {task_type}            # The AutoTrain task id. Example: extractive_question_answering
     splits:

--- a/datasetcard.md
+++ b/datasetcard.md
@@ -34,13 +34,13 @@ task_ids:
 - {subtask_1}  # Example: multi-class-image-classification
 paperswithcode_id: {paperswithcode_id}  # Dataset id on PapersWithCode (from the URL). Example for SQuAD: squad
 configs:  # Optional. This can be used to pass additional parameters to the dataset loader, such as `data_files`, `data_dir`, and any builder-specific parameters  
-- config_name: {config_name_0}  # Example: default
+- config_name: {config_name_0}  # Name of the configuration (or subset). Example: default
   data_files:
   - split: {split_name_0}  # Example: train
     path: {file_path_0}  # Example: data.csv
   - split: {split_name_1}  # Example: test
     path: {file_path_1}   # Example: holdout.csv
-- config_name: {config_name_1}  # Example: processed
+- config_name: {config_name_1}  # Name of the configuration (or subset). Example: processed
   data_files:
   - split: {split_name_3}  # Example: train
     path: {file_path_3}  # Example: data_processed.csv
@@ -69,7 +69,7 @@ dataset_info:
     #       dtype: string
     #     - name: answer_start
     #       dtype: int32
-  config_name: {config_name}  # Example for glue: sst2
+  config_name: {config_name}  # Name of the configuration (or subset). Example for glue: sst2
   splits:
     - name: {split_name_0}                  # Example: train
       num_bytes: {split_num_bytes_0}        # Example for SQuAD: 79317110
@@ -77,7 +77,7 @@ dataset_info:
   download_size: {dataset_download_size}   # Example for SQuAD: 35142551
   dataset_size: {dataset_size}             # Example for SQuAD: 89789763
 
-# It can also be a list of multiple configurations:
+# It can also be a list of multiple configurations (or subsets):
 # ```yaml
 # dataset_info:
 #   - config_name: {config0}

--- a/docs/hub/api.md
+++ b/docs/hub/api.md
@@ -112,7 +112,7 @@ Get the list of auto-converted parquet files.
 
 ### GET /api/datasets/{repo_id}/parquet/{config}/{split}/{n}.parquet
 
-Get the nth shard of the auto-converted parquet files, for a specific configuration (or subset) and split.
+Get the nth shard of the auto-converted parquet files, for a specific subset (also called "config") and split.
 
 ### GET /api/datasets/{repo_id}/croissant
 

--- a/docs/hub/api.md
+++ b/docs/hub/api.md
@@ -112,7 +112,7 @@ Get the list of auto-converted parquet files.
 
 ### GET /api/datasets/{repo_id}/parquet/{config}/{split}/{n}.parquet
 
-Get the nth shard of the auto-converted parquet files.
+Get the nth shard of the auto-converted parquet files, for a specific configuration (or subset) and split.
 
 ### GET /api/datasets/{repo_id}/croissant
 

--- a/docs/hub/datasets-data-files-configuration.md
+++ b/docs/hub/datasets-data-files-configuration.md
@@ -5,9 +5,9 @@ There are no constraints on how to structure dataset repositories.
 However, if you want the Dataset Viewer to show certain data files, or to separate your dataset in train/validation/test splits, you need to structure your dataset accordingly.
 Often it is as simple as naming your data files according to their split names, e.g. `train.csv` and `test.csv`.
 
-## What are splits and configurations?
+## What are splits and subsets?
 
-Machine learning datasets typically have splits and may also have configurations (or subsets). A dataset is generally made of _splits_ (e.g. `train` and `test`) that are used during different stages of training and evaluating a model. A _configuration_ (or _subset_) is a sub-dataset contained within a larger dataset. Configurations are especially common in multilingual speech datasets where there may be a different configuration for each language. If you're interested in learning more about splits and configurations, check out the [Splits and configurations](https://huggingface.co/docs/datasets-server/configs_and_splits) guide!
+Machine learning datasets typically have splits and may also have subsets. A dataset is generally made of _splits_ (e.g. `train` and `test`) that are used during different stages of training and evaluating a model. A _subset_ (also called _configuration_) is a sub-dataset contained within a larger dataset. Subsets are especially common in multilingual speech datasets where there may be a different subset for each language. If you're interested in learning more about splits and subsets, check out the [Splits and configurations](https://huggingface.co/docs/datasets-server/configs_and_splits) guide!
 
 ![split-configs-server](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/split-configs-server.gif)
 
@@ -20,7 +20,7 @@ To structure your dataset by naming your data files or directories according to 
 You can choose the data files to show in the Dataset Viewer for your dataset using YAML.
 It is useful if you want to specify which file goes into which split manually.
 
-You can also define multiple configurations (or subsets) for your dataset, and pass dataset building parameters (e.g. the separator to use for CSV files).
+You can also define multiple subsets for your dataset, and pass dataset building parameters (e.g. the separator to use for CSV files).
 
 See the documentation on [Manual configuration](./datasets-manual-configuration) for more information.
 

--- a/docs/hub/datasets-data-files-configuration.md
+++ b/docs/hub/datasets-data-files-configuration.md
@@ -7,7 +7,7 @@ Often it is as simple as naming your data files according to their split names, 
 
 ## What are splits and configurations?
 
-Machine learning datasets typically have splits and may also have configurations. A dataset is generally made of _splits_ (e.g. `train` and `test`) that are used during different stages of training and evaluating a model. A _configuration_ is a sub-dataset contained within a larger dataset. Configurations are especially common in multilingual speech datasets where there may be a different configuration for each language. If you're interested in learning more about splits and configurations, check out the [Splits and configurations](https://huggingface.co/docs/datasets-server/configs_and_splits) guide!
+Machine learning datasets typically have splits and may also have configurations (or subsets). A dataset is generally made of _splits_ (e.g. `train` and `test`) that are used during different stages of training and evaluating a model. A _configuration_ (or _subset_) is a sub-dataset contained within a larger dataset. Configurations are especially common in multilingual speech datasets where there may be a different configuration for each language. If you're interested in learning more about splits and configurations, check out the [Splits and configurations](https://huggingface.co/docs/datasets-server/configs_and_splits) guide!
 
 ![split-configs-server](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/split-configs-server.gif)
 

--- a/docs/hub/datasets-image.md
+++ b/docs/hub/datasets-image.md
@@ -153,7 +153,7 @@ You can disable this automatic addition of the `label` column in the [YAML confi
 
 ```yaml
 configs:
-  - config_name: default
+  - config_name: default # name of the configuration (or subset)
     drop_labels: true
 ```
 

--- a/docs/hub/datasets-image.md
+++ b/docs/hub/datasets-image.md
@@ -153,7 +153,7 @@ You can disable this automatic addition of the `label` column in the [YAML confi
 
 ```yaml
 configs:
-  - config_name: default # name of the dataset subset
+  - config_name: default  # Name of the dataset subset, if applicable.
     drop_labels: true
 ```
 

--- a/docs/hub/datasets-image.md
+++ b/docs/hub/datasets-image.md
@@ -153,7 +153,7 @@ You can disable this automatic addition of the `label` column in the [YAML confi
 
 ```yaml
 configs:
-  - config_name: default # name of the configuration (or subset)
+  - config_name: default # name of the dataset subset
     drop_labels: true
 ```
 

--- a/docs/hub/datasets-manual-configuration.md
+++ b/docs/hub/datasets-manual-configuration.md
@@ -2,9 +2,9 @@
 
 This guide will show you how to configure a custom structure for your dataset repository.
 
-A dataset with a supported structure and [file formats](./datasets-adding#file-formats) automatically has a Dataset Viewer on its dataset page on the Hub. You can use YAML to define the splits, configurations (or subsets) and builder parameters that are used by the Viewer.
+A dataset with a supported structure and [file formats](./datasets-adding#file-formats) automatically has a Dataset Viewer on its dataset page on the Hub. You can use YAML to define the splits, subsets and builder parameters that are used by the Viewer.
 
-It is also possible to define multiple configurations (or subsets) for the same dataset (e.g. if the dataset has various independent files).
+It is also possible to define multiple subsets (also called "configurations") for the same dataset (e.g. if the dataset has various independent files).
 
 ## Splits
 
@@ -19,7 +19,7 @@ my_dataset_repository/
 └── holdout.csv
 ```
 
-You can define a configuration (or subset) for your splits by adding the `configs` field in the YAML block at the top of your README.md:
+You can define a subset for your splits by adding the `configs` field in the YAML block at the top of your README.md:
 
 ```yaml
 ---
@@ -75,16 +75,16 @@ configs:
 
 <Tip warning={true}>
 
-Note that `config_name` field is required even if you have a single configuration (or subset).
+Note that `config_name` field is required even if you have a single subset.
 
 </Tip>
 
-## Multiple Configurations (or subsets)
+## Multiple Subsets
 
 Your dataset might have several subsets of data that you want to be able to use separately.
-For example each configuration has its own dropdown in the Dataset Viewer the Hugging Face Hub.
+For example each subset has its own dropdown in the Dataset Viewer the Hugging Face Hub.
 
-In that case you can define a list of configurations inside the `configs` field in YAML:
+In that case you can define a list of subsets inside the `configs` field in YAML:
 
 ```
 my_dataset_repository/
@@ -105,7 +105,7 @@ configs:
 
 ## Builder parameters
 
-Not only `data_files`, but other builder-specific parameters can be passed via YAML, allowing for more flexibility on how to load the data while not requiring any custom code. For example, define which separator to use in which configuration (or subset) to load your `csv` files:
+Not only `data_files`, but other builder-specific parameters can be passed via YAML, allowing for more flexibility on how to load the data while not requiring any custom code. For example, define which separator to use in which subset to load your `csv` files:
 
 ```yaml
 ---
@@ -123,7 +123,7 @@ Refer to the [specific builders' documentation](../datasets/package_reference/bu
 
 <Tip>
 
-You can set a default configuration (or subset) using `default: true`
+You can set a default subset using `default: true`
 
 ```yaml
 - config_name: main_data

--- a/docs/hub/datasets-manual-configuration.md
+++ b/docs/hub/datasets-manual-configuration.md
@@ -2,9 +2,9 @@
 
 This guide will show you how to configure a custom structure for your dataset repository.
 
-A dataset with a supported structure and [file formats](./datasets-adding#file-formats) automatically has a Dataset Viewer on its dataset page on the Hub. You can use YAML to define the splits, configurations and builder parameters that are used by the Viewer.
+A dataset with a supported structure and [file formats](./datasets-adding#file-formats) automatically has a Dataset Viewer on its dataset page on the Hub. You can use YAML to define the splits, configurations (or subsets) and builder parameters that are used by the Viewer.
 
-It is also possible to define multiple configurations for the same dataset (e.g. if the dataset has various independent files).
+It is also possible to define multiple configurations (or subsets) for the same dataset (e.g. if the dataset has various independent files).
 
 ## Splits
 
@@ -19,7 +19,7 @@ my_dataset_repository/
 └── holdout.csv
 ```
 
-You can define a configuration for your splits by adding the `configs` field in the YAML block at the top of your README.md:
+You can define a configuration (or subset) for your splits by adding the `configs` field in the YAML block at the top of your README.md:
 
 ```yaml
 ---
@@ -75,11 +75,11 @@ configs:
 
 <Tip warning={true}>
 
-Note that `config_name` field is required even if you have a single configuration.
+Note that `config_name` field is required even if you have a single configuration (or subset).
 
 </Tip>
 
-## Multiple Configurations
+## Multiple Configurations (or subsets)
 
 Your dataset might have several subsets of data that you want to be able to use separately.
 For example each configuration has its own dropdown in the Dataset Viewer the Hugging Face Hub.
@@ -105,7 +105,7 @@ configs:
 
 ## Builder parameters
 
-Not only `data_files`, but other builder-specific parameters can be passed via YAML, allowing for more flexibility on how to load the data while not requiring any custom code. For example, define which separator to use in which configuration to load your `csv` files:
+Not only `data_files`, but other builder-specific parameters can be passed via YAML, allowing for more flexibility on how to load the data while not requiring any custom code. For example, define which separator to use in which configuration (or subset) to load your `csv` files:
 
 ```yaml
 ---
@@ -119,11 +119,11 @@ configs:
 ---
 ```
 
-Refer to the [specific builders' documentation](../datasets/package_reference/builder_classes) to see what configuration parameters they have.
+Refer to the [specific builders' documentation](../datasets/package_reference/builder_classes) to see what parameters they have.
 
 <Tip>
 
-You can set a default configuration using `default: true`
+You can set a default configuration (or subset) using `default: true`
 
 ```yaml
 - config_name: main_data

--- a/docs/hub/datasets-viewer-embed.md
+++ b/docs/hub/datasets-viewer-embed.md
@@ -2,7 +2,7 @@
 
 You can embed the Dataset Viewer in your own webpage using an iframe.
 
-The URL to use is `https://huggingface.co/datasets/<namespace>/<dataset-name>/embed/viewer`, where `<namespace>` is the owner of the dataset (user or organization) and `<dataset-name>` is the name of the dataset. You can also pass other parameters like the configuration, split, filter, search or selected row.
+The URL to use is `https://huggingface.co/datasets/<namespace>/<dataset-name>/embed/viewer`, where `<namespace>` is the owner of the dataset (user or organization) and `<dataset-name>` is the name of the dataset. You can also pass other parameters like the configuration (or subset), split, filter, search or selected row.
 
 For example, the following iframe embeds the Dataset Viewer for the `glue` dataset from the `nyu-mll` organization:
 

--- a/docs/hub/datasets-viewer-embed.md
+++ b/docs/hub/datasets-viewer-embed.md
@@ -2,7 +2,7 @@
 
 You can embed the Dataset Viewer in your own webpage using an iframe.
 
-The URL to use is `https://huggingface.co/datasets/<namespace>/<dataset-name>/embed/viewer`, where `<namespace>` is the owner of the dataset (user or organization) and `<dataset-name>` is the name of the dataset. You can also pass other parameters like the configuration (or subset), split, filter, search or selected row.
+The URL to use is `https://huggingface.co/datasets/<namespace>/<dataset-name>/embed/viewer`, where `<namespace>` is the owner of the dataset (user or organization) and `<dataset-name>` is the name of the dataset. You can also pass other parameters like the subset, split, filter, search or selected row.
 
 For example, the following iframe embeds the Dataset Viewer for the `glue` dataset from the `nyu-mll` organization:
 

--- a/docs/hub/datasets-viewer.md
+++ b/docs/hub/datasets-viewer.md
@@ -67,7 +67,7 @@ For the biggest datasets, the page shows a preview of the first 100 rows instead
 
 ## Embed the Dataset Viewer in a webpage
 
-You can embed the Dataset Viewer in your own webpage using an iframe. The URL to use is `https://huggingface.co/datasets/<namespace>/<dataset-name>/embed/viewer`, where `<namespace>` is the owner of the dataset and `<dataset-name>` is the name of the dataset. You can also pass other parameters like the configuration, split, filter, search or selected row.
+You can embed the Dataset Viewer in your own webpage using an iframe. The URL to use is `https://huggingface.co/datasets/<namespace>/<dataset-name>/embed/viewer`, where `<namespace>` is the owner of the dataset and `<dataset-name>` is the name of the dataset. You can also pass other parameters like the configuration (or subset), split, filter, search or selected row.
 
 For more information see our guide on [How to embed the Dataset Viewer in a webpage](./datasets-viewer-embed).
 

--- a/docs/hub/datasets-viewer.md
+++ b/docs/hub/datasets-viewer.md
@@ -67,7 +67,7 @@ For the biggest datasets, the page shows a preview of the first 100 rows instead
 
 ## Embed the Dataset Viewer in a webpage
 
-You can embed the Dataset Viewer in your own webpage using an iframe. The URL to use is `https://huggingface.co/datasets/<namespace>/<dataset-name>/embed/viewer`, where `<namespace>` is the owner of the dataset and `<dataset-name>` is the name of the dataset. You can also pass other parameters like the configuration (or subset), split, filter, search or selected row.
+You can embed the Dataset Viewer in your own webpage using an iframe. The URL to use is `https://huggingface.co/datasets/<namespace>/<dataset-name>/embed/viewer`, where `<namespace>` is the owner of the dataset and `<dataset-name>` is the name of the dataset. You can also pass other parameters like the subset, split, filter, search or selected row.
 
 For more information see our guide on [How to embed the Dataset Viewer in a webpage](./datasets-viewer-embed).
 

--- a/modelcard.md
+++ b/modelcard.md
@@ -29,7 +29,7 @@ model-index:
     dataset:
       type: {dataset_type}          # Required. Example: common_voice. Use dataset id from https://hf.co/datasets
       name: {dataset_name}          # Required. A pretty name for the dataset. Example: Common Voice (French)
-      config: {dataset_config}      # Optional. The name of the dataset configuration used in `load_dataset()`. Example: fr in `load_dataset("common_voice", "fr")`. See the `datasets` docs for more info: https://huggingface.co/docs/datasets/package_reference/loading_methods#datasets.load_dataset.name
+      config: {dataset_config}      # Optional. The name of the dataset subset used in `load_dataset()`. Example: fr in `load_dataset("common_voice", "fr")`. See the `datasets` docs for more info: https://huggingface.co/docs/datasets/package_reference/loading_methods#datasets.load_dataset.name
       split: {dataset_split}        # Optional. Example: test
       revision: {dataset_revision}  # Optional. Example: 5503434ddd753f426f4b38109466949a1217c2bb
       args:


### PR DESCRIPTION
cc https://github.com/huggingface/datasets/pull/7057#pullrequestreview-2191208969

> cool, let's aim to have "subsets" everywhere, and "configure the subsets" when it comes to the YAML (that uses the fields "configs" / "config_name" ) :)
