### PR TITLE
[Inference Providers] Fix screenshot display

### DIFF
--- a/docs/api-inference/hub-integration.md
+++ b/docs/api-inference/hub-integration.md
@@ -7,7 +7,7 @@ Inference Providers is tightly integrated with the Hugging Face Hub. No matter w
 When listing models on the Hub, you can filter to select models deployed on the inference provider of your choice. For example, to list all models deployed on Fireworks AI infra: https://huggingface.co/models?inference_provider=fireworks-ai.
 
 <div class="flex justify-center">
-    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/models-filter-by-provider-light.png"/>
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/models-filter-by-provider-light.png"/>
     <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/models-filter-by-provider-dark.png"/>
 </div>
 


### PR DESCRIPTION
Fixing an issue with screenshot display in the hub integration page when dark mode is on.

Before:

![Screenshot 2025-04-01 at 13 03 51](https://github.com/user-attachments/assets/950558b4-bc94-44a6-b646-ece61739edf1)

After:

![Screenshot 2025-04-01 at 13 06 20](https://github.com/user-attachments/assets/2fa6a7c9-bdf5-4911-92a5-74bf9769f10a)
