### PR TITLE
Update pip installation of spacy models from hub spacy.md

### DIFF
--- a/docs/hub/spacy.md
+++ b/docs/hub/spacy.md
@@ -24,7 +24,7 @@ All models on the Hub come up with useful features
 All `spaCy` models from the Hub can be directly installed using pip install.
 
 ```bash
-pip install https://huggingface.co/spacy/en_core_web_sm/resolve/main/en_core_web_sm-any-py3-none-any.whl
+pip install "en_core_web_sm @ https://huggingface.co/spacy/en_core_web_sm/resolve/main/en_core_web_sm-any-py3-none-any.whl"
 ```
 
 To find the link of interest, you can go to a repository with a `spaCy` model. When you open the repository, you can click `Use in spaCy` and you will be given a working snippet that you can use to install and load the model!


### PR DESCRIPTION
The update in the way to install spacy models from the hub comes from how pip parse the URL to check pacage name and version. As it detect's "any" as version, it can raise an error. Adding the name of the package alongside the URL solve this.  More info in this GitHub issue: https://github.com/explosion/spaCy/issues/13599