### PR TITLE
Updated Tips in inference providers docs to show links and code

### DIFF
--- a/docs/inference-providers/guides/building-first-app.md
+++ b/docs/inference-providers/guides/building-first-app.md
@@ -177,9 +177,12 @@ We'll also need to implement the `transcribe` and `summarize` functions.
 <hfoptions id="transcription">
 <hfoption id="python">
 
-Now let's implement the transcription using OpenAI's `whisper-large-v3` model for fast, reliable speech processing. 
+Now let's implement the transcription using OpenAI's `whisper-large-v3` model for fast, reliable speech processing.
+
 <Tip>
+
 We'll use the `auto` provider to automatically select the first available provider for the model. You can define your own priority list of providers in the [Inference Providers](https://huggingface.co/settings/inference-providers) page.
+
 </Tip>
 
 ```python
@@ -200,9 +203,12 @@ def transcribe_audio(audio_file_path):
 </hfoption>
 <hfoption id="javascript">
 
-Now let's implement the transcription using OpenAI's `whisper-large-v3` model for fast, reliable speech processing. 
+Now let's implement the transcription using OpenAI's `whisper-large-v3` model for fast, reliable speech processing.
+
 <Tip>
+
 We'll use the `auto` provider to automatically select the first available provider for the model. You can define your own priority list of providers in the [Inference Providers](https://huggingface.co/settings/inference-providers) page.
+
 </Tip>
 
 ```javascript


### PR DESCRIPTION
Small update to [Building Your First AI App with Inference Providers](https://huggingface.co/docs/inference-providers/guides/building-first-app) to properly display links and code inside Tips.

Problem:

<img width="886" alt="Screenshot 2025-07-04 at 17 12 51" src="https://github.com/user-attachments/assets/9c967e0d-e588-4f4e-8c38-4b41085a2a77" />

Solution:

<img width="920" alt="Screenshot 2025-07-04 at 17 13 07" src="https://github.com/user-attachments/assets/9fba16dc-a0e3-405e-adba-2d0427924145" />

Same was happening for the Agents Course 😄 . Was solved adding new lines before and after <Tip>.

