### PR TITLE
[Api inference] Split up tasks by modality

### DIFF
--- a/docs/api-inference/_toctree.yml
+++ b/docs/api-inference/_toctree.yml
@@ -18,8 +18,6 @@
       sections:
         - local: tasks/audio-classification
           title: Audio Classification
-        - local: tasks/automatic-speech-recognition
-          title: Automatic Speech Recognition
     - title: Computer Vision
       sections:
         - local: tasks/image-classification
@@ -30,8 +28,12 @@
           title: Object Detection
     - title: Multimodal
       sections:
+        - local: tasks/automatic-speech-recognition
+          title: Automatic Speech Recognition
         - local: tasks/image-to-image
           title: Image to Image
+        - local: tasks/table-question-answering
+          title: Table Question Answering
         - local: tasks/image-text-to-text
           title: Image-Text to Text
         - local: tasks/text-to-image
@@ -48,8 +50,6 @@
           title: Question Answering
         - local: tasks/summarization
           title: Summarization
-        - local: tasks/table-question-answering
-          title: Table Question Answering
         - local: tasks/text-classification
           title: Text Classification
         - local: tasks/text-generation

--- a/docs/api-inference/_toctree.yml
+++ b/docs/api-inference/_toctree.yml
@@ -14,43 +14,51 @@
   - local: parameters
     title: Parameters
   - sections:
-    - local: tasks/audio-classification
-      title: Audio Classification
-    - local: tasks/automatic-speech-recognition
-      title: Automatic Speech Recognition
-    - local: tasks/chat-completion
-      title: Chat Completion
-    - local: tasks/feature-extraction
-      title: Feature Extraction
-    - local: tasks/fill-mask
-      title: Fill Mask
-    - local: tasks/image-classification
-      title: Image Classification
-    - local: tasks/image-segmentation
-      title: Image Segmentation
-    - local: tasks/image-to-image
-      title: Image to Image
-    - local: tasks/image-text-to-text
-      title: Image-Text to Text
-    - local: tasks/object-detection
-      title: Object Detection
-    - local: tasks/question-answering
-      title: Question Answering
-    - local: tasks/summarization
-      title: Summarization
-    - local: tasks/table-question-answering
-      title: Table Question Answering
-    - local: tasks/text-classification
-      title: Text Classification
-    - local: tasks/text-generation
-      title: Text Generation
-    - local: tasks/text-to-image
-      title: Text to Image
-    - local: tasks/token-classification
-      title: Token Classification
-    - local: tasks/translation
-      title: Translation
-    - local: tasks/zero-shot-classification
-      title: Zero Shot Classification
+    - title: Audio
+      sections:
+        - local: tasks/audio-classification
+          title: Audio Classification
+        - local: tasks/automatic-speech-recognition
+          title: Automatic Speech Recognition
+    - title: Computer Vision
+      sections:
+        - local: tasks/image-classification
+          title: Image Classification
+        - local: tasks/image-segmentation
+          title: Image Segmentation
+        - local: tasks/object-detection
+          title: Object Detection
+    - title: Multimodal
+      sections:
+        - local: tasks/image-to-image
+          title: Image to Image
+        - local: tasks/image-text-to-text
+          title: Image-Text to Text
+        - local: tasks/text-to-image
+          title: Text to Image
+    - title: Natural Language
+      sections:
+        - local: tasks/chat-completion
+          title: Chat Completion
+        - local: tasks/feature-extraction
+          title: Feature Extraction
+        - local: tasks/fill-mask
+          title: Fill Mask
+        - local: tasks/question-answering
+          title: Question Answering
+        - local: tasks/summarization
+          title: Summarization
+        - local: tasks/table-question-answering
+          title: Table Question Answering
+        - local: tasks/text-classification
+          title: Text Classification
+        - local: tasks/text-generation
+          title: Text Generation
+        - local: tasks/token-classification
+          title: Token Classification
+        - local: tasks/translation
+          title: Translation
+        - local: tasks/zero-shot-classification
+          title: Zero Shot Classification
     title: Detailed Task Parameters
   title: API Reference


### PR DESCRIPTION
This PR proposes to split up the inference API tasks by modality, similar to the docs of Transformers.

## Before

<img width="281" alt="Screenshot 2024-10-19 at 17 09 58" src="https://github.com/user-attachments/assets/203ab16b-7340-43a0-807e-a53c0da3c368">

## After

<img width="279" alt="Screenshot 2024-10-19 at 17 09 37" src="https://github.com/user-attachments/assets/94e7c4e9-854e-486a-a508-49c83600b7ea">
