### PR TITLE
Fix typo: Correct "fulfilment" spelling in GGUF docs

### DIFF
--- a/docs/hub/datasets-spark.md
+++ b/docs/hub/datasets-spark.md
@@ -165,7 +165,7 @@ To filter the dataset and only keep dialogues in Chinese:
 ```
 
 It is also possible to apply filters or remove columns on the loaded DataFrame, but it is more efficient to do it while loading, especially on Parquet datasets.
-Indeed, Parquet contains metadata at the file and row group level, which allows to skip entire parts of the dataset that don't contain samples that satisfy the criteria. Columns in Parquet can also be loaded indepentently, whch allows to skip the excluded columns and avoid loading unnecessary data.
+Indeed, Parquet contains metadata at the file and row group level, which allows to skip entire parts of the dataset that don't contain samples that satisfy the criteria. Columns in Parquet can also be loaded independently, whch allows to skip the excluded columns and avoid loading unnecessary data.
 
 ### Options
 

--- a/docs/hub/gguf-llamacpp.md
+++ b/docs/hub/gguf-llamacpp.md
@@ -61,7 +61,7 @@ curl http://localhost:8080/v1/chat/completions \
 "messages": [
     {
         "role": "system",
-        "content": "You are an AI assistant. Your top priority is achieving user fulfilment via helping them with their requests."
+        "content": "You are an AI assistant. Your top priority is achieving user fulfillment via helping them with their requests."
     },
     {
         "role": "user",


### PR DESCRIPTION
Minor changes:
• Fix spelling of "fulfillment" in GGUF LLaMA.cpp documentation
• Clean up formatting in Spark datasets documentation
