### PR TITLE
[HF Inference API] fix broken link

### DIFF
--- a/docs/api-inference/tasks/text-generation.md
+++ b/docs/api-inference/tasks/text-generation.md
@@ -16,7 +16,7 @@ For more details, check out:
 
 Generate text based on a prompt.
 
-If you are interested in a Chat Completion task, which generates a response based on a list of messages, check out the [`chat-completion`](./chat_completion) task.
+If you are interested in a Chat Completion task, which generates a response based on a list of messages, check out the [`chat-completion`](./chat-completion) task.
 
 <Tip>
 


### PR DESCRIPTION
This PR fixes a broken link. 
Note that this documentation will be probably revamped in the future with the introduction of Inference Providers.