### PR TITLE
Update mlx-image.md

### DIFF
--- a/docs/hub/mlx-image.md
+++ b/docs/hub/mlx-image.md
@@ -35,8 +35,6 @@ To list all available models:
 from mlxim.model import list_models
 list_models()
 ```
-> [!WARNING]
-> As of today (2024-03-15) mlx does not support `group` param for nn.Conv2d. Therefore, architectures such as `resnext`, `regnet` or `efficientnet` are not yet supported in `mlx-image`.
 
 ## ImageNet-1K Results
 


### PR DESCRIPTION
This PR removes an outdated warning about grouped conv2d, which is now supported by MLX.