### PR TITLE
Fix typo in `index.md`

### DIFF
--- a/docs/sagemaker/index.md
+++ b/docs/sagemaker/index.md
@@ -16,7 +16,7 @@ Hugging Face DLCs are open source and licensed under Apache 2.0. Feel free to re
 
 ## Features & benefits 🔥
 
-Hugging Face Deep DLCs make it easier than ever to train Transformer models in SageMaker. Here is why you should consider using Hugging Face DLCs to train and deploy your next machine learning models:
+Hugging Face DLCs make it easier than ever to train Transformer models in SageMaker. Here is why you should consider using Hugging Face DLCs to train and deploy your next machine learning models:
 
 **One command is all you need**
 


### PR DESCRIPTION
## Description

This PR is just a tiny fix to remove the `"Deep"` from `"Hugging Face Deep DLCs"` in favour of just `"Hugging Face DLCs".