### PR TITLE
docs: add HF MCP Server section to agents page

### DIFF
--- a/docs/hub/agents.md
+++ b/docs/hub/agents.md
@@ -1,9 +1,28 @@
 # Agents on the Hub
 
 This page compiles all the libraries and tools Hugging Face offers for agentic workflows: 
+- `HF MCP Server`: Connect your MCP-compatible AI assistant directly to the Hugging Face Hub.
 - `tiny-agents`: A lightweight toolkit for MCP-powered agents, available in both JS (`@huggingface/tiny-agents`) and Python (`huggingface_hub`).
 - `Gradio MCP Server`: Easily create MCP servers from Gradio apps and Spaces.
 - `smolagents`: a Python library that enables you to run powerful agents in a few lines of code.
+
+## HF MCP Server
+
+The official **Hugging Face MCP (Model Context Protocol) Server** enables seamless integration between the Hugging Face Hub and any MCP-compatible AI assistant—including VSCode, Cursor, and Claude Desktop.
+
+With the HF MCP Server, you can enhance your AI assistant's capabilities by connecting directly to the Hub's ecosystem. It comes with:
+- a curated set of **built-in tools** like Spaces and Papers Semantic Search, Model and Dataset exploration, etc
+- **MCP-compatible Gradio apps**: Connect to any [MCP-compatible Gradio app](https://huggingface.co/spaces?filter=mcp-server) built by the Hugging Face community
+
+#### Getting Started
+
+Visit [huggingface.co/settings/mcp](https://huggingface.co/settings/mcp) to configure your MCP client and get started.
+
+<Tip warning={true}>
+
+This feature is experimental ⚗️ and will continue to evolve.
+
+</Tip>
 
 ## smolagents
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the official Hugging Face MCP Server to the agents page.

## Changes

- **New HF MCP Server section**: Added detailed documentation explaining the official Hugging Face MCP Server
- **Integration capabilities**: Documents seamless integration with MCP-compatible AI assistants (VSCode, Cursor, Claude Desktop)
- **Built-in tools**: Lists and explains the curated set of built-in tools:
  - Spaces and Papers Semantic Search
  - Model and Dataset exploration
  - MCP-compatible Gradio apps connectivity
- **Getting started guide**: Includes link to configuration page and setup instructions
- **Experimental status**: Added appropriate warning about the experimental nature of the feature
- **Updated introduction**: Modified the page introduction to include HF MCP Server in the tools list

## Related Links

- [HF MCP Server Changelog](https://huggingface.co/changelog/hf-mcp-server)
- [HF MCP Settings Page](https://huggingface.co/settings/mcp)

## Testing

- [x] Documentation builds without errors
- [x] Links are functional
- [x] Content is accurate and comprehensive