### PR TITLE
Don't open PR if only a dependency update

### DIFF
--- a/.github/workflows/api_inference_generate_documentation.yml
+++ b/.github/workflows/api_inference_generate_documentation.yml
@@ -37,10 +37,21 @@ jobs:
 
       # Check changes
       - name: Check changes
-        run: git status
+        run: |
+          git diff --name-only > changed_files.txt
+          if grep -v -E "^(scripts/api-inference/package.json|scripts/api-inference/pnpm-lock.yaml)$" changed_files.txt | grep -q '.'; then
+            echo "changes_detected=true" >> $GITHUB_ENV
+          else
+            echo "changes_detected=false" >> $GITHUB_ENV
+
+      # Skip PR if only certain files are updated
+      - name: Skip PR creation if no meaningful changes
+        if: env.changes_detected == 'false'
+        run: echo "No meaningful changes. Skipping PR creation."
 
       # Create or update Pull Request
       - name: Create Pull Request
+        if: env.changes_detected == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.TOKEN_INFERENCE_SYNC_BOT }}


### PR DESCRIPTION
This should prevent the automated script to open useless PRs like this one: https://github.com/huggingface/hub-docs/pull/1517/files.

Won't lie, it's a AI-generated PR. See https://chatgpt.com/share/67569be4-2c94-8001-b74e-776777064c9f for details. (I also tried https://hf.co/chat/r/ghnR9Ci?leafId=5a1964ac-8ddc-4645-bc25-5de22cb684ca but felt the solution was less elegant)