### PR TITLE
Fix url typo in Inference API docs

### DIFF
--- a/docs/api-inference/rate-limits.md
+++ b/docs/api-inference/rate-limits.md
@@ -2,7 +2,7 @@
 
 The Inference API has rate limits based on the number of requests. These rate limits are subject to change in the future to be compute-based or token-based. 
 
-Serverless API is not meant to be used for heavy production applications. If you need higher rate limits, consider [Inference Endpoints](https://huggingface.co/docs/inference/endpoints) to have dedicated resources.
+Serverless API is not meant to be used for heavy production applications. If you need higher rate limits, consider [Inference Endpoints](https://huggingface.co/docs/inference-endpoints) to have dedicated resources.
 
 | User Tier           | Rate Limit                |
 |---------------------|---------------------------|

--- a/docs/api-inference/supported-models.md
+++ b/docs/api-inference/supported-models.md
@@ -23,4 +23,4 @@ In addition to thousands of public models available in the Hub, PRO and Enterpri
 
 ## Running Private Models
 
-The free Serverless API is designed to run popular public models. If you have a private model, you can use [Inference Endpoints](https://huggingface.co/docs/inference/endpoints) to deploy it.
+The free Serverless API is designed to run popular public models. If you have a private model, you can use [Inference Endpoints](https://huggingface.co/docs/inference-endpoints) to deploy it.


### PR DESCRIPTION
https://huggingface.co/docs/inference/endpoints => https://huggingface.co/docs/inference-endpoints/index