### PR TITLE
Rehaul 'how to integrate your library' docs

### DIFF
--- a/docs/hub/models-adding-libraries.md
+++ b/docs/hub/models-adding-libraries.md
@@ -160,7 +160,7 @@ To register a new library, please open a Pull Request [here](https://github.com/
 
 Before opening the PR, make sure that at least one model is referenced on https://huggingface.co/models?other=my-library-name. If not, the model card metadata of the relevant models must be updated with `library_name: my-library-name` (see [example](https://huggingface.co/google/gemma-scope/blob/main/README.md?code=true#L3)). If you are not the owner of the models on the Hub, please open PRs (see [example](https://huggingface.co/MCG-NJU/VFIMamba/discussions/1)).
 
-Here is a minimal [example](https://github.com/huggingface/huggingface.js/pull/561/files) adding integration for Grok-1.
+Here is a minimal [example](https://github.com/huggingface/huggingface.js/pull/885/files) adding integration for VFIMamba.
 
 ### Code snippets
 

--- a/docs/hub/models-adding-libraries.md
+++ b/docs/hub/models-adding-libraries.md
@@ -156,7 +156,7 @@ To register a new library, please open a Pull Request [here](https://github.com/
 - set `filter` to `false`.
 - (optional) define how downloads must be counted by setting `countDownload`. Downloads can be tracked by file extensions or filenames. Please make sure to not duplicate the counting. For instance, if loading a model requires 3 files, the download count rule must count downloads only on 1 of the 3 files. Otherwise, the download count will be overestimated.
 **Note:** if the library uses one of the default config files (`config.json`, `config.yaml`, `hyperparams.yaml`, and `meta.yaml`, see [here](https://huggingface.co/docs/hub/models-download-stats#which-are-the-query-files-for-different-libraries)), there is no need to manually define a download count rule.
-- [ ] (optional) define `snippets` to let the user know how they can quickly instantiate a model. More details below.
+- (optional) define `snippets` to let the user know how they can quickly instantiate a model. More details below.
 
 Before opening the PR, please make sure that at least one model should be referenced on https://huggingface.co/models?other=my-library-name. If not, the model card metadata of the relevant models must be updated with `library_name: my-library-name` (see [example](https://huggingface.co/google/gemma-scope/blob/main/README.md?code=true#L3)). If you are not the owner of the models on the Hub, please open PRs (see [example](https://huggingface.co/MCG-NJU/VFIMamba/discussions/1)).
 

--- a/docs/hub/models-adding-libraries.md
+++ b/docs/hub/models-adding-libraries.md
@@ -182,11 +182,6 @@ model = BaseModel.from_pretrained("${model.id}")`;
 
 Doing so will also add a tag to your model so users can quickly identify models from your library.
 
-<div class="flex justify-center">
-<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/libraries-tags.png"/>
-<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/libraries-tags-dark.png"/>
-</div>
-
 Once your snippet has been added to [model-libraries-snippets.ts](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries-snippets.ts), you can reference it in [model-libraries.ts](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts) as described above.
 
 ## Document your library

--- a/docs/hub/models-adding-libraries.md
+++ b/docs/hub/models-adding-libraries.md
@@ -149,16 +149,16 @@ Well done! You should now have a library able to load a model from the Hub and e
 - code snippets can be generated to show how to load the model using your library 
 
 To register a new library, please open a Pull Request [here](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts) following the instructions below:
-- The library id should be lowercased and hyphen-separated (example: `"adapter-transformers"`). Please make sure to preserve alphabetical order when opening the PR. 
+- The library id should be lowercased and hyphen-separated (example: `"adapter-transformers"`). Make sure to preserve alphabetical order when opening the PR.
 - set `repoName` and `prettyLabel` with user-friendly casing (example: `DeepForest`).
 - set `repoUrl` with a link to the library source code (usually a GitHub repository).
 - (optional) set `docsUrl` with a link to the docs of the library. If the documentation is in the GitHub repo referenced above, no need to set it twice.
 - set `filter` to `false`.
-- (optional) define how downloads must be counted by setting `countDownload`. Downloads can be tracked by file extensions or filenames. Please make sure to not duplicate the counting. For instance, if loading a model requires 3 files, the download count rule must count downloads only on 1 of the 3 files. Otherwise, the download count will be overestimated.
+- (optional) define how downloads must be counted by setting `countDownload`. Downloads can be tracked by file extensions or filenames. Make sure to not duplicate the counting. For instance, if loading a model requires 3 files, the download count rule must count downloads only on 1 of the 3 files. Otherwise, the download count will be overestimated.
 **Note:** if the library uses one of the default config files (`config.json`, `config.yaml`, `hyperparams.yaml`, and `meta.yaml`, see [here](https://huggingface.co/docs/hub/models-download-stats#which-are-the-query-files-for-different-libraries)), there is no need to manually define a download count rule.
 - (optional) define `snippets` to let the user know how they can quickly instantiate a model. More details below.
 
-Before opening the PR, please make sure that at least one model should be referenced on https://huggingface.co/models?other=my-library-name. If not, the model card metadata of the relevant models must be updated with `library_name: my-library-name` (see [example](https://huggingface.co/google/gemma-scope/blob/main/README.md?code=true#L3)). If you are not the owner of the models on the Hub, please open PRs (see [example](https://huggingface.co/MCG-NJU/VFIMamba/discussions/1)).
+Before opening the PR, make sure that at least one model is referenced on https://huggingface.co/models?other=my-library-name. If not, the model card metadata of the relevant models must be updated with `library_name: my-library-name` (see [example](https://huggingface.co/google/gemma-scope/blob/main/README.md?code=true#L3)). If you are not the owner of the models on the Hub, please open PRs (see [example](https://huggingface.co/MCG-NJU/VFIMamba/discussions/1)).
 
 Here is a minimal [example](https://github.com/huggingface/huggingface.js/pull/561/files) adding integration for Grok-1.
 

--- a/docs/hub/models-adding-libraries.md
+++ b/docs/hub/models-adding-libraries.md
@@ -78,8 +78,8 @@ For example, download the `config.json` file from the [lysandre/arxiv-nlp](https
 If your library needs to download an entire repository, use [`snapshot_download`](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/file_download#huggingface_hub.snapshot_download). It will take care of downloading all the files in parallel. The return value is a path to the directory containing the downloaded files.
 
 ```py
-from huggingface_hub import snapshot_download
-snapshot_download(repo_id="lysandre/arxiv-nlp")
+>>> from huggingface_hub import snapshot_download
+>>> snapshot_download(repo_id="lysandre/arxiv-nlp")
 '/home/lysandre/.cache/huggingface/hub/models--lysandre--arxiv-nlp/snapshots/894a9adde21d9a3e3843e6d5aeaaf01875c7fade'
 ```
 

--- a/docs/hub/models-adding-libraries.md
+++ b/docs/hub/models-adding-libraries.md
@@ -1,6 +1,6 @@
 # Integrate your library with the Hub
 
-The Hugging Face Hub aims to facilitate sharing machine learning models, checkpoints, and artifacts. This endeavor includes integrating the Hub into many of the amazing third-party libraries in the community. Some of the ones already integrated include [spaCy](https://spacy.io/usage/projects#huggingface_hub), [AllenNLP](https://allennlp.org/), and [timm](https://rwightman.github.io/pytorch-image-models/), among many others. Integration means users can download and upload files to the Hub directly from your library. We hope you will integrate your library and join us in democratizing artificial intelligence for everyone.
+The Hugging Face Hub aims to facilitate sharing machine learning models, checkpoints, and artifacts. This endeavor includes integrating the Hub into many of the amazing third-party libraries in the community. Some of the ones already integrated include [spaCy](https://spacy.io/usage/projects#huggingface_hub), [Sentence Transformers](https://sbert.net/), [OpenCLIP](https://github.com/mlfoundations/open_clip), and [timm](https://huggingface.co/docs/timm/index), among many others. Integration means users can download and upload files to the Hub directly from your library. We hope you will integrate your library and join us in democratizing artificial intelligence for everyone.
 
 Integrating the Hub with your library provides many benefits, including:
 

--- a/docs/hub/models-adding-libraries.md
+++ b/docs/hub/models-adding-libraries.md
@@ -39,15 +39,15 @@ npm add @huggingface/hub
 
 </Tip>
 
-Users will need to authenticate once they have successfully installed the `huggingface_hub` library. The easiest way to authenticate is to save the token on the machine. You can do that from the terminal using the `login()` command:
+Users will need to authenticate once they have successfully installed the `huggingface_hub` library. The easiest way to authenticate is to save the token on the machine. Users can do that from the terminal using the `login()` command:
 
 ```
 huggingface-cli login
 ```
 
-The command tells you if you are already logged in and prompts you for your token. The token is then validated and saved in your `HF_HOME` directory (defaults to `~/.cache/huggingface/token`). Any script or library interacting with the Hub will use this token when sending requests.
+The command tells them if they are already logged in and prompts them for their token. The token is then validated and saved in their `HF_HOME` directory (defaults to `~/.cache/huggingface/token`). Any script or library interacting with the Hub will use this token when sending requests.
 
-Alternatively, you can programmatically login using `login()` in a notebook or a script:
+Alternatively, users can programmatically login using `login()` in a notebook or a script:
 
 ```py
 from huggingface_hub import login

--- a/docs/hub/models-adding-libraries.md
+++ b/docs/hub/models-adding-libraries.md
@@ -17,7 +17,7 @@ If you need help with the integration, feel free to open an [issue](https://gith
 
 ## Implementation
 
-Implementing an integration of a library with the Hub often means providing built-in methods to load models from the Hub and allow users to push new models to the Hub. In this section, we will cover the basics on how to do that using the `huggingface_hub` library. For more in-depth guidance, check out [this guide](https://huggingface.co/docs/huggingface_hub/guides/integrations). 
+Implementing an integration of a library with the Hub often means providing built-in methods to load models from the Hub and allow users to push new models to the Hub. This section will cover the basics of how to do that using the `huggingface_hub` library. For more in-depth guidance, check out [this guide](https://huggingface.co/docs/huggingface_hub/guides/integrations). 
 
 ### Installation
 
@@ -39,13 +39,13 @@ npm add @huggingface/hub
 
 </Tip>
 
-Once they have successfully installed the `huggingface_hub` library, users will need to authenticate. The easiest way to authenticate is to save the token on the machine. You can do that from the terminal using the `login()` command:
+Users will need to authenticate once they have successfully installed the `huggingface_hub` library. The easiest way to authenticate is to save the token on the machine. You can do that from the terminal using the `login()` command:
 
 ```
 huggingface-cli login
 ```
 
-The command tells if you are already logged in and prompt you for your token. The token is then validated and saved in your `HF_HOME` directory (defaults to `~/.cache/huggingface/token`). Any script or library interacting with the Hub will use this token when sending requests.
+The command tells you if you are already logged in and prompts you for your token. The token is then validated and saved in your `HF_HOME` directory (defaults to `~/.cache/huggingface/token`). Any script or library interacting with the Hub will use this token when sending requests.
 
 Alternatively, you can programmatically login using `login()` in a notebook or a script:
 
@@ -58,7 +58,7 @@ Authentication is optional when downloading files from public repos on the Hub.
 
 ### Download files from the Hub
 
-Integrations allows users to download a model from the Hub and instantiate it directly from yours library. This is often made possible by providing a method (usually called `from_pretrained` or `load_from_hf`) that has be specific to your library. To instantiate a model from the Hub, your library has to:
+Integrations allow users to download a model from the Hub and instantiate it directly from your library. This is often made possible by providing a method (usually called `from_pretrained` or `load_from_hf`) that has to be specific to your library. To instantiate a model from the Hub, your library has to:
 - download files from the Hub. This is what we will discuss now.
 - instantiate the Python model from these files.
 
@@ -142,7 +142,7 @@ If your library allows pushing a model to the Hub, it is recommended to generate
 
 ## Register your library
 
-Well done! You should now have a library able to load a model from the Hub and eventually push new models. The next step is to make sure that your models on the Hub are well documented and integrated with the platform. To do so, libraries can be registered on the Hub, which comes with a few benefits for the users:
+Well done! You should now have a library able to load a model from the Hub and eventually push new models. The next step is to make sure that your models on the Hub are well-documented and integrated with the platform. To do so, libraries can be registered on the Hub, which comes with a few benefits for the users:
 - a pretty label can be shown on the model page (e.g. `KerasNLP` instead of `keras-nlp`)
 - a link to your library repository and documentation is added to each model page
 - a custom download count rule can be defined

--- a/docs/hub/models-download-stats.md
+++ b/docs/hub/models-download-stats.md
@@ -12,7 +12,7 @@ By default, the Hub looks at `config.json`, `config.yaml`, `hyperparams.yaml`, a
 
 ## Can I add my query files for my library? 
 
-Yes, you can open a Pull Request [here](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts). Here is a minimal [example](https://github.com/huggingface/huggingface.js/pull/561/files) adding download metrics for Grok-1.
+Yes, you can open a Pull Request [here](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts). Here is a minimal [example](https://github.com/huggingface/huggingface.js/pull/561/files) adding download metrics for Grok-1. Check out the [integration guide](./models-adding-libraries.md#register-your-library) for more details.
 
 ## How are `GGUF` files handled?
 

--- a/docs/hub/models-download-stats.md
+++ b/docs/hub/models-download-stats.md
@@ -12,7 +12,7 @@ By default, the Hub looks at `config.json`, `config.yaml`, `hyperparams.yaml`, a
 
 ## Can I add my query files for my library? 
 
-Yes, you can open a Pull Request [here](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts). Here is a minimal [example](https://github.com/huggingface/huggingface.js/pull/561/files) adding download metrics for Grok-1. Check out the [integration guide](./models-adding-libraries.md#register-your-library) for more details.
+Yes, you can open a Pull Request [here](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts). Here is a minimal [example](https://github.com/huggingface/huggingface.js/pull/885/files) adding download metrics for VFIMamba. Check out the [integration guide](./models-adding-libraries.md#register-your-library) for more details.
 
 ## How are `GGUF` files handled?
 

--- a/docs/hub/models-download-stats.md
+++ b/docs/hub/models-download-stats.md
@@ -12,7 +12,7 @@ By default, the Hub looks at `config.json`, `config.yaml`, `hyperparams.yaml`, a
 
 ## Can I add my query files for my library? 
 
-Yes, you can open a Pull Request [here](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts). Here is a minimal [example](https://github.com/huggingface/huggingface.js/pull/885/files) adding download metrics for VFIMamba. Check out the [integration guide](./models-adding-libraries.md#register-your-library) for more details.
+Yes, you can open a Pull Request [here](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts). Here is a minimal [example](https://github.com/huggingface/huggingface.js/pull/885/files) adding download metrics for VFIMamba. Check out the [integration guide](./models-adding-libraries#register-your-library) for more details.
 
 ## How are `GGUF` files handled?
 


### PR DESCRIPTION
I first started to work on this PR to document how to integrate a library with the Hub (i.e. how to open the PR on huggingface.js). In the end, I've updated more than that to focus the page on "how to implement the integration?" + "how to register your library?". 

I feel that some sections are outdated, typically the "how to login" (out of scope for a library integration?) and "how to add inference API" (we don't want to add new libs to api-inference-community, right?) so I removed them. Let me know if you feel strongly against it.

Once merged, I will open a PR to delete https://github.com/huggingface/huggingface.js/blob/main/.github/pull_request_template/new_library.md which is currently useless (not discoverable :confused:)

---

**For reviewers:** https://moon-ci-docs.huggingface.co/docs/hub/pr_1442/en/models-adding-libraries