### PR TITLE
set a `/docs/hub/xet` alias for ease of use

### DIFF
--- a/docs/hub/_redirects.yml
+++ b/docs/hub/_redirects.yml
@@ -18,3 +18,4 @@ api-webhook: webhooks
 adapter-transformers: adapters
 security-two-fa: security-2fa
 repositories-recommendations: storage-limits
+xet: storage-backends#xet

--- a/docs/hub/storage-backends.md
+++ b/docs/hub/storage-backends.md
@@ -46,6 +46,7 @@ To start using Xet Storage, you need a Xet-enabled repository and a Xet-aware ve
 <Tip>
 
 To make Xet the default for all your repositories, [join the waitlist](https://huggingface.co/join/xet)! You can apply for yourself or your entire organization (requires [admin permissions](https://huggingface.co/docs/hub/organizations-security)). Once approved, all current repositories will be automatically migrated to Xet and future repositories will be Xet-enabled by default.
+Note that our intent is to fast-track PRO users and Enterprise Hub organizations.
 
 </Tip>
 


### PR DESCRIPTION
and also add a note that we will fast-track PRO users and Enterprise Hub organizations in the waitlist