### PR TITLE
Expand academia hub details

### DIFF
--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -1,49 +1,117 @@
 # Academia Hub
 
 <Tip>
-Ask your university's IT or Procurement Team to <a href="https://huggingface.co/contact/sales?from=academia" target="_blank">get in touch</a> from a university-affiliated email address to initiate the subscription process.
+If you're a student, researcher, or faculty member, ask your university's IT or Procurement Team to <a href="https://huggingface.co/contact/sales?from=academia" target="_blank">get in touch</a> from a university-affiliated email address to initiate the subscription process.
 </Tip>
 
-Academia Hub is a paid offering that provides the Hugging Face Hub’s PRO features to every student, researcher, or faculty member of an academic institution. Explore advanced tools, enhanced collaboration, and exclusive resources to accelerate your learning, research, and teaching. The Hugging Face team is able to work with your IT or procurement department to set the product up.
+Academia Hub is a paid offering that provides the Hugging Face Hub's PRO features to every student, researcher, or faculty member of an academic institution. Explore advanced tools, enhanced collaboration, and exclusive resources to accelerate your learning, research, and teaching. The Hugging Face team is able to work with your IT or procurement department to set the product up.
 
 <a href="https://huggingface.co/contact/sales?from=academia" class="flex justify-center">
     <img class="block" src="https://huggingface.co/datasets/Chunte/documentation-images/resolve/main/AcademiaHub.png" />
 </a>
-
-#### How does it work
-
-When Academia Hub is enabled, any affiliated user will need to add their `@your-university-name.edu` email address (or other university domain) to their HF account.
 
 Academia Hub is designed for:
 - **Students:** Unlock powerful features to learn about AI and Machine learning in the most efficient way.
 - **Researchers:** Collaborate with peers using the standard AI ecosystem of tools.
 - **Faculty members:** Enhance your classes' projects with PRO capabilities.
 
-Key Features of Academia Hub:
+When Academia Hub is enabled, any affiliated user will need to add their `@your-university-name.edu` email address (or other university domain) to their HF account.
 
-- **ZeroGPU:** Get 5x usage quota and highest GPU queue priority.
-- **Spaces Hosting:** Create ZeroGPU Spaces with A100 hardware.
-- **Spaces Dev Mode:** Fast iterations via SSH/VS Code for Spaces.
-- **Inference Providers:** Get monthly included credits across all Inference Providers.
-- **HF Inference API:** Get x20 higher rate limits on HF Serverless API.
-- **Dataset Viewer:** Activate it on private datasets.
-- **Blog Articles:** Publish articles to the Hugging Face blog.
-- **Social Posts:** Share short updates with the community.
-- **Seamless Onboarding:** Quick and secure sign-up with your academic email.
-- **Enhanced Collaboration:** Connect with peers and mentors.
-- **Exclusive Resources:** Access datasets, models, and projects tailored for academia.
+## Key Features of Academia Hub
 
-#### Eligibility
+Academia Hub includes all the features of [Enterprise Hub](./enterprise-hub). Let's compare the features between the free tier, PRO, and Academia Hub.
+
+<table>
+  <thead>
+    <tr>
+      <th>Feature</th>
+      <th>Free Tier</th>
+      <th>PRO</th>
+      <th>Academia Hub</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong><a href="./spaces-zerogpu.md">ZeroGPU</a></strong></td>
+      <td>Quota</td>
+      <td>5x more daily usage quota + high priority</td>
+      <td>PRO + highest priority</td>
+    </tr>
+    <tr>
+      <td><strong><a href="./spaces-zerogpu.md">Spaces Hosting</a></strong></td>
+      <td>Pay as you go</td>
+      <td>10 ZeroGPU Spaces</td>
+      <td>50 ZeroGPU Spaces + A100 (40GB VRAM)</td>
+    </tr>
+    <tr>
+      <td><strong><a href="./storage-limits.md">Private Storage</a></strong></td>
+      <td>100GB</td>
+      <td>1TB + $25/TB/month</td>
+      <td>1TB per seat + $25/TB/month</td>
+    </tr>
+    <tr>
+      <td><strong><a href="./models-inference.md">HF Inference API</a></strong></td>
+      <td>&lt;$0.10 monthly credits</td>
+      <td>$2.00 monthly credits</td>
+      <td>$2.00 monthly credits with 20x higher rate limits</td>
+    </tr>
+    <tr>
+      <td><strong><a href="./enterprise-sso.md">Advanced Security</a></strong></td>
+      <td colspan="2">GDPR compliant and SOC2 Type 2 certified</td>
+      <td>Enterprise-grade with SSO, audit logs, resource groups</td>
+    </tr>
+    <tr>
+      <td><strong><a href="./enterprise-analytics.md">Analytics</a></strong></td>
+      <td colspan="2">Social and download metrics</td>
+      <td>Advanced with detailed metrics and CSV export</td>
+    </tr>
+    <tr>
+      <td><strong><a href="https://huggingface.co/blog/inference-providers">Inference Providers</a></strong></td>
+      <td>Pay as you go</td>
+      <td colspan="2">Monthly credits across all providers</td>
+    </tr>
+    <tr>
+      <td><strong><a href="./spaces-dev-mode.md">Spaces Dev Mode</a></strong></td>
+      <td>Not available</td>
+      <td colspan="2">Available via SSH/VS Code</td>
+    </tr>
+    <tr>
+      <td><strong><a href="./datasets-viewer.md">Dataset Viewer</a></strong></td>
+      <td>Public datasets only</td>
+      <td colspan="2">Available on private datasets</td>
+    </tr>
+    <tr>
+      <td><strong><a href="./storage-limits.md">Public Storage</a></strong></td>
+      <td>Best-effort</td>
+      <td colspan="2">Unlimited</td>
+    </tr>
+    <tr>
+      <td><strong>Blog Articles</strong></td>
+      <td>Not available</td>
+      <td colspan="2">Can publish to HF blog</td>
+    </tr>
+    <tr>
+      <td><strong>Social Posts</strong></td>
+      <td>Not available</td>
+      <td colspan="2">Can share community updates</td>
+    </tr>
+  </tbody>
+</table>
+
+## Eligibility for Students, Researchers, and Faculty Members
+
+Once an institution is subscribed to Academia Hub, any affiliated user will gain access if they meet the following criteria:
 
 - Must possess a valid university or college email address.
 - Open to all students regardless of discipline or level of study.
 - Pricing: Academia Hub is priced based on volume of usage and number of active users at your institution.
 
-#### Subscribe
+## Get started with Academia Hub
+
+👩‍🎓 If you're a student or researcher then contact your TA, teacher, or supervisor and share this page to get started.
+
+👩‍🔬 If you're a faculty member then connect your institution's IT or procurement team with Hugging Face to get started. 
+
+👩‍💼 If you're a procurement, IT, or project manager then <a href="https://huggingface.co/contact/sales?from=academia" target="_blank">get in touch</a> or send an email to academia@hf.co to initiate the subscription process to the Academia Hub today.
 
 
-<a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Get in touch</a> or send an email to academia@hf.co to initiate the subscription process to the Academia Hub today.
-
-#### Private storage
-
-Academia Hub includes 1TB of [private repository storage](./storage-limits) per seat in the subscription, i.e. if your institution has 400 students and faculty, your students and faculty have 400TB included storage accross their private models and datasets.


### PR DESCRIPTION
This PR expands on the details between free, pro, and academia in these ways:

- add a table with links to other docs pages on features
- uses columns to show where offerings align
- targets the CTA at roles like student or teacher

![image](https://github.com/user-attachments/assets/403b32e3-23bf-41e4-a63f-5e0bfa383898)
