### PR TITLE
[WIP] docs: add langfuse as spaces template

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -285,6 +285,8 @@
         title: Evidence on Spaces
       - local: spaces-sdks-docker-marimo
         title: marimo on Spaces
+      - local: spaces-sdks-docker-langfuse
+        title: Langfuse on Spaces
   - local: spaces-embed
     title: Embed your Space
   - local: spaces-run-with-docker

--- a/docs/hub/spaces-sdks-docker-langfuse.md
+++ b/docs/hub/spaces-sdks-docker-langfuse.md
@@ -1,0 +1,1 @@
+# Langfuse on Spaces


### PR DESCRIPTION
This PR adds the documentation guide for using the [Langfuse](https://langfuse.com/) docker space.

The space template currently lives here: https://huggingface.co/spaces/langfuse/langfuse-template-space