### PR TITLE
Template for providers logos in dark and light mode + images in HF dataset

### DIFF
--- a/docs/inference-providers/providers/cerebras.md
+++ b/docs/inference-providers/providers/cerebras.md
@@ -26,7 +26,7 @@ For more details, check out the `generate.ts` script: https://github.com/hugging
     </a>
 </div>
 
-<div class="flex justify-center">
+<div class="flex">
     <a href="https://huggingface.co/cerebras" target="_blank">
         <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
         <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>

--- a/docs/inference-providers/providers/cerebras.md
+++ b/docs/inference-providers/providers/cerebras.md
@@ -3,16 +3,35 @@ WARNING
 
 This markdown file has been generated from a script. Please do not edit it directly.
 
+### Template
+
 If you want to update the content related to cerebras's description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/cerebras.handlebars`.
+
+### Logos
+
+If you want to update cerebras's logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `cerebras-light.png` and `cerebras-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
 
 For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.
 --->
 
 # Cerebras
 
-[![Cerebras Logo](https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Cerebras_logo.svg/512px-Cerebras_logo.svg.png)](https://www.cerebras.ai/)
+<div class="flex justify-center">
+    <a href="https://www.cerebras.ai/" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/cerebras-light.png"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/cerebras-dark.png"/>
+    </a>
+</div>
 
-[![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/cerebras)
+<div class="flex justify-center">
+    <a href="https://huggingface.co/cerebras" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
+    </a>
+</div>
 
 Cerebras stands alone as the world’s fastest AI inference and training platform. Organizations across fields like medical research, cryptography, energy, and agentic AI use our CS-2 and CS-3 systems to build on-premise supercomputers, while developers and enterprises everywhere can access the power of Cerebras through our pay-as-you-go cloud offerings.
 

--- a/docs/inference-providers/providers/fal-ai.md
+++ b/docs/inference-providers/providers/fal-ai.md
@@ -26,8 +26,8 @@ For more details, check out the `generate.ts` script: https://github.com/hugging
     </a>
 </div>
 
-<div class="flex justify-center">
-    <a href="https://huggingface.co/fal-ai" target="_blank">
+<div class="flex">
+    <a href="https://huggingface.co/fal" target="_blank">
         <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
         <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
     </a>

--- a/docs/inference-providers/providers/fal-ai.md
+++ b/docs/inference-providers/providers/fal-ai.md
@@ -3,16 +3,35 @@ WARNING
 
 This markdown file has been generated from a script. Please do not edit it directly.
 
+### Template
+
 If you want to update the content related to fal-ai's description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/fal-ai.handlebars`.
+
+### Logos
+
+If you want to update fal-ai's logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `fal-ai-light.png` and `fal-ai-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
 
 For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.
 --->
 
 # Fal
 
-[![fal.ai logo](https://images.seeklogo.com/logo-png/61/1/fal-ai-logo-png_seeklogo-611592.png)](https://fal.ai/)
+<div class="flex justify-center">
+    <a href="https://fal.ai/" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/fal-ai-light.png"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/fal-ai-dark.png"/>
+    </a>
+</div>
 
-[![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/fal)
+<div class="flex justify-center">
+    <a href="https://huggingface.co/fal-ai" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
+    </a>
+</div>
 
 Founded in 2021 by [Burkay Gur](https://huggingface.co/burkaygur) and [Gorkem Yurtseven](https://huggingface.co/gorkemyurt), fal.ai was born out of a shared passion for AI and a desire to address the challenges in AI infrastructure observed during their tenures at Coinbase and Amazon.
 

--- a/docs/inference-providers/providers/fireworks-ai.md
+++ b/docs/inference-providers/providers/fireworks-ai.md
@@ -26,7 +26,7 @@ For more details, check out the `generate.ts` script: https://github.com/hugging
     </a>
 </div>
 
-<div class="flex justify-center">
+<div class="flex">
     <a href="https://huggingface.co/fireworks-ai" target="_blank">
         <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
         <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>

--- a/docs/inference-providers/providers/fireworks-ai.md
+++ b/docs/inference-providers/providers/fireworks-ai.md
@@ -3,16 +3,35 @@ WARNING
 
 This markdown file has been generated from a script. Please do not edit it directly.
 
+### Template
+
 If you want to update the content related to fireworks-ai's description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/fireworks-ai.handlebars`.
+
+### Logos
+
+If you want to update fireworks-ai's logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `fireworks-ai-light.png` and `fireworks-ai-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
 
 For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.
 --->
 
 # Fireworks AI
 
-[![fireworks.ai](https://d1.awsstatic.com/fireworks-ai-wordmark-color-dark.93b1f27fdf77899fa02afb949fb27317ee4081ad.png)](https://fireworks.ai/)
+<div class="flex justify-center">
+    <a href="https://fireworks.ai/" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/fireworks-ai-light.png"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/fireworks-ai-dark.png"/>
+    </a>
+</div>
 
-[![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/fireworks-ai)
+<div class="flex justify-center">
+    <a href="https://huggingface.co/fireworks-ai" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
+    </a>
+</div>
 
 Fireworks AI is a developer-centric platform that delivers high-performance generative AI solutions, enabling efficient deployment and fine-tuning of large language models (LLMs) and image models.
 ## Supported tasks

--- a/docs/inference-providers/providers/hf-inference.md
+++ b/docs/inference-providers/providers/hf-inference.md
@@ -3,16 +3,35 @@ WARNING
 
 This markdown file has been generated from a script. Please do not edit it directly.
 
+### Template
+
 If you want to update the content related to hf-inference's description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/hf-inference.handlebars`.
+
+### Logos
+
+If you want to update hf-inference's logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `hf-inference-light.png` and `hf-inference-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
 
 For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.
 --->
 
 # HF Inference
 
-[![Hugging Face](https://huggingface.co/datasets/huggingface/brand-assets/resolve/main/hf-logo-with-title.png)](https://huggingface.co/)
+<div class="flex justify-center">
+    <a href="https://huggingface.co/" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/hf-inference-light.png"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/hf-inference-dark.png"/>
+    </a>
+</div>
 
-[![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/hf-inference)
+<div class="flex justify-center">
+    <a href="https://huggingface.co/hf-inference" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
+    </a>
+</div>
 
 HF Inference is the serverless Inference API powered by Hugging Face. This service used to be called "Inference API (serverless)" prior to Inference Providers.
 If you are interested in deploying models to a dedicated and autoscaling infrastructure managed by Hugging Face, check out [Inference Endpoints](https://huggingface.co/docs/inference-endpoints/index) instead.

--- a/docs/inference-providers/providers/hf-inference.md
+++ b/docs/inference-providers/providers/hf-inference.md
@@ -26,7 +26,7 @@ For more details, check out the `generate.ts` script: https://github.com/hugging
     </a>
 </div>
 
-<div class="flex justify-center">
+<div class="flex">
     <a href="https://huggingface.co/hf-inference" target="_blank">
         <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
         <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>

--- a/docs/inference-providers/providers/hyperbolic.md
+++ b/docs/inference-providers/providers/hyperbolic.md
@@ -3,16 +3,35 @@ WARNING
 
 This markdown file has been generated from a script. Please do not edit it directly.
 
+### Template
+
 If you want to update the content related to hyperbolic's description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/hyperbolic.handlebars`.
+
+### Logos
+
+If you want to update hyperbolic's logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `hyperbolic-light.png` and `hyperbolic-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
 
 For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.
 --->
 
 # Hyperbolic
 
-[![hyperbolic.xyz logo](https://cdn-images-1.medium.com/max/330/1*vVHd_J2oAOKr1IyjFB-pYQ@2x.png)](https://hyperbolic.xyz/)
+<div class="flex justify-center">
+    <a href="https://hyperbolic.xyz/" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/hyperbolic-light.png"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/hyperbolic-dark.png"/>
+    </a>
+</div>
 
-[![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/hyperbolic)
+<div class="flex justify-center">
+    <a href="https://huggingface.co/hyperbolic" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
+    </a>
+</div>
 
 Hyperbolic is building an open-access platform for AI development by aggregating idle computing resources and making it seamlessly simple to use them.
 

--- a/docs/inference-providers/providers/hyperbolic.md
+++ b/docs/inference-providers/providers/hyperbolic.md
@@ -26,8 +26,8 @@ For more details, check out the `generate.ts` script: https://github.com/hugging
     </a>
 </div>
 
-<div class="flex justify-center">
-    <a href="https://huggingface.co/hyperbolic" target="_blank">
+<div class="flex">
+    <a href="https://huggingface.co/Hyperbolic" target="_blank">
         <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
         <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
     </a>

--- a/docs/inference-providers/providers/nebius.md
+++ b/docs/inference-providers/providers/nebius.md
@@ -26,7 +26,7 @@ For more details, check out the `generate.ts` script: https://github.com/hugging
     </a>
 </div>
 
-<div class="flex justify-center">
+<div class="flex">
     <a href="https://huggingface.co/nebius" target="_blank">
         <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
         <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>

--- a/docs/inference-providers/providers/nebius.md
+++ b/docs/inference-providers/providers/nebius.md
@@ -3,16 +3,35 @@ WARNING
 
 This markdown file has been generated from a script. Please do not edit it directly.
 
+### Template
+
 If you want to update the content related to nebius's description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/nebius.handlebars`.
+
+### Logos
+
+If you want to update nebius's logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `nebius-light.png` and `nebius-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
 
 For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.
 --->
 
 # Nebius
 
-[![Nebius Logo](https://companieslogo.com/img/orig/NBIS_BIG-446495ba.png?t=1729269594)](https://nebius.com/)
+<div class="flex justify-center">
+    <a href="https://nebius.com/" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/nebius-light.png"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/nebius-dark.png"/>
+    </a>
+</div>
 
-[![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/nebius)
+<div class="flex justify-center">
+    <a href="https://huggingface.co/nebius" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
+    </a>
+</div>
 
 ​Nebius AI is a technology company specializing in AI-centric cloud platforms, offering scalable GPU clusters, managed services, and developer tools designed for intensive AI workloads. Headquartered in Amsterdam, Nebius provides flexible architecture and high-performance infrastructure to support AI model training and inference at any scale.
 

--- a/docs/inference-providers/providers/novita.md
+++ b/docs/inference-providers/providers/novita.md
@@ -3,16 +3,35 @@ WARNING
 
 This markdown file has been generated from a script. Please do not edit it directly.
 
+### Template
+
 If you want to update the content related to novita's description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/novita.handlebars`.
+
+### Logos
+
+If you want to update novita's logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `novita-light.png` and `novita-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
 
 For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.
 --->
 
 # Novita
 
-[![https://novita.ai/](https://novita.ai/logo/logo.svg)](https://novita.ai/)
+<div class="flex justify-center">
+    <a href="https://novita.ai/" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/novita-light.png"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/novita-dark.png"/>
+    </a>
+</div>
 
-[![https://huggingface.co/novita](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/novita)
+<div class="flex justify-center">
+    <a href="https://huggingface.co/novita" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
+    </a>
+</div>
 
 ​Novita AI is a comprehensive AI cloud platform that provides developers and businesses with access to over 200 APIs for tasks such as image generation, video processing, audio synthesis, and large language models.
 

--- a/docs/inference-providers/providers/novita.md
+++ b/docs/inference-providers/providers/novita.md
@@ -26,7 +26,7 @@ For more details, check out the `generate.ts` script: https://github.com/hugging
     </a>
 </div>
 
-<div class="flex justify-center">
+<div class="flex">
     <a href="https://huggingface.co/novita" target="_blank">
         <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
         <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>

--- a/docs/inference-providers/providers/replicate.md
+++ b/docs/inference-providers/providers/replicate.md
@@ -3,16 +3,35 @@ WARNING
 
 This markdown file has been generated from a script. Please do not edit it directly.
 
+### Template
+
 If you want to update the content related to replicate's description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/replicate.handlebars`.
+
+### Logos
+
+If you want to update replicate's logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `replicate-light.png` and `replicate-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
 
 For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.
 --->
 
 # Replicate
 
-[![https://replicate.com/](https://cdn.sanity.io/images/50q6fr1p/production/2542fad4ab944c0f5e1ab7507a3333a2d5f7f464-2626x684.png?auto=format)](https://replicate.com/)
+<div class="flex justify-center">
+    <a href="https://replicate.com/" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/replicate-light.png"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/replicate-dark.png"/>
+    </a>
+</div>
 
-[![https://huggingface.co/replicate](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/replicate)
+<div class="flex justify-center">
+    <a href="https://huggingface.co/replicate" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
+    </a>
+</div>
 
 Replicate is building tools so all software engineers can use AI as if it were normal software. You should be able to import an image generator the same way you import an npm package. You should be able to customize a model as easily as you can fork something on GitHub.
 

--- a/docs/inference-providers/providers/replicate.md
+++ b/docs/inference-providers/providers/replicate.md
@@ -26,7 +26,7 @@ For more details, check out the `generate.ts` script: https://github.com/hugging
     </a>
 </div>
 
-<div class="flex justify-center">
+<div class="flex">
     <a href="https://huggingface.co/replicate" target="_blank">
         <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
         <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>

--- a/docs/inference-providers/providers/sambanova.md
+++ b/docs/inference-providers/providers/sambanova.md
@@ -3,16 +3,35 @@ WARNING
 
 This markdown file has been generated from a script. Please do not edit it directly.
 
+### Template
+
 If you want to update the content related to sambanova's description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/sambanova.handlebars`.
+
+### Logos
+
+If you want to update sambanova's logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `sambanova-light.png` and `sambanova-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
 
 For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.
 --->
 
 # SambaNova
 
-[![SambaNova Logo](https://sambanova.ai/hubfs/sambanova-logo-black.png)](https://sambanova.ai/)
+<div class="flex justify-center">
+    <a href="https://sambanova.ai/" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/sambanova-light.png"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/sambanova-dark.png"/>
+    </a>
+</div>
 
-[![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/sambanovasystems)
+<div class="flex justify-center">
+    <a href="https://huggingface.co/sambanova" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
+    </a>
+</div>
 
 SambaNova's AI platform is the technology backbone for the next decade of AI innovation.
 Customers are turning to SambaNova to quickly deploy state-of-the-art AI and deep learning capabilities that help them outcompete their peers.

--- a/docs/inference-providers/providers/sambanova.md
+++ b/docs/inference-providers/providers/sambanova.md
@@ -26,8 +26,8 @@ For more details, check out the `generate.ts` script: https://github.com/hugging
     </a>
 </div>
 
-<div class="flex justify-center">
-    <a href="https://huggingface.co/sambanova" target="_blank">
+<div class="flex">
+    <a href="https://huggingface.co/sambanovasystems" target="_blank">
         <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
         <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
     </a>

--- a/docs/inference-providers/providers/together.md
+++ b/docs/inference-providers/providers/together.md
@@ -26,8 +26,8 @@ For more details, check out the `generate.ts` script: https://github.com/hugging
     </a>
 </div>
 
-<div class="flex justify-center">
-    <a href="https://huggingface.co/together" target="_blank">
+<div class="flex">
+    <a href="https://huggingface.co/togethercomputer" target="_blank">
         <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
         <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
     </a>

--- a/docs/inference-providers/providers/together.md
+++ b/docs/inference-providers/providers/together.md
@@ -3,16 +3,35 @@ WARNING
 
 This markdown file has been generated from a script. Please do not edit it directly.
 
+### Template
+
 If you want to update the content related to together's description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/together.handlebars`.
+
+### Logos
+
+If you want to update together's logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `together-light.png` and `together-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
 
 For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.
 --->
 
 # Together
 
-[![https://www.together.ai/](https://cdn.prod.website-files.com/64f6f2c0e3f4c5a91c1e823a/65d36320026d81d87266e15f_together-color.jpg)](https://www.together.ai/)
+<div class="flex justify-center">
+    <a href="https://together.xyz/" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/together-light.png"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/together-dark.png"/>
+    </a>
+</div>
 
-[![https://huggingface.co/togethercomputer](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/togethercomputer)
+<div class="flex justify-center">
+    <a href="https://huggingface.co/together" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
+    </a>
+</div>
 
 Together decentralized cloud services empower developers and researchers at organizations of all sizes to train, fine-tune, and deploy generative AI models.
 

--- a/scripts/inference-providers/scripts/generate.ts
+++ b/scripts/inference-providers/scripts/generate.ts
@@ -31,6 +31,19 @@ const SPECS_REVISION = "main";
 
 const HEADERS = { Authorization: `Bearer ${process.env.HF_TOKEN}` };
 
+const PROVIDERS_URLS: Record<string, string> = {
+  cerebras: "https://www.cerebras.ai/",
+  "fal-ai": "https://fal.ai/",
+  "fireworks-ai": "https://fireworks.ai/",
+  "hf-inference": "https://huggingface.co/",
+  hyperbolic: "https://hyperbolic.xyz/",
+  nebius: "https://nebius.com/",
+  novita: "https://novita.ai/",
+  replicate: "https://replicate.com/",
+  sambanova: "https://sambanova.ai/",
+  together: "https://together.xyz/",
+};
+
 async function authFetchJson(url: string) {
   const headers = url.includes("huggingface.co") ? HEADERS : {};
   try {
@@ -370,6 +383,12 @@ const SPECS_OUTPUT_TEMPLATE = Handlebars.compile(
 );
 const PROVIDER_TASKS_TEMPLATE = Handlebars.compile(
   await readTemplate("provider-tasks", "common")
+);
+const PROVIDER_LOGO_TEMPLATE = Handlebars.compile(
+  await readTemplate("provider-logo", "common")
+);
+const FOLLOW_US_BUTTON_TEMPLATE = Handlebars.compile(
+  await readTemplate("follow-us-button", "common")
 );
 
 ////////////////////
@@ -738,6 +757,11 @@ await Promise.all(
   Object.entries(PER_PROVIDER_TASKS).map(async ([provider, tasks]) => {
     const rendered = await renderTemplate(provider, "providers", {
       tasksSection: PROVIDER_TASKS_TEMPLATE({ tasks }),
+      followUsSection: FOLLOW_US_BUTTON_TEMPLATE({ provider }),
+      logoSection: PROVIDER_LOGO_TEMPLATE({
+        provider,
+        providerUrl: PROVIDERS_URLS[provider],
+      }),
     });
     await writeProviderDoc(provider, rendered);
   })

--- a/scripts/inference-providers/scripts/generate.ts
+++ b/scripts/inference-providers/scripts/generate.ts
@@ -31,6 +31,19 @@ const SPECS_REVISION = "main";
 
 const HEADERS = { Authorization: `Bearer ${process.env.HF_TOKEN}` };
 
+const PROVIDERS_HUB_ORGS: Record<string, string> = {
+  cerebras: "cerebras",
+  "fal-ai": "fal",
+  "fireworks-ai": "fireworks-ai",
+  "hf-inference": "hf-inference",
+  hyperbolic: "Hyperbolic",
+  nebius: "nebius",
+  novita: "novita",
+  replicate: "replicate",
+  sambanova: "sambanovasystems",
+  together: "togethercomputer",
+};
+
 const PROVIDERS_URLS: Record<string, string> = {
   cerebras: "https://www.cerebras.ai/",
   "fal-ai": "https://fal.ai/",
@@ -757,7 +770,10 @@ await Promise.all(
   Object.entries(PER_PROVIDER_TASKS).map(async ([provider, tasks]) => {
     const rendered = await renderTemplate(provider, "providers", {
       tasksSection: PROVIDER_TASKS_TEMPLATE({ tasks }),
-      followUsSection: FOLLOW_US_BUTTON_TEMPLATE({ provider }),
+      followUsSection: FOLLOW_US_BUTTON_TEMPLATE({
+        provider,
+        providerHubOrg: PROVIDERS_HUB_ORGS[provider],
+      }),
       logoSection: PROVIDER_LOGO_TEMPLATE({
         provider,
         providerUrl: PROVIDERS_URLS[provider],

--- a/scripts/inference-providers/templates/common/follow-us-button.handlebars
+++ b/scripts/inference-providers/templates/common/follow-us-button.handlebars
@@ -1,0 +1,6 @@
+<div class="flex justify-center">
+    <a href="https://huggingface.co/{{provider}}" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
+    </a>
+</div>

--- a/scripts/inference-providers/templates/common/follow-us-button.handlebars
+++ b/scripts/inference-providers/templates/common/follow-us-button.handlebars
@@ -1,5 +1,5 @@
-<div class="flex justify-center">
-    <a href="https://huggingface.co/{{provider}}" target="_blank">
+<div class="flex">
+    <a href="https://huggingface.co/{{providerHubOrg}}" target="_blank">
         <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
         <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
     </a>

--- a/scripts/inference-providers/templates/common/provider-header.handlebars
+++ b/scripts/inference-providers/templates/common/provider-header.handlebars
@@ -2,6 +2,15 @@ WARNING
 
 This markdown file has been generated from a script. Please do not edit it directly.
 
+### Template
+
 If you want to update the content related to {{provider}}'s description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/{{provider}}.handlebars`.
+
+### Logos
+
+If you want to update {{provider}}'s logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `{{provider}}-light.png` and `{{provider}}-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
 
 For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.

--- a/scripts/inference-providers/templates/common/provider-logo.handlebars
+++ b/scripts/inference-providers/templates/common/provider-logo.handlebars
@@ -1,0 +1,6 @@
+<div class="flex justify-center">
+    <a href="{{{providerUrl}}}" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/{{provider}}-light.png"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/{{provider}}-dark.png"/>
+    </a>
+</div>

--- a/scripts/inference-providers/templates/providers/cerebras.handlebars
+++ b/scripts/inference-providers/templates/providers/cerebras.handlebars
@@ -1,8 +1,8 @@
 # Cerebras
 
-[![Cerebras Logo](https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Cerebras_logo.svg/512px-Cerebras_logo.svg.png)](https://www.cerebras.ai/)
+{{{logoSection}}}
 
-[![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/cerebras)
+{{{followUsSection}}}
 
 Cerebras stands alone as the world’s fastest AI inference and training platform. Organizations across fields like medical research, cryptography, energy, and agentic AI use our CS-2 and CS-3 systems to build on-premise supercomputers, while developers and enterprises everywhere can access the power of Cerebras through our pay-as-you-go cloud offerings.
 

--- a/scripts/inference-providers/templates/providers/fal-ai.handlebars
+++ b/scripts/inference-providers/templates/providers/fal-ai.handlebars
@@ -1,8 +1,8 @@
 # Fal
 
-[![fal.ai logo](https://images.seeklogo.com/logo-png/61/1/fal-ai-logo-png_seeklogo-611592.png)](https://fal.ai/)
+{{{logoSection}}}
 
-[![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/fal)
+{{{followUsSection}}}
 
 Founded in 2021 by [Burkay Gur](https://huggingface.co/burkaygur) and [Gorkem Yurtseven](https://huggingface.co/gorkemyurt), fal.ai was born out of a shared passion for AI and a desire to address the challenges in AI infrastructure observed during their tenures at Coinbase and Amazon.
 

--- a/scripts/inference-providers/templates/providers/fireworks-ai.handlebars
+++ b/scripts/inference-providers/templates/providers/fireworks-ai.handlebars
@@ -1,8 +1,8 @@
 # Fireworks AI
 
-[![fireworks.ai](https://d1.awsstatic.com/fireworks-ai-wordmark-color-dark.93b1f27fdf77899fa02afb949fb27317ee4081ad.png)](https://fireworks.ai/)
+{{{logoSection}}}
 
-[![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/fireworks-ai)
+{{{followUsSection}}}
 
 Fireworks AI is a developer-centric platform that delivers high-performance generative AI solutions, enabling efficient deployment and fine-tuning of large language models (LLMs) and image models.
 {{{tasksSection}}}

--- a/scripts/inference-providers/templates/providers/hf-inference.handlebars
+++ b/scripts/inference-providers/templates/providers/hf-inference.handlebars
@@ -1,8 +1,8 @@
 # HF Inference
 
-[![Hugging Face](https://huggingface.co/datasets/huggingface/brand-assets/resolve/main/hf-logo-with-title.png)](https://huggingface.co/)
+{{{logoSection}}}
 
-[![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/hf-inference)
+{{{followUsSection}}}
 
 HF Inference is the serverless Inference API powered by Hugging Face. This service used to be called "Inference API (serverless)" prior to Inference Providers.
 If you are interested in deploying models to a dedicated and autoscaling infrastructure managed by Hugging Face, check out [Inference Endpoints](https://huggingface.co/docs/inference-endpoints/index) instead.

--- a/scripts/inference-providers/templates/providers/hyperbolic.handlebars
+++ b/scripts/inference-providers/templates/providers/hyperbolic.handlebars
@@ -1,8 +1,8 @@
 # Hyperbolic
 
-[![hyperbolic.xyz logo](https://cdn-images-1.medium.com/max/330/1*vVHd_J2oAOKr1IyjFB-pYQ@2x.png)](https://hyperbolic.xyz/)
+{{{logoSection}}}
 
-[![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/hyperbolic)
+{{{followUsSection}}}
 
 Hyperbolic is building an open-access platform for AI development by aggregating idle computing resources and making it seamlessly simple to use them.
 

--- a/scripts/inference-providers/templates/providers/nebius.handlebars
+++ b/scripts/inference-providers/templates/providers/nebius.handlebars
@@ -1,8 +1,8 @@
 # Nebius
 
-[![Nebius Logo](https://companieslogo.com/img/orig/NBIS_BIG-446495ba.png?t=1729269594)](https://nebius.com/)
+{{{logoSection}}}
 
-[![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/nebius)
+{{{followUsSection}}}
 
 ​Nebius AI is a technology company specializing in AI-centric cloud platforms, offering scalable GPU clusters, managed services, and developer tools designed for intensive AI workloads. Headquartered in Amsterdam, Nebius provides flexible architecture and high-performance infrastructure to support AI model training and inference at any scale.
 

--- a/scripts/inference-providers/templates/providers/novita.handlebars
+++ b/scripts/inference-providers/templates/providers/novita.handlebars
@@ -1,8 +1,8 @@
 # Novita
 
-[![https://novita.ai/](https://novita.ai/logo/logo.svg)](https://novita.ai/)
+{{{logoSection}}}
 
-[![https://huggingface.co/novita](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/novita)
+{{{followUsSection}}}
 
 ​Novita AI is a comprehensive AI cloud platform that provides developers and businesses with access to over 200 APIs for tasks such as image generation, video processing, audio synthesis, and large language models.
 

--- a/scripts/inference-providers/templates/providers/replicate.handlebars
+++ b/scripts/inference-providers/templates/providers/replicate.handlebars
@@ -1,8 +1,8 @@
 # Replicate
 
-[![https://replicate.com/](https://cdn.sanity.io/images/50q6fr1p/production/2542fad4ab944c0f5e1ab7507a3333a2d5f7f464-2626x684.png?auto=format)](https://replicate.com/)
+{{{logoSection}}}
 
-[![https://huggingface.co/replicate](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/replicate)
+{{{followUsSection}}}
 
 Replicate is building tools so all software engineers can use AI as if it were normal software. You should be able to import an image generator the same way you import an npm package. You should be able to customize a model as easily as you can fork something on GitHub.
 

--- a/scripts/inference-providers/templates/providers/sambanova.handlebars
+++ b/scripts/inference-providers/templates/providers/sambanova.handlebars
@@ -1,8 +1,8 @@
 # SambaNova
 
-[![SambaNova Logo](https://sambanova.ai/hubfs/sambanova-logo-black.png)](https://sambanova.ai/)
+{{{logoSection}}}
 
-[![Follow us on Hugging Face](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/sambanovasystems)
+{{{followUsSection}}}
 
 SambaNova's AI platform is the technology backbone for the next decade of AI innovation.
 Customers are turning to SambaNova to quickly deploy state-of-the-art AI and deep learning capabilities that help them outcompete their peers.

--- a/scripts/inference-providers/templates/providers/together.handlebars
+++ b/scripts/inference-providers/templates/providers/together.handlebars
@@ -1,8 +1,8 @@
 # Together
 
-[![https://www.together.ai/](https://cdn.prod.website-files.com/64f6f2c0e3f4c5a91c1e823a/65d36320026d81d87266e15f_together-color.jpg)](https://www.together.ai/)
+{{{logoSection}}}
 
-[![https://huggingface.co/togethercomputer](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg)](https://huggingface.co/togethercomputer)
+{{{followUsSection}}}
 
 Together decentralized cloud services empower developers and researchers at organizations of all sizes to train, fine-tune, and deploy generative AI models.
 


### PR DESCRIPTION
- logos are now stored under https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos
- logos and badges and both in light and dark modes
- use templates to avoid maintaining urls and stuff manually (1 template for logos, 1 template for badges)
- add instruction in comments