### PR TITLE
Undocument `x-wait-for-model` and `x-use-cache` headers

### DIFF
--- a/docs/inference-providers/tasks/audio-classification.md
+++ b/docs/inference-providers/tasks/audio-classification.md
@@ -46,6 +46,11 @@ No snippet available for this task.
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _string_ | The input audio data as a base64-encoded string. If no `parameters` are provided, you can also provide the audio data as a raw bytes payload. |
@@ -53,16 +58,6 @@ No snippet available for this task.
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;function_to_apply** | _enum_ | Possible values: sigmoid, softmax, none. |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;top_k** | _integer_ | When specified, limits the output to the top K most probable classes. |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/audio-classification.md
+++ b/docs/inference-providers/tasks/audio-classification.md
@@ -48,7 +48,7 @@ No snippet available for this task.
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/automatic-speech-recognition.md
+++ b/docs/inference-providers/tasks/automatic-speech-recognition.md
@@ -50,7 +50,7 @@ Explore all available models and find the one that suits you best [here](https:/
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/automatic-speech-recognition.md
+++ b/docs/inference-providers/tasks/automatic-speech-recognition.md
@@ -48,6 +48,11 @@ Explore all available models and find the one that suits you best [here](https:/
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _string_ | The input audio data as a base64-encoded string. If no `parameters` are provided, you can also provide the audio data as a raw bytes payload. |
@@ -71,16 +76,6 @@ Explore all available models and find the one that suits you best [here](https:/
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;penalty_alpha** | _number_ | The value balances the model confidence and the degeneration penalty in contrastive search decoding. |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;use_cache** | _boolean_ | Whether the model should use the past last key/values attentions to speed up decoding |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/chat-completion.md
+++ b/docs/inference-providers/tasks/chat-completion.md
@@ -81,7 +81,7 @@ conversational />
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/chat-completion.md
+++ b/docs/inference-providers/tasks/chat-completion.md
@@ -79,6 +79,11 @@ conversational />
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **frequency_penalty** | _number_ | Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. |
@@ -139,16 +144,6 @@ conversational />
 | **top_logprobs** | _integer_ | An integer between 0 and 5 specifying the number of most likely tokens to return at each token position, each with an associated log probability. logprobs must be set to true if this parameter is used. |
 | **top_p** | _number_ | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/feature-extraction.md
+++ b/docs/inference-providers/tasks/feature-extraction.md
@@ -49,7 +49,7 @@ Explore all available models and find the one that suits you best [here](https:/
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/feature-extraction.md
+++ b/docs/inference-providers/tasks/feature-extraction.md
@@ -47,6 +47,11 @@ Explore all available models and find the one that suits you best [here](https:/
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _unknown_ | One of the following: |
@@ -57,16 +62,6 @@ Explore all available models and find the one that suits you best [here](https:/
 | **truncate** | _boolean_ |  |
 | **truncation_direction** | _enum_ | Possible values: Left, Right. |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/fill-mask.md
+++ b/docs/inference-providers/tasks/fill-mask.md
@@ -39,6 +39,11 @@ No snippet available for this task.
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _string_ | The text with masked tokens |
@@ -46,16 +51,6 @@ No snippet available for this task.
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;top_k** | _integer_ | When passed, overrides the number of predictions to return. |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;targets** | _string[]_ | When passed, the model will limit the scores to the passed targets instead of looking up in the whole vocabulary. If the provided targets are not in the model vocab, they will be tokenized and the first resulting token will be used (with a warning, and that might be slower). |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/fill-mask.md
+++ b/docs/inference-providers/tasks/fill-mask.md
@@ -41,7 +41,7 @@ No snippet available for this task.
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/image-classification.md
+++ b/docs/inference-providers/tasks/image-classification.md
@@ -44,6 +44,11 @@ Explore all available models and find the one that suits you best [here](https:/
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _string_ | The input image data as a base64-encoded string. If no `parameters` are provided, you can also provide the image data as a raw bytes payload. |
@@ -51,16 +56,6 @@ Explore all available models and find the one that suits you best [here](https:/
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;function_to_apply** | _enum_ | Possible values: sigmoid, softmax, none. |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;top_k** | _integer_ | When specified, limits the output to the top K most probable classes. |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/image-classification.md
+++ b/docs/inference-providers/tasks/image-classification.md
@@ -46,7 +46,7 @@ Explore all available models and find the one that suits you best [here](https:/
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/image-segmentation.md
+++ b/docs/inference-providers/tasks/image-segmentation.md
@@ -45,7 +45,7 @@ Explore all available models and find the one that suits you best [here](https:/
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/image-segmentation.md
+++ b/docs/inference-providers/tasks/image-segmentation.md
@@ -43,6 +43,11 @@ Explore all available models and find the one that suits you best [here](https:/
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _string_ | The input image data as a base64-encoded string. If no `parameters` are provided, you can also provide the image data as a raw bytes payload. |
@@ -52,16 +57,6 @@ Explore all available models and find the one that suits you best [here](https:/
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subtask** | _enum_ | Possible values: instance, panoptic, semantic. |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;threshold** | _number_ | Probability threshold to filter out predicted masks. |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/image-to-image.md
+++ b/docs/inference-providers/tasks/image-to-image.md
@@ -48,7 +48,7 @@ Explore all available models and find the one that suits you best [here](https:/
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/image-to-image.md
+++ b/docs/inference-providers/tasks/image-to-image.md
@@ -46,6 +46,11 @@ Explore all available models and find the one that suits you best [here](https:/
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _string_ | The input image data as a base64-encoded string. If no `parameters` are provided, you can also provide the image data as a raw bytes payload. |
@@ -58,16 +63,6 @@ Explore all available models and find the one that suits you best [here](https:/
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;width*** | _integer_ |  |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;height*** | _integer_ |  |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/object-detection.md
+++ b/docs/inference-providers/tasks/object-detection.md
@@ -44,7 +44,7 @@ Explore all available models and find the one that suits you best [here](https:/
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/object-detection.md
+++ b/docs/inference-providers/tasks/object-detection.md
@@ -42,22 +42,17 @@ Explore all available models and find the one that suits you best [here](https:/
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _string_ | The input image data as a base64-encoded string. If no `parameters` are provided, you can also provide the image data as a raw bytes payload. |
 | **parameters** | _object_ |  |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;threshold** | _number_ | The probability necessary to make a prediction. |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/question-answering.md
+++ b/docs/inference-providers/tasks/question-answering.md
@@ -46,7 +46,7 @@ Explore all available models and find the one that suits you best [here](https:/
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/question-answering.md
+++ b/docs/inference-providers/tasks/question-answering.md
@@ -44,6 +44,11 @@ Explore all available models and find the one that suits you best [here](https:/
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _object_ | One (context, question) pair to answer |
@@ -58,16 +63,6 @@ Explore all available models and find the one that suits you best [here](https:/
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;handle_impossible_answer** | _boolean_ | Whether to accept impossible as an answer. |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;align_to_words** | _boolean_ | Attempts to align the answer to real words. Improves quality on space separated languages. Might hurt on non-space-separated languages (like Japanese or Chinese) |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/summarization.md
+++ b/docs/inference-providers/tasks/summarization.md
@@ -43,6 +43,11 @@ Explore all available models and find the one that suits you best [here](https:/
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _string_ | The input text to summarize. |
@@ -51,16 +56,6 @@ Explore all available models and find the one that suits you best [here](https:/
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;truncation** | _enum_ | Possible values: do_not_truncate, longest_first, only_first, only_second. |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generate_parameters** | _object_ | Additional parametrization of the text generation algorithm. |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/summarization.md
+++ b/docs/inference-providers/tasks/summarization.md
@@ -45,7 +45,7 @@ Explore all available models and find the one that suits you best [here](https:/
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/table-question-answering.md
+++ b/docs/inference-providers/tasks/table-question-answering.md
@@ -40,6 +40,11 @@ No snippet available for this task.
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _object_ | One (table, question) pair to answer |
@@ -50,16 +55,6 @@ No snippet available for this task.
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sequential** | _boolean_ | Whether to do inference sequentially or as a batch. Batching is faster, but models like SQA require the inference to be done sequentially to extract relations within sequences, given their conversational nature. |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;truncation** | _boolean_ | Activates and controls truncation. |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/table-question-answering.md
+++ b/docs/inference-providers/tasks/table-question-answering.md
@@ -42,7 +42,7 @@ No snippet available for this task.
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/text-classification.md
+++ b/docs/inference-providers/tasks/text-classification.md
@@ -48,7 +48,7 @@ Explore all available models and find the one that suits you best [here](https:/
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/text-classification.md
+++ b/docs/inference-providers/tasks/text-classification.md
@@ -46,6 +46,11 @@ Explore all available models and find the one that suits you best [here](https:/
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _string_ | The text to classify |
@@ -53,16 +58,6 @@ Explore all available models and find the one that suits you best [here](https:/
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;function_to_apply** | _enum_ | Possible values: sigmoid, softmax, none. |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;top_k** | _integer_ | When specified, limits the output to the top K most probable classes. |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/text-generation.md
+++ b/docs/inference-providers/tasks/text-generation.md
@@ -51,7 +51,7 @@ Explore all available models and find the one that suits you best [here](https:/
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/text-generation.md
+++ b/docs/inference-providers/tasks/text-generation.md
@@ -49,6 +49,11 @@ Explore all available models and find the one that suits you best [here](https:/
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _string_ |  |
@@ -80,16 +85,6 @@ Explore all available models and find the one that suits you best [here](https:/
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;watermark** | _boolean_ | Watermarking with [A Watermark for Large Language Models](https://arxiv.org/abs/2301.10226). |
 | **stream** | _boolean_ |  |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/text-to-image.md
+++ b/docs/inference-providers/tasks/text-to-image.md
@@ -46,7 +46,7 @@ Explore all available models and find the one that suits you best [here](https:/
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/text-to-image.md
+++ b/docs/inference-providers/tasks/text-to-image.md
@@ -44,6 +44,11 @@ Explore all available models and find the one that suits you best [here](https:/
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _string_ | The input text data (sometimes called "prompt") |
@@ -56,16 +61,6 @@ Explore all available models and find the one that suits you best [here](https:/
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;scheduler** | _string_ | Override the scheduler with a compatible one. |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;seed** | _integer_ | Seed for the random number generator. |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/token-classification.md
+++ b/docs/inference-providers/tasks/token-classification.md
@@ -45,6 +45,11 @@ Explore all available models and find the one that suits you best [here](https:/
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _string_ | The input text data |
@@ -58,16 +63,6 @@ Explore all available models and find the one that suits you best [here](https:/
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(#4)** | _&#x27;average&#x27;_ | Similar to "simple", also preserves word integrity (uses the label with the highest score, averaged across the word's tokens). |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(#5)** | _&#x27;max&#x27;_ | Similar to "simple", also preserves word integrity (uses the label with the highest score across the word's tokens). |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/token-classification.md
+++ b/docs/inference-providers/tasks/token-classification.md
@@ -47,7 +47,7 @@ Explore all available models and find the one that suits you best [here](https:/
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/translation.md
+++ b/docs/inference-providers/tasks/translation.md
@@ -45,7 +45,7 @@ Explore all available models and find the one that suits you best [here](https:/
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/translation.md
+++ b/docs/inference-providers/tasks/translation.md
@@ -43,6 +43,11 @@ Explore all available models and find the one that suits you best [here](https:/
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _string_ | The text to translate. |
@@ -53,16 +58,6 @@ Explore all available models and find the one that suits you best [here](https:/
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;truncation** | _enum_ | Possible values: do_not_truncate, longest_first, only_first, only_second. |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generate_parameters** | _object_ | Additional parametrization of the text generation algorithm. |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/docs/inference-providers/tasks/zero-shot-classification.md
+++ b/docs/inference-providers/tasks/zero-shot-classification.md
@@ -44,7 +44,7 @@ Explore all available models and find the one that suits you best [here](https:/
 
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
 
 
 | Payload |  |  |

--- a/docs/inference-providers/tasks/zero-shot-classification.md
+++ b/docs/inference-providers/tasks/zero-shot-classification.md
@@ -42,6 +42,11 @@ Explore all available models and find the one that suits you best [here](https:/
 
 #### Request
 
+| Headers |   |    |
+| :--- | :--- | :--- |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+
+
 | Payload |  |  |
 | :--- | :--- | :--- |
 | **inputs*** | _string_ | The text to classify |
@@ -50,16 +55,6 @@ Explore all available models and find the one that suits you best [here](https:/
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hypothesis_template** | _string_ | The sentence used in conjunction with `candidate_labels` to attempt the text classification by replacing the placeholder with the candidate labels. |
 | **&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multi_label** | _boolean_ | Whether multiple candidate labels can be true. If false, the scores are normalized such that the sum of the label likelihoods for each sequence is 1. If true, the labels are considered independent and probabilities are normalized for each candidate. |
 
-
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
-| Headers |   |    |
-| :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
 
 #### Response
 

--- a/scripts/inference-providers/templates/common/specs-headers.handlebars
+++ b/scripts/inference-providers/templates/common/specs-headers.handlebars
@@ -1,3 +1,3 @@
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Providers" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |

--- a/scripts/inference-providers/templates/common/specs-headers.handlebars
+++ b/scripts/inference-providers/templates/common/specs-headers.handlebars
@@ -1,9 +1,3 @@
-Some options can be configured by passing headers to the Inference API. Here are the available headers:
-
 | Headers |   |    |
 | :--- | :--- | :--- |
-| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with Inference API permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens). |
-| **x-use-cache** | _boolean, default to `true`_ | There is a cache layer on the inference API to speed up requests we have already seen. Most models can use those results as they are deterministic (meaning the outputs will be the same anyway). However, if you use a nondeterministic model, you can set this parameter to prevent the caching mechanism from being used, resulting in a real new query. Read more about caching [here](../parameters#caching]). |
-| **x-wait-for-model** | _boolean, default to `false`_ | If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error, as it will limit hanging in your application to known places. Read more about model availability [here](../overview#eligibility]). |
-
-For more information about Inference API headers, check out the parameters [guide](../parameters).
+| **authorization** | _string_ | Authentication header in the form `'Bearer: hf_****'` when `hf_****` is a personal user access token with "Inference Provider" permission. You can generate one from [your settings page](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained). |

--- a/scripts/inference-providers/templates/task/audio-classification.handlebars
+++ b/scripts/inference-providers/templates/task/audio-classification.handlebars
@@ -25,9 +25,9 @@ Example applications:
 
 #### Request
 
-{{{specs.audio-classification.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.audio-classification.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/automatic-speech-recognition.handlebars
+++ b/scripts/inference-providers/templates/task/automatic-speech-recognition.handlebars
@@ -25,9 +25,9 @@ Example applications:
 
 #### Request
 
-{{{specs.automatic-speech-recognition.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.automatic-speech-recognition.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/chat-completion.handlebars
+++ b/scripts/inference-providers/templates/task/chat-completion.handlebars
@@ -52,9 +52,9 @@ The API supports:
 
 #### Request
 
-{{{specs.chat-completion.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.chat-completion.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/feature-extraction.handlebars
+++ b/scripts/inference-providers/templates/task/feature-extraction.handlebars
@@ -25,9 +25,9 @@ Example applications:
 
 #### Request
 
-{{{specs.feature-extraction.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.feature-extraction.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/fill-mask.handlebars
+++ b/scripts/inference-providers/templates/task/fill-mask.handlebars
@@ -20,9 +20,9 @@ Mask filling is the task of predicting the right word (token to be precise) in t
 
 #### Request
 
-{{{specs.fill-mask.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.fill-mask.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/image-classification.handlebars
+++ b/scripts/inference-providers/templates/task/image-classification.handlebars
@@ -20,9 +20,9 @@ Image classification is the task of assigning a label or class to an entire imag
 
 #### Request
 
-{{{specs.image-classification.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.image-classification.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/image-segmentation.handlebars
+++ b/scripts/inference-providers/templates/task/image-segmentation.handlebars
@@ -20,9 +20,9 @@ Image Segmentation divides an image into segments where each pixel in the image 
 
 #### Request
 
-{{{specs.image-segmentation.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.image-segmentation.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/image-to-image.handlebars
+++ b/scripts/inference-providers/templates/task/image-to-image.handlebars
@@ -25,9 +25,9 @@ Example applications:
 
 #### Request
 
-{{{specs.image-to-image.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.image-to-image.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/object-detection.handlebars
+++ b/scripts/inference-providers/templates/task/object-detection.handlebars
@@ -20,9 +20,9 @@ Object Detection models allow users to identify objects of certain defined class
 
 #### Request
 
-{{{specs.object-detection.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.object-detection.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/question-answering.handlebars
+++ b/scripts/inference-providers/templates/task/question-answering.handlebars
@@ -20,9 +20,9 @@ Question Answering models can retrieve the answer to a question from a given tex
 
 #### Request
 
-{{{specs.question-answering.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.question-answering.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/summarization.handlebars
+++ b/scripts/inference-providers/templates/task/summarization.handlebars
@@ -20,9 +20,9 @@ Summarization is the task of producing a shorter version of a document while pre
 
 #### Request
 
-{{{specs.summarization.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.summarization.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/table-question-answering.handlebars
+++ b/scripts/inference-providers/templates/task/table-question-answering.handlebars
@@ -20,9 +20,9 @@ Table Question Answering (Table QA) is the answering a question about an informa
 
 #### Request
 
-{{{specs.table-question-answering.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.table-question-answering.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/text-classification.handlebars
+++ b/scripts/inference-providers/templates/task/text-classification.handlebars
@@ -20,9 +20,9 @@ Text Classification is the task of assigning a label or class to a given text. S
 
 #### Request
 
-{{{specs.text-classification.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.text-classification.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/text-generation.handlebars
+++ b/scripts/inference-providers/templates/task/text-generation.handlebars
@@ -22,9 +22,9 @@ If you are interested in a Chat Completion task, which generates a response base
 
 #### Request
 
-{{{specs.text-generation.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.text-generation.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/text-to-image.handlebars
+++ b/scripts/inference-providers/templates/task/text-to-image.handlebars
@@ -20,9 +20,9 @@ Generate an image based on a given text prompt.
 
 #### Request
 
-{{{specs.text-to-image.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.text-to-image.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/token-classification.handlebars
+++ b/scripts/inference-providers/templates/task/token-classification.handlebars
@@ -20,9 +20,9 @@ Token classification is a task in which a label is assigned to some tokens in a 
 
 #### Request
 
-{{{specs.token-classification.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.token-classification.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/translation.handlebars
+++ b/scripts/inference-providers/templates/task/translation.handlebars
@@ -20,9 +20,9 @@ Translation is the task of converting text from one language to another.
 
 #### Request
 
-{{{specs.translation.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.translation.input}}}
 
 #### Response
 

--- a/scripts/inference-providers/templates/task/zero-shot-classification.handlebars
+++ b/scripts/inference-providers/templates/task/zero-shot-classification.handlebars
@@ -20,9 +20,9 @@ Zero-shot text classification is super useful to try out classification with zer
 
 #### Request
 
-{{{specs.zero-shot-classification.input}}}
-
 {{{constants.specsHeaders}}}
+
+{{{specs.zero-shot-classification.input}}}
 
 #### Response
 


### PR DESCRIPTION
This PR:
- removes `x-wait-for-model` and `x-use-cache` from the headers table. Only the `authorization` header is kept
- removes some wording around the headers table
- updates the settings page link to the correct finegrained settings https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained
- moves the headers table above the paramters table