### PR TITLE
feat: add model links to inference provider templates

### DIFF
--- a/scripts/inference-providers/templates/providers/cerebras.handlebars
+++ b/scripts/inference-providers/templates/providers/cerebras.handlebars
@@ -1,3 +1,6 @@
+<Tip>
+All supported {{providerName}} models can be found [here](https://huggingface.co/models?inference_provider={{providerName}}&sort=trending)
+</Tip>
 # Cerebras
 
 {{{logoSection}}}

--- a/scripts/inference-providers/templates/providers/cohere.handlebars
+++ b/scripts/inference-providers/templates/providers/cohere.handlebars
@@ -1,3 +1,6 @@
+<Tip>
+All supported {{providerName}} models can be found [here](https://huggingface.co/models?inference_provider={{providerName}}&sort=trending)
+</Tip>
 # Cohere
 
 {{{logoSection}}}

--- a/scripts/inference-providers/templates/providers/fal-ai.handlebars
+++ b/scripts/inference-providers/templates/providers/fal-ai.handlebars
@@ -1,3 +1,6 @@
+<Tip>
+All supported {{providerName}} models can be found [here](https://huggingface.co/models?inference_provider={{providerName}}&sort=trending)
+</Tip>
 # Fal
 
 {{{logoSection}}}

--- a/scripts/inference-providers/templates/providers/featherless-ai.handlebars
+++ b/scripts/inference-providers/templates/providers/featherless-ai.handlebars
@@ -1,3 +1,6 @@
+<Tip>
+All supported {{providerName}} models can be found [here](https://huggingface.co/models?inference_provider={{providerName}}&sort=trending)
+</Tip>
 # Featherless AI
 
 {{{logoSection}}}

--- a/scripts/inference-providers/templates/providers/fireworks-ai.handlebars
+++ b/scripts/inference-providers/templates/providers/fireworks-ai.handlebars
@@ -1,3 +1,6 @@
+<Tip>
+All supported {{providerName}} models can be found [here](https://huggingface.co/models?inference_provider={{providerName}}&sort=trending)
+</Tip>
 # Fireworks AI
 
 {{{logoSection}}}

--- a/scripts/inference-providers/templates/providers/groq.handlebars
+++ b/scripts/inference-providers/templates/providers/groq.handlebars
@@ -1,3 +1,6 @@
+<Tip>
+All supported {{providerName}} models can be found [here](https://huggingface.co/models?inference_provider={{providerName}}&sort=trending)
+</Tip>
 # Groq
 
 {{{logoSection}}}

--- a/scripts/inference-providers/templates/providers/hf-inference.handlebars
+++ b/scripts/inference-providers/templates/providers/hf-inference.handlebars
@@ -1,3 +1,6 @@
+<Tip>
+All supported {{providerName}} models can be found [here](https://huggingface.co/models?inference_provider={{providerName}}&sort=trending)
+</Tip>
 # HF Inference
 
 {{{logoSection}}}

--- a/scripts/inference-providers/templates/providers/hyperbolic.handlebars
+++ b/scripts/inference-providers/templates/providers/hyperbolic.handlebars
@@ -1,3 +1,6 @@
+<Tip>
+All supported {{providerName}} models can be found [here](https://huggingface.co/models?inference_provider={{providerName}}&sort=trending)
+</Tip>
 # Hyperbolic: The On-Demand AI Cloud
 
 {{{logoSection}}}

--- a/scripts/inference-providers/templates/providers/nebius.handlebars
+++ b/scripts/inference-providers/templates/providers/nebius.handlebars
@@ -1,3 +1,6 @@
+<Tip>
+All supported {{providerName}} models can be found [here](https://huggingface.co/models?inference_provider={{providerName}}&sort=trending)
+</Tip>
 # Nebius
 
 {{{logoSection}}}

--- a/scripts/inference-providers/templates/providers/novita.handlebars
+++ b/scripts/inference-providers/templates/providers/novita.handlebars
@@ -1,3 +1,6 @@
+<Tip>
+All supported {{providerName}} models can be found [here](https://huggingface.co/models?inference_provider={{providerName}}&sort=trending)
+</Tip>
 # Novita
 
 {{{logoSection}}}

--- a/scripts/inference-providers/templates/providers/nscale.handlebars
+++ b/scripts/inference-providers/templates/providers/nscale.handlebars
@@ -1,3 +1,6 @@
+<Tip>
+All supported {{providerName}} models can be found [here](https://huggingface.co/models?inference_provider={{providerName}}&sort=trending)
+</Tip>
 # Nscale
 
 {{{logoSection}}}

--- a/scripts/inference-providers/templates/providers/replicate.handlebars
+++ b/scripts/inference-providers/templates/providers/replicate.handlebars
@@ -1,3 +1,6 @@
+<Tip>
+All supported {{providerName}} models can be found [here](https://huggingface.co/models?inference_provider={{providerName}}&sort=trending)
+</Tip>
 # Replicate
 
 {{{logoSection}}}

--- a/scripts/inference-providers/templates/providers/sambanova.handlebars
+++ b/scripts/inference-providers/templates/providers/sambanova.handlebars
@@ -1,3 +1,6 @@
+<Tip>
+All supported {{providerName}} models can be found [here](https://huggingface.co/models?inference_provider={{providerName}}&sort=trending)
+</Tip>
 # SambaNova
 
 {{{logoSection}}}

--- a/scripts/inference-providers/templates/providers/together.handlebars
+++ b/scripts/inference-providers/templates/providers/together.handlebars
@@ -1,3 +1,6 @@
+<Tip>
+All supported {{providerName}} models can be found [here](https://huggingface.co/models?inference_provider={{providerName}}&sort=trending)
+</Tip>
 # Together
 
 {{{logoSection}}}


### PR DESCRIPTION
Trying out jules.google to add URL to models deployed by Inference Providers on the hub as well