### PR TITLE
Org Plans: split Team and Enterprise

### DIFF
--- a/docs/hub/advanced-compute-options.md
+++ b/docs/hub/advanced-compute-options.md
@@ -1,7 +1,7 @@
 # Advanced Compute Options
 
 <Tip warning={true}>
-This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 Enterprise Hub organizations gain access to advanced compute options to accelerate their machine learning journey.

--- a/docs/hub/audit-logs.md
+++ b/docs/hub/audit-logs.md
@@ -1,7 +1,7 @@
 # Audit Logs
 
 <Tip warning={true}>
-This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 Audit Logs enable organization admins to easily review actions taken by members, including organization membership, repository settings and billing changes.

--- a/docs/hub/billing.md
+++ b/docs/hub/billing.md
@@ -10,7 +10,7 @@ We offer advanced security and compliance features for organizations through our
 
 The Enterprise Hub is billed like a typical subscription. It renews automatically, but you can choose to cancel it at any time in the organization's billing settings.
 
-You can pay for the Enterprise Hub subscription with a credit card or your AWS account, or via an annual contract.
+You can pay for a Team subscription with a credit card or your AWS account, or upgrade to Enterprise via an annual contract.
 
 Upon renewal, the number of seats in your Enterprise Hub subscription will be updated to match the number of members of your organization.
 Private repository storage above the [included storage](./storage-limits) will be billed along with your subscription renewal.
@@ -44,7 +44,7 @@ Note: PRO benefits are also included in the Enterprise Hub subscription.
 ## Pay-as-you-go private storage 
 
 Above the included 1TB (or 1TB per seat) of private storage in PRO, Team, and Enterprise, private storage is invoiced at **$25/TB/month**, in 1TB increments.
-It is billed with the renewal invoices of your PRO, Team or Enterprise Hub subscription.
+It is billed with the renewal invoices of your PRO, Team or Enterprise subscription.
 
 
 ## Compute Services on the Hub

--- a/docs/hub/billing.md
+++ b/docs/hub/billing.md
@@ -12,7 +12,7 @@ The Enterprise Hub is billed like a typical subscription. It renews automaticall
 
 You can pay for a Team subscription with a credit card or your AWS account, or upgrade to Enterprise via an annual contract.
 
-Upon renewal, the number of seats in your Enterprise Hub subscription will be updated to match the number of members of your organization.
+Upon renewal, the number of seats in your subscription will be updated to match the number of members of your organization.
 Private repository storage above the [included storage](./storage-limits) will be billed along with your subscription renewal.
 
 

--- a/docs/hub/billing.md
+++ b/docs/hub/billing.md
@@ -4,13 +4,13 @@ At Hugging Face, we build a collaboration platform for the ML community (i.e., t
 
 Any feedback or support request related to billing is welcome at billing@huggingface.co
 
-## Enterprise Hub subscriptions
+## Team and Enterprise subscriptions
 
-We offer advanced security and compliance features for organizations through our Enterprise Hub subscription, including [Single Sign-On](./enterprise-sso), [Advanced Access Control](./enterprise-hub-resource-groups) for repositories, control over your data location, higher [storage capacity](./storage-limits) for private repositories, and more.
+We offer advanced security and compliance features for organizations through our Team or Enterprise subscription, including [Single Sign-On](./enterprise-sso), [Advanced Access Control](./enterprise-hub-resource-groups) for repositories, control over your data location, higher [storage capacity](./storage-limits) for private repositories, and more.
 
 The Enterprise Hub is billed like a typical subscription. It renews automatically, but you can choose to cancel it at any time in the organization's billing settings.
 
-You can pay for the Enterprise Hub subscription with a credit card or your AWS account.
+You can pay for the Enterprise Hub subscription with a credit card or your AWS account, or via an annual contract.
 
 Upon renewal, the number of seats in your Enterprise Hub subscription will be updated to match the number of members of your organization.
 Private repository storage above the [included storage](./storage-limits) will be billed along with your subscription renewal.
@@ -43,8 +43,8 @@ Note: PRO benefits are also included in the Enterprise Hub subscription.
 
 ## Pay-as-you-go private storage 
 
-Above the included 1TB (or 1TB per seat) of private storage in PRO and Enterprise Hub, private storage is invoiced at **$25/TB/month**, in 1TB increments.
-It is billed with the renewal invoices of your PRO or Enterprise Hub subscription.
+Above the included 1TB (or 1TB per seat) of private storage in PRO, Team, and Enterprise, private storage is invoiced at **$25/TB/month**, in 1TB increments.
+It is billed with the renewal invoices of your PRO, Team or Enterprise Hub subscription.
 
 
 ## Compute Services on the Hub
@@ -149,7 +149,7 @@ A. You can pay your bill with another payment method by clicking on the “pay o
 A. You can cancel your subscription at anytime here: https://huggingface.co/settings/billing/subscription. 
 Drop us a line at billing@huggingface.co with your feedback.
 
-**Q. My org has an Enterprise Hub subscription and I need to update the number of seats. How can I do this?**
+**Q. My org has a Team or Enterprise subscription and I need to update the number of seats. How can I do this?**
 
 A. The number of seats will automatically be adjusted at the time of the subscription renewal to reflect any increases in the number of members in the organization during the previous period. There’s no need to update the subscribed number of seats during the month or year as it’s a flat fee subscription.
 

--- a/docs/hub/enterprise-hub-advanced-security.md
+++ b/docs/hub/enterprise-hub-advanced-security.md
@@ -1,7 +1,7 @@
 # Advanced Security
 
 <Tip warning={true}>
-This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 Enterprise Hub organizations can improve their security with advanced security controls for both members and repositories.

--- a/docs/hub/enterprise-hub-analytics.md
+++ b/docs/hub/enterprise-hub-analytics.md
@@ -1,7 +1,7 @@
 # Analytics
 
 <Tip warning={true}>
-This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 ## Analytics Dashboard

--- a/docs/hub/enterprise-hub-datasets.md
+++ b/docs/hub/enterprise-hub-datasets.md
@@ -1,7 +1,7 @@
 # Datasets
 
 <Tip warning={true}>
-This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 Data Studio is enabled on private datasets under your Enterprise Hub organization.

--- a/docs/hub/enterprise-hub-gating-group-collections.md
+++ b/docs/hub/enterprise-hub-gating-group-collections.md
@@ -1,7 +1,7 @@
 # Gating Group Collections
 
 <Tip warning={true}>
-This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 Gating Group Collections allow organizations to grant (or reject) access to all the models and datasets in a collection at once, rather than per repo. Users will only have to go through **a single access request**.

--- a/docs/hub/enterprise-hub-network-security.md
+++ b/docs/hub/enterprise-hub-network-security.md
@@ -1,7 +1,7 @@
 # Network Security
 
 <Tip warning={true}>
-This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Plus</a> plan.
+This feature is part of the <a href="https://huggingface.co/contact/sales?from=enterprise" target="_blank">Enterprise Plus</a> plan.
 </Tip>
 
 ## Define your organization IP Ranges

--- a/docs/hub/enterprise-hub-resource-groups.md
+++ b/docs/hub/enterprise-hub-resource-groups.md
@@ -1,7 +1,7 @@
 # Resource groups
 
 <Tip warning={true}>
-This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 Resource Groups allow organizations to enforce fine-grained access control to their repositories.

--- a/docs/hub/enterprise-hub-tokens-management.md
+++ b/docs/hub/enterprise-hub-tokens-management.md
@@ -1,7 +1,7 @@
 # Tokens Management
 
 <Tip warning={true}>
-This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 Tokens Management enables organization administrators to oversee access tokens within their organization, ensuring secure access to organization resources.

--- a/docs/hub/enterprise-hub.md
+++ b/docs/hub/enterprise-hub.md
@@ -1,7 +1,7 @@
 # Enterprise Hub
 
 <Tip>
-<a href="https://huggingface.co/enterprise" target="_blank">Subscribe to Enterprise Hub</a> to get access to advanced features for your organization.
+<a href="https://huggingface.co/enterprise" target="_blank">Subscribe to a Team or Enterprise plan</a> to get access to advanced features for your organization.
 </Tip>
 
 Enterprise Hub adds advanced capabilities to organizations, enabling safe, compliant and managed collaboration for companies and teams on Hugging Face.
@@ -26,4 +26,4 @@ In this section we will document the following Enterprise Hub features:
 - [Network Security](./enterprise-hub-network-security)
 - [Gating Group Collections](./enterprise-hub-gating-group-collections)
 
-Finally, Enterprise Hub includes 1TB of [private repository storage](./storage-limits) per seat in the subscription, i.e. if your organization has 40 members, then you have 40TB included storage for your private models and datasets.
+Finally, Team & Enterprise plans include 1TB of [private repository storage](./storage-limits) per seat in the subscription, i.e. if your organization has 40 members, then you have 40TB included storage for your private models and datasets.

--- a/docs/hub/enterprise-sso.md
+++ b/docs/hub/enterprise-sso.md
@@ -1,7 +1,7 @@
 # Single Sign-On (SSO)
 
 <Tip warning={true}>
-This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 Single sign-on (SSO) allows organizations to securely manage user authentication through their own identity provider (IdP). Both SAML 2.0 and OpenID Connect (OIDC) protocols are supported.

--- a/docs/hub/organizations-security.md
+++ b/docs/hub/organizations-security.md
@@ -34,7 +34,7 @@ As an organization `admin`, go to the **Members** section of the org settings to
 ## Viewing members' email address
 
 <Tip warning={true}>
-This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 You may be able to view the email addresses of members of your organization. The visibility of the email addresses depends on the organization's SSO configuration, or verified organization status.

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -1,7 +1,7 @@
 # Advanced Access Control in Organizations with Resource Groups
 
 <Tip warning={true}>
-This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 In your Hugging Face organization, you can use Resource Groups to control which members have access to specific repositories.

--- a/docs/hub/security-sso-azure-oidc.md
+++ b/docs/hub/security-sso-azure-oidc.md
@@ -3,7 +3,7 @@
 This guide will use Azure as the SSO provider and the Open ID Connect (OIDC) protocol as our preferred identity protocol.
 
 <Tip warning={true}>
-	This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+	This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 ### Step 1: Create a new application in your Identity Provider

--- a/docs/hub/security-sso-azure-saml.md
+++ b/docs/hub/security-sso-azure-saml.md
@@ -5,7 +5,7 @@ In this guide, we will use Azure as the SSO provider and with the Security Asser
 We currently support SP-initiated and IdP-initiated authentication. User provisioning is part of Enterprise Plus's [Advanced SSO](./enterprise-hub-advanced-sso).
 
 <Tip warning={true}>
-	This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+	This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 ### Step 1: Create a new application in your Identity Provider

--- a/docs/hub/security-sso-okta-oidc.md
+++ b/docs/hub/security-sso-okta-oidc.md
@@ -3,7 +3,7 @@
 In this guide, we will use Okta as the SSO provider and with the Open ID Connect (OIDC) protocol as our preferred identity protocol.
 
 <Tip warning={true}>
-	This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+	This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 ### Step 1: Create a new application in your Identity Provider

--- a/docs/hub/security-sso-okta-saml.md
+++ b/docs/hub/security-sso-okta-saml.md
@@ -5,7 +5,7 @@ In this guide, we will use Okta as the SSO provider and with the Security Assert
 We currently support SP-initiated and IdP-initiated authentication. User provisioning is part of Enterprise Plus's [Advanced SSO](./enterprise-hub-advanced-sso).
 
 <Tip warning={true}>
-	This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+	This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 ### Step 1: Create a new application in your Identity Provider

--- a/docs/hub/storage-regions.md
+++ b/docs/hub/storage-regions.md
@@ -1,7 +1,7 @@
 # Storage Regions on the Hub
 
 <Tip warning={true}>
-This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise Hub</a>.
+This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
 Regions allow you to specify where your organization's models, datasets and Spaces are stored. For non-Enterprise Hub users, repositories are always stored in the US.


### PR DESCRIPTION
This pull request updates documentation to reflect the new plan structure, changing all references from "Enterprise Hub" (and similar variants) to "Team & Enterprise" or related terminology.  
- Update documentation links and text to align with new plan naming  
- Adjust subscription details and billing information accordingly  
- Modify tip warnings and call-to-action components to reference the updated plan names
