### PR TITLE
Filter out frozen models from API docs for tasks

### DIFF
--- a/docs/api-inference/tasks/chat_completion.md
+++ b/docs/api-inference/tasks/chat_completion.md
@@ -10,7 +10,6 @@ This is a subtask of [`text-generation`](./text_generation) designed to generate
 - [google/gemma-2-2b-it](https://huggingface.co/google/gemma-2-2b-it): A text-generation model trained to follow instructions.
 - [meta-llama/Meta-Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct): Very powerful text generation model trained to follow instructions.
 - [microsoft/Phi-3-mini-4k-instruct](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct): Small yet powerful text generation model.
-- [AI-MO/NuminaMath-7B-TIR](https://huggingface.co/AI-MO/NuminaMath-7B-TIR): A very powerful model that can solve mathematical problems.
 - [HuggingFaceH4/starchat2-15b-v0.1](https://huggingface.co/HuggingFaceH4/starchat2-15b-v0.1): Strong coding assistant model.
 - [mistralai/Mistral-Nemo-Instruct-2407](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407): Very strong open-source large language model.
 

--- a/docs/api-inference/tasks/image_to_image.md
+++ b/docs/api-inference/tasks/image_to_image.md
@@ -17,10 +17,6 @@ For more details about the `image-to-image` task, check out its [dedicated page]
 
 ### Recommended models
 
-- [fal/AuraSR-v2](https://huggingface.co/fal/AuraSR-v2): An image-to-image model to improve image resolution.
-- [keras-io/super-resolution](https://huggingface.co/keras-io/super-resolution): A model that increases the resolution of an image.
-- [lambdalabs/sd-image-variations-diffusers](https://huggingface.co/lambdalabs/sd-image-variations-diffusers): A model that creates a set of variations of the input image in the style of DALL-E using Stable Diffusion.
-- [mfidabel/controlnet-segment-anything](https://huggingface.co/mfidabel/controlnet-segment-anything): A model that generates images based on segments in the input image and the text prompt.
 - [timbrooks/instruct-pix2pix](https://huggingface.co/timbrooks/instruct-pix2pix): A model that takes an image and an instruction to edit the image.
 
 This is only a subset of the supported models. Find the model that suits you best [here](https://huggingface.co/models?inference=warm&pipeline_tag=image-to-image&sort=trending).

--- a/docs/api-inference/tasks/question_answering.md
+++ b/docs/api-inference/tasks/question_answering.md
@@ -11,7 +11,6 @@ For more details about the `question-answering` task, check out its [dedicated p
 ### Recommended models
 
 - [deepset/roberta-base-squad2](https://huggingface.co/deepset/roberta-base-squad2): A robust baseline model for most question answering domains.
-- [google/tapas-base-finetuned-wtq](https://huggingface.co/google/tapas-base-finetuned-wtq): A special model that can answer questions from tables!
 
 This is only a subset of the supported models. Find the model that suits you best [here](https://huggingface.co/models?inference=warm&pipeline_tag=question-answering&sort=trending).
 

--- a/docs/api-inference/tasks/summarization.md
+++ b/docs/api-inference/tasks/summarization.md
@@ -11,7 +11,6 @@ For more details about the `summarization` task, check out its [dedicated page](
 ### Recommended models
 
 - [facebook/bart-large-cnn](https://huggingface.co/facebook/bart-large-cnn): A strong summarization model trained on English news articles. Excels at generating factual summaries.
-- [google/bigbird-pegasus-large-pubmed](https://huggingface.co/google/bigbird-pegasus-large-pubmed): A summarization model trained on medical articles.
 
 This is only a subset of the supported models. Find the model that suits you best [here](https://huggingface.co/models?inference=warm&pipeline_tag=summarization&sort=trending).
 

--- a/docs/api-inference/tasks/table_question_answering.md
+++ b/docs/api-inference/tasks/table_question_answering.md
@@ -10,8 +10,6 @@ For more details about the `table-question-answering` task, check out its [dedic
 
 ### Recommended models
 
-- [microsoft/tapex-base](https://huggingface.co/microsoft/tapex-base): A table question answering model that is capable of neural SQL execution, i.e., employ TAPEX to execute a SQL query on a given table.
-- [google/tapas-base-finetuned-wtq](https://huggingface.co/google/tapas-base-finetuned-wtq): A robust table question answering model.
 
 This is only a subset of the supported models. Find the model that suits you best [here](https://huggingface.co/models?inference=warm&pipeline_tag=table-question-answering&sort=trending).
 

--- a/docs/api-inference/tasks/text_generation.md
+++ b/docs/api-inference/tasks/text_generation.md
@@ -16,7 +16,6 @@ For more details about the `text-generation` task, check out its [dedicated page
 - [bigcode/starcoder](https://huggingface.co/bigcode/starcoder): A code generation model that can generate code in 80+ languages.
 - [meta-llama/Meta-Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct): Very powerful text generation model trained to follow instructions.
 - [microsoft/Phi-3-mini-4k-instruct](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct): Small yet powerful text generation model.
-- [AI-MO/NuminaMath-7B-TIR](https://huggingface.co/AI-MO/NuminaMath-7B-TIR): A very powerful model that can solve mathematical problems.
 - [HuggingFaceH4/starchat2-15b-v0.1](https://huggingface.co/HuggingFaceH4/starchat2-15b-v0.1): Strong coding assistant model.
 - [mistralai/Mistral-Nemo-Instruct-2407](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407): Very strong open-source large language model.
 

--- a/docs/api-inference/tasks/text_to_image.md
+++ b/docs/api-inference/tasks/text_to_image.md
@@ -12,7 +12,6 @@ For more details about the `text-to-image` task, check out its [dedicated page](
 
 - [black-forest-labs/FLUX.1-dev](https://huggingface.co/black-forest-labs/FLUX.1-dev): One of the most powerful image generation models that can generate realistic outputs.
 - [latent-consistency/lcm-lora-sdxl](https://huggingface.co/latent-consistency/lcm-lora-sdxl): A powerful yet fast image generation model.
-- [Kwai-Kolors/Kolors](https://huggingface.co/Kwai-Kolors/Kolors): Text-to-image model for photorealistic generation.
 - [stabilityai/stable-diffusion-3-medium-diffusers](https://huggingface.co/stabilityai/stable-diffusion-3-medium-diffusers): A powerful text-to-image model.
 
 This is only a subset of the supported models. Find the model that suits you best [here](https://huggingface.co/models?inference=warm&pipeline_tag=text-to-image&sort=trending).

--- a/scripts/api-inference/scripts/generate.ts
+++ b/scripts/api-inference/scripts/generate.ts
@@ -377,13 +377,18 @@ await Promise.all(
 
 // Fetch recommended models
 TASKS.forEach((task) => {
-  DATA.models[task] = TASKS_DATA[task].models;
+  DATA.models[task] = TASKS_DATA[task].models.filter(
+    (model: { inference: string }) =>
+      ["cold", "loading", "warm"].includes(model.inference),
+  );
 });
 
 // Fetch snippets
 // TODO: render snippets only if they are available
 TASKS.forEach((task) => {
-  const mainModel = TASKS_DATA[task].models[0].id;
+  // Let's take as example the first available model that is recommended.
+  // Otherwise, fallback to the first model of the task (better to have a snippet than nothing).
+  const mainModel = DATA.models[task][0]?.id || TASKS_DATA[task].models[0].id;
   const taskSnippets = {
     curl: getInferenceSnippet(mainModel, task, "curl"),
     python: getInferenceSnippet(mainModel, task, "python"),

--- a/scripts/api-inference/scripts/generate.ts
+++ b/scripts/api-inference/scripts/generate.ts
@@ -387,8 +387,8 @@ TASKS.forEach((task) => {
 // TODO: render snippets only if they are available
 TASKS.forEach((task) => {
   // Let's take as example the first available model that is recommended.
-  // Otherwise, fallback to the first model of the task (better to have a snippet than nothing).
-  const mainModel = DATA.models[task][0]?.id || TASKS_DATA[task].models[0].id;
+  // Otherwise, fallback to "<REPO_ID>".
+  const mainModel = DATA.models[task][0]?.id || "<REPO_ID>";
   const taskSnippets = {
     curl: getInferenceSnippet(mainModel, task, "curl"),
     python: getInferenceSnippet(mainModel, task, "python"),


### PR DESCRIPTION
see https://github.com/huggingface/hub-docs/pull/1393#discussion_r1734668929 and https://github.com/huggingface/hub-docs/pull/1384#discussion_r1729042102

What I did is filter out all models that are not "warm", "cold" or "loading".

One problem is `table-question-answering` where all models are filtered out. The only warm model seems to be `google/tapas-large-finetuned-wtq` (see [here](https://huggingface.co/models?inference=warm&pipeline_tag=table-question-answering&sort=trending)) but it's not in the recommended models in hf.co/tasks. The page looks empty but maybe not the most problematic thing (1 model is not much anyway...)

![image](https://github.com/user-attachments/assets/49ee1615-98a3-403e-b51d-cb18f512f827)
