### PR TITLE
Fix Typos in Documentation: "utility" and "accommodate"

### DIFF
--- a/docs/hub/fastai.md
+++ b/docs/hub/fastai.md
@@ -14,7 +14,7 @@ All models on the Hub come up with the following features:
 
 ## Using existing models
 
-The `huggingface_hub` library is a lightweight Python client with utlity functions to download models from the Hub.
+The `huggingface_hub` library is a lightweight Python client with utility functions to download models from the Hub.
 
 ```bash
 pip install huggingface_hub["fastai"]

--- a/docs/hub/security-protectai.md
+++ b/docs/hub/security-protectai.md
@@ -11,7 +11,7 @@ Interested in joining our security partnership / providing scanning information 
 
 We partnered with Protect AI to provide scanning in order to make the Hub safer. The same way files are scanned by our internal scanning system, public repositories' files are scanned by Guardian.
 
-Our frontend has been redesigned specifically for this purpose, in order to accomodate for new scanners:
+Our frontend has been redesigned specifically for this purpose, in order to accommodate for new scanners:
 
 <img class="block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/third-party-scans-list.png"/>
 


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in the documentation files:

- In docs/hub/fastai.md, the word "utlity" was corrected to "utility".
- In docs/hub/security-protectai.md, the word "accomodate" was corrected to "accommodate".

These changes improve the clarity and professionalism of the documentation. No functional code changes were made.