### PR TITLE
feat(inference): Add BagelNet inference provider documentation

### DIFF
--- a/docs/inference-providers/_toctree.yml
+++ b/docs/inference-providers/_toctree.yml
@@ -20,6 +20,8 @@
 
 - title: Providers
   sections:
+  - local: providers/bagelnet
+    title: BagelNet
   - local: providers/cerebras
     title: Cerebras
   - local: providers/cohere

--- a/docs/inference-providers/index.md
+++ b/docs/inference-providers/index.md
@@ -13,6 +13,7 @@ Our platform integrates with leading AI infrastructure providers, giving you acc
 
 | Provider                                     | Chat completion (LLM) | Chat completion (VLM) | Feature Extraction | Text to Image | Text to video | Speech to text |
 | -------------------------------------------- | :-------------------: | :-------------------: | :----------------: | :-----------: | :-----------: | :------------: |
+| [BagelNet](./providers/bagelnet)             |          ✅           |          ✅            |                    |     ✅        |      ✅       |                |
 | [Cerebras](./providers/cerebras)             |          ✅           |                       |                    |               |               |                |
 | [Cohere](./providers/cohere)                 |          ✅           |          ✅           |                    |               |               |                |
 | [Fal AI](./providers/fal-ai)                 |                       |                       |                    |      ✅       |      ✅       |       ✅       |

--- a/docs/inference-providers/providers/bagelnet.md
+++ b/docs/inference-providers/providers/bagelnet.md
@@ -1,0 +1,39 @@
+<!---
+WARNING
+
+This markdown file has been generated from a script. Please do not edit it directly.
+
+### Template
+
+If you want to update the content related to bagelnet's description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/bagelnet.handlebars`.
+
+### Logos
+
+If you want to update bagelnet's logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `bagelnet-light.png` and `bagelnet-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
+
+For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.
+--->
+
+# BagelNet
+
+<div class="flex justify-center">
+    <a href="https://bagel.net/" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/bagelnet-light.png"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/bagelnet-dark.png"/>
+    </a>
+</div>
+
+<div class="flex">
+    <a href="https://huggingface.co/bagelnet" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
+    </a>
+</div>
+
+**Bagel** (https://bagel.net) is a privacy‑first AI research lab behind the **Bakery** platform, enabling creators to fine‑tune open‑source models and secure their work with cryptographic proofs.
+
+## Supported tasks
+

--- a/scripts/inference-providers/scripts/generate.ts
+++ b/scripts/inference-providers/scripts/generate.ts
@@ -33,6 +33,7 @@ const HEADERS: Record<string, string> = process.env.HF_TOKEN
   : {};
 
 const PROVIDERS_HUB_ORGS: Record<string, string> = {
+  bagelnet: "bagelnet",
   cerebras: "cerebras",
   cohere: "CohereLabs",
   "fal-ai": "fal",
@@ -50,6 +51,7 @@ const PROVIDERS_HUB_ORGS: Record<string, string> = {
 };
 
 const PROVIDERS_URLS: Record<string, string> = {
+  bagelnet: "https://bagel.net/",
   cerebras: "https://www.cerebras.ai/",
   cohere: "https://cohere.com/",
   "fal-ai": "https://fal.ai/",
@@ -120,15 +122,14 @@ await Promise.all(
     >;
 
     for (const [task, models] of Object.entries(mapping)) {
-      const hasLiveModel = Object.values(models).some(
-        (model) => model.status === "live",
-      );
-
-      if (hasLiveModel) {
-        if (!PER_TASK_SUPPORTED_PROVIDERS[task]) {
-          PER_TASK_SUPPORTED_PROVIDERS[task] = [];
+      for (const [modelId, modelMapping] of Object.entries(models)) {
+        if (modelMapping.status == "live") {
+          if (!PER_TASK_SUPPORTED_PROVIDERS[task]) {
+            PER_TASK_SUPPORTED_PROVIDERS[task] = [];
+          }
+          PER_TASK_SUPPORTED_PROVIDERS[task].push(provider);
+          break;
         }
-        PER_TASK_SUPPORTED_PROVIDERS[task].push(provider);
       }
     }
   }),

--- a/scripts/inference-providers/scripts/generate.ts
+++ b/scripts/inference-providers/scripts/generate.ts
@@ -122,14 +122,15 @@ await Promise.all(
     >;
 
     for (const [task, models] of Object.entries(mapping)) {
-      for (const [modelId, modelMapping] of Object.entries(models)) {
-        if (modelMapping.status == "live") {
-          if (!PER_TASK_SUPPORTED_PROVIDERS[task]) {
-            PER_TASK_SUPPORTED_PROVIDERS[task] = [];
-          }
-          PER_TASK_SUPPORTED_PROVIDERS[task].push(provider);
-          break;
+      const hasLiveModel = Object.values(models).some(
+        (model) => model.status === "live",
+      );
+
+      if (hasLiveModel) {
+        if (!PER_TASK_SUPPORTED_PROVIDERS[task]) {
+          PER_TASK_SUPPORTED_PROVIDERS[task] = [];
         }
+        PER_TASK_SUPPORTED_PROVIDERS[task].push(provider);
       }
     }
   }),

--- a/scripts/inference-providers/templates/providers/bagelnet.handlebars
+++ b/scripts/inference-providers/templates/providers/bagelnet.handlebars
@@ -1,0 +1,9 @@
+# BagelNet
+
+{{{logoSection}}}
+
+{{{followUsSection}}}
+
+**Bagel** (https://bagel.net) is a privacy‑first AI research lab behind the **Bakery** platform, enabling creators to fine‑tune open‑source models and secure their work with cryptographic proofs.
+
+{{{tasksSection}}}


### PR DESCRIPTION
This PR adds BagelNet as an inference provider following the guidelines in the register-as-a-provider documentation.

## Changes:
- Add BagelNet provider template (`bagelnet.handlebars`)
- Update table of contents (`_toctree.yml`) with BagelNet in alphabetical order
- Register BagelNet in `generate.ts`
- Generate BagelNet documentation page

## Request Review:
@Wauplin @SBrandeis @julien-c @hanouticelina 

Addresses Step 8 of the inference provider registration process.