### PR TITLE
LFS files are garbage collected once every 36h

### DIFF
--- a/docs/hub/storage-limits.md
+++ b/docs/hub/storage-limits.md
@@ -138,7 +138,7 @@ The super-squash operation compresses your entire Git history into a single comm
 
 ⚠️ **Important**: This is a destructive operation that cannot be undone, commit history will be permanently lost and **LFS file history will be removed**
 
-The effects from the squash operation on your storage quota are not immediate and will be reflected on your quota within a few minutes.
+The effects from the squash operation on your storage quota are not immediate and will be reflected on your quota within 24 hours.
 
 ### Advanced: Track LFS file references
 

--- a/docs/hub/storage-limits.md
+++ b/docs/hub/storage-limits.md
@@ -138,7 +138,7 @@ The super-squash operation compresses your entire Git history into a single comm
 
 ⚠️ **Important**: This is a destructive operation that cannot be undone, commit history will be permanently lost and **LFS file history will be removed**
 
-The effects from the squash operation on your storage quota are not immediate and will be reflected on your quota within 24 hours.
+The effects from the squash operation on your storage quota are not immediate and will be reflected on your quota within 36 hours.
 
 ### Advanced: Track LFS file references
 


### PR DESCRIPTION
Based on [slack thread](https://huggingface.slack.com/archives/C02EMARJ65P/p1742827144943069?thread_ts=1742825127.913709&cid=C02EMARJ65P) (internal). AFAIK, the garbage collector deletes untracked LFS file only once a day. 