### PR TITLE
fix: image for Deploy To Spaces svg

### DIFF
--- a/docs/hub/spaces-sdks-docker-giskard.md
+++ b/docs/hub/spaces-sdks-docker-giskard.md
@@ -27,7 +27,7 @@ Hugging Face Spaces. This Giskard app is a **self-contained application complete
 You can deploy Giskard on Spaces with just a few clicks:
 
 <a  href="https://huggingface.co/new-space?template=giskardai%2Fgiskard">
-    <img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/deploy-to-spaces-lg.svg" />
+    <img src="https://huggingface.co/datasets/huggingface/badges/raw/main/deploy-to-spaces-lg.svg" />
 </a>
 
 

--- a/docs/hub/spaces-sdks-docker-jupyter.md
+++ b/docs/hub/spaces-sdks-docker-jupyter.md
@@ -7,7 +7,7 @@
 You can deploy JupyterLab on Spaces with just a few clicks. First, go to [this link](https://huggingface.co/new-space?template=SpacesExamples/jupyterlab) or click the button below:
 
 <a  href="https://huggingface.co/new-space?template=SpacesExamples/jupyterlab">
-  <img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/deploy-to-spaces-lg.svg" />
+  <img src="https://huggingface.co/datasets/huggingface/badges/raw/main/deploy-to-spaces-lg.svg" />
 </a>
 
 Spaces requires you to define:

--- a/docs/hub/spaces-sdks-docker-label-studio.md
+++ b/docs/hub/spaces-sdks-docker-label-studio.md
@@ -20,7 +20,7 @@ production-ready application hosted on Spaces.
 You can deploy Label Studio on Spaces with just a few clicks:
 
 <a  href="https://huggingface.co/new-space?template=LabelStudio/LabelStudio">
-  <img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/deploy-to-spaces-lg.svg" />
+  <img src="https://huggingface.co/datasets/huggingface/badges/raw/main/deploy-to-spaces-lg.svg" />
 </a>
 
 Spaces requires you to define:

--- a/docs/hub/spaces-sdks-docker-livebook.md
+++ b/docs/hub/spaces-sdks-docker-livebook.md
@@ -15,7 +15,7 @@ To learn more about it, watch this [15-minute video](https://www.youtube.com/wat
 You can get Livebook up and running in a Space with just a few clicks. Click the button below to start creating a new Space using Livebook's Docker template:
 
 <a href="http://huggingface.co/new-space?template=livebook-dev/livebook" target="_blank">
-    <img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/deploy-to-spaces-lg.svg" alt="">
+    <img src="https://huggingface.co/datasets/huggingface/badges/raw/main/deploy-to-spaces-lg.svg" alt="">
 </a>
 
 Then:
@@ -32,7 +32,7 @@ This will start building your Space using Livebook's Docker image.
 The visibility of the Space must be set to public for the Smart cells feature in Livebook to function properly. However, your Livebook instance will be protected by Livebook authentication.
 
 <Tip>
- 
+
 <a href="https://news.livebook.dev/v0.6-automate-and-learn-with-smart-cells-mxJJe" target="_blank">Smart cell</a> is a type of Livebook cell that provides a UI component for accomplishing a specific task. The code for the task is generated automatically based on the user's interactions with the UI, allowing for faster completion of high-level tasks without writing code from scratch.
 
 </Tip>

--- a/docs/hub/spaces-sdks-docker-marimo.md
+++ b/docs/hub/spaces-sdks-docker-marimo.md
@@ -16,7 +16,7 @@ Key features:
 To get started with marimo on Spaces, click the button below:
 
 <a href="http://huggingface.co/new-space?template=marimo-team/marimo-app-template" target="_blank">
-    <img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/deploy-to-spaces-lg.svg" alt="">
+    <img src="https://huggingface.co/datasets/huggingface/badges/raw/main/deploy-to-spaces-lg.svg" alt="">
 </a>
 
 This will start building your Space using marimo's Docker template. If successful, you should see a similar application to the [marimo introduction notebook](https://huggingface.co/spaces/marimo-team/marimo-app-template).

--- a/docs/hub/spaces-sdks-docker-panel.md
+++ b/docs/hub/spaces-sdks-docker-panel.md
@@ -8,7 +8,7 @@ Visit [Panel documentation](https://panel.holoviz.org/) to learn more about maki
 
 You can deploy Panel on Spaces with just a few clicks:
 
-<a href="https://huggingface.co/new-space?template=Panel-Org/panel-template"> <img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/deploy-to-spaces-lg.svg"/> </a>
+<a href="https://huggingface.co/new-space?template=Panel-Org/panel-template"> <img src="https://huggingface.co/datasets/huggingface/badges/raw/main/deploy-to-spaces-lg.svg"/> </a>
 
 There are a few key parameters you need to define: the Owner (either your personal account or an organization), a Space name, and Visibility. In case you intend to execute computationally intensive deep learning models, consider upgrading to a GPU to boost performance. 
 

--- a/docs/hub/spaces-sdks-docker-shiny.md
+++ b/docs/hub/spaces-sdks-docker-shiny.md
@@ -17,7 +17,7 @@ Shiny for Python is ideal for Hugging Face applications because it integrates sm
 To get started deploying a Space, click this button to select your hardware and specify if you want a public or private Space.
 The Space template will populate a few files to get your app started.
 
-<a  href="https://huggingface.co/new-space?template=posit/shiny-for-python-template"> <img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/deploy-to-spaces-lg.svg"/> </a>
+<a  href="https://huggingface.co/new-space?template=posit/shiny-for-python-template"> <img src="https://huggingface.co/datasets/huggingface/badges/raw/main/deploy-to-spaces-lg.svg"/> </a>
 
 
 _app.py_
@@ -43,7 +43,7 @@ To integrate Hugging Face tools into an R app, you can either use [httr2](https:
 To deploy an R Shiny Space, click this button and fill out the space metadata. 
 This will populate the Space with all the files you need to get started.
 
-<a  href="https://huggingface.co/new-space?template=posit/shiny-for-r-template"> <img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/deploy-to-spaces-lg.svg"/> </a>
+<a  href="https://huggingface.co/new-space?template=posit/shiny-for-r-template"> <img src="https://huggingface.co/datasets/huggingface/badges/raw/main/deploy-to-spaces-lg.svg"/> </a>
 
 
 _app.R_

--- a/docs/hub/spaces-sdks-docker-zenml.md
+++ b/docs/hub/spaces-sdks-docker-zenml.md
@@ -35,7 +35,7 @@ make it work with whatever your custom tool or workflow is.
 You can deploy ZenML on Spaces with just a few clicks:
 
 <a  href="https://huggingface.co/new-space?template=zenml/zenml-template-space">
-    <img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/deploy-to-spaces-lg.svg" />
+    <img src="https://huggingface.co/datasets/huggingface/badges/raw/main/deploy-to-spaces-lg.svg" />
 </a>
 
 To set up your ZenML app, you need to specify three main components: the Owner


### PR DESCRIPTION
Updates the URLs to use `raw` instead of `resolve` which gets the svgs to show up properly.

