### PR TITLE
Add Llama 3.2 license

### DIFF
--- a/docs/hub/repositories-licenses.md
+++ b/docs/hub/repositories-licenses.md
@@ -78,7 +78,8 @@ A full list of the available licenses is available here:
 | DeepFloyd IF Research License Agreement                        | `deepfloyd-if-license`                   |
 | Llama 2 Community License Agreement                            | `llama2`                                 | <!-- license: https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/blob/main/LICENSE.txt -->
 | Llama 3 Community License Agreement                            | `llama3`                                 | <!-- license: https://huggingface.co/meta-llama/Meta-Llama-3-8B/blob/main/LICENSE -->
-| Llama 3.1 Community License Agreement                            | `llama3.1`                                 | <!-- license: https://huggingface.co/meta-llama/Meta-Llama-3.1-70B-Instruct/blob/main/LICENSE -->
+| Llama 3.1 Community License Agreement                          | `llama3.1`                               | <!-- license: https://huggingface.co/meta-llama/Meta-Llama-3.1-70B-Instruct/blob/main/LICENSE -->
+| Llama 3.2 Community License Agreement                          | `llama3.2`                               | <!-- license: https://huggingface.co/meta-llama/Llama-3.2-1B/blob/main/LICENSE -->
 | Gemma Terms of Use                                             | `gemma`                                  | <!-- license: https://ai.google.dev/gemma/terms -->
 | Unknown                                                        | `unknown`                                |
 | Other                                                          | `other`                                  |


### PR DESCRIPTION
I forgot, but this is the correct way to add the license to moon @osanseviero @pcuenca since the final metadata is generated by a script, otherwise it gets overridden (like at https://github.com/huggingface-internal/moon-landing/pull/11251/files)