### PR TITLE
(fix typo) change port to 7860

### DIFF
--- a/docs/hub/spaces-sdks-python.md
+++ b/docs/hub/spaces-sdks-python.md
@@ -6,7 +6,7 @@ Spaces now support arbitrary Dockerfiles so you can host any Python app directly
 
 </Tip>
 
-While not an official workflow, you are able to run your own Python + interface stack in Spaces by selecting Gradio as your SDK and serving a frontend on port `7680`. See the [templates](https://huggingface.co/templates#spaces) for examples.
+While not an official workflow, you are able to run your own Python + interface stack in Spaces by selecting Gradio as your SDK and serving a frontend on port `7860`. See the [templates](https://huggingface.co/templates#spaces) for examples.
 
 Spaces are served in iframes, which by default restrict links from opening in the parent page. The simplest solution is to open them in a new window:
 


### PR DESCRIPTION
## Why

There is a typo in port number for running custom python spaces through the gradio sdk. 
Fixing so that others won't find out the hard way like me. 

Sidenote: 
I think this is an under-emphasized way of setting up a space. 
Consider for example deploying a FastHTML app to spaces, is actually as simple as

```python
from fasthtml.common import *

app,rt = fast_app()

@rt('/')
def get(): return Div(P('Hello World!'), hx_get="/change")

serve(port=7860)
```

Which means that you can remove a lot of complexity of deploying to a space. 
As of now, the recommended approach is to use https://github.com/AnswerDotAI/fasthtml-hf, but this is way easier imho.
Creating a space template for FastHTML would also be nice.