### PR TITLE
Fix pandas_audio_methods code snippet

### DIFF
--- a/docs/hub/datasets-pandas.md
+++ b/docs/hub/datasets-pandas.md
@@ -167,7 +167,7 @@ Using [pandas-audio-methods](https://github.com/lhoestq/pandas-audio-methods) yo
 
 ```python
 import pandas as pd
-from pandas_image_methods import SFMethods
+from pandas_audio_methods import SFMethods
 
 pd.api.extensions.register_series_accessor("sf")(SFMethods)
 


### PR DESCRIPTION
Fixed the example code snippet which was incorrectly importing `SFMethods` from `pandas_image_methods` rather than `pandas_audio_methods`.