### PR TITLE
Add cli instructions to download datasets

### DIFF
--- a/docs/hub/datasets-downloading.md
+++ b/docs/hub/datasets-downloading.md
@@ -16,8 +16,13 @@ If a dataset on the Hub is tied to a [supported library](./datasets-libraries), 
 
 ## Using the Hugging Face Client Library
 
-You can use the [`huggingface_hub`](/docs/huggingface_hub) library to create, delete, update and retrieve information from repos. You can also download files from repos or integrate them into your library! For example, you can quickly load a CSV dataset with a few lines using Pandas.
+You can use the [`huggingface_hub`](/docs/huggingface_hub) library to create, delete, update and retrieve information from repos. For example, to download the `HuggingFaceH4/ultrachat_200k` dataset from the command line, run
+```bash
+huggingface-cli download HuggingFaceH4/ultrachat_200k --repo-type dataset
+```
+See the [huggingface-cli download documentation](https://huggingface.co/docs/huggingface_hub/en/guides/cli#download-a-dataset-or-a-space) for more information.
 
+You can also integrate this into your own library! For example, you can quickly load a CSV dataset with a few lines using Pandas.
 ```py
 from huggingface_hub import hf_hub_download
 import pandas as pd


### PR DESCRIPTION
Fixes #1729 . Show how to use `huggingface-cli` to download a dataset.