### PR TITLE
Update tiny-agents example

### DIFF
--- a/docs/hub/agents.md
+++ b/docs/hub/agents.md
@@ -156,10 +156,8 @@ The following example shows a web-browsing agent configured to use the [Qwen/Qwe
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": ["@playwright/mcp@latest"]
-			}
+			"command": "npx",
+			"args": ["@playwright/mcp@latest"]
 		}
 	]
 }
@@ -174,10 +172,8 @@ To use a local LLM (such as [llama.cpp](https://github.com/ggerganov/llama.cpp),
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": ["@playwright/mcp@latest"]
-			}
+			"command": "npx",
+			"args": ["@playwright/mcp@latest"]
 		}
 	]
 }


### PR DESCRIPTION
Fix docs example after https://github.com/huggingface/huggingface_hub/pull/3166 / https://github.com/huggingface/huggingface.js/pull/1556. Since release [0.33.2](https://github.com/huggingface/huggingface_hub/releases/tag/v0.33.2) `tiny-agents` config follow VSCode format. We made the change without a proper deprecation warning as it's still experimental and we wanted to harmonize with VSCode as quickly as possible (to avoid future conflicts).  