### PR TITLE
Remove streamlit from Space SDKs

### DIFF
--- a/docs/hub/api.md
+++ b/docs/hub/api.md
@@ -176,7 +176,7 @@ Parameters:
 - `name`: Name of repo.
 - `organization`: Name of organization (optional).
 - `private`: Whether the repo is private.
-- `sdk`: When the type is `space` (streamlit, gradio, docker or static)
+- `sdk`: When the type is `space` (gradio, docker or static)
 
 Payload:
 

--- a/docs/hub/index.md
+++ b/docs/hub/index.md
@@ -56,7 +56,6 @@ The Hugging Face Hub is a platform with over 1.7M models, 400k datasets, and 600
 <a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces">Introduction</a>
 <a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-overview">Spaces Overview</a>
 <a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-sdks-gradio">Gradio Spaces</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-sdks-streamlit">Streamlit Spaces</a>
 <a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-sdks-static">Static HTML Spaces</a>
 <a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-sdks-docker">Docker Spaces</a>
 <a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-embed">Embed your Space</a>

--- a/docs/hub/spaces-changelog.md
+++ b/docs/hub/spaces-changelog.md
@@ -2,7 +2,7 @@
 
 ## [2025-04-30] - Deprecate Streamlit SDK
 
-- Streamlit is no longer provided as a standard SDK option. Streamlit applications are now created using the Docker template.
+- Streamlit is no longer provided as a default built-in SDK option. Streamlit applications are now created using the Docker template.
 
 ## [2023-07-28] - Upstream Streamlit frontend for `>=1.23.0`
 

--- a/docs/hub/spaces-changelog.md
+++ b/docs/hub/spaces-changelog.md
@@ -1,5 +1,9 @@
 # Spaces Changelog
 
+## [2025-04-30] - Deprecate Streamlit SDK
+
+- Streamlit is no longer provided as a standard SDK option. Streamlit applications are now created using the Docker template.
+
 ## [2023-07-28] - Upstream Streamlit frontend for `>=1.23.0`
 
 - Streamlit SDK uses the upstream packages published on PyPI for `>=1.23.0`, so the newly released versions are available from the day of release.

--- a/docs/hub/spaces-config-reference.md
+++ b/docs/hub/spaces-config-reference.md
@@ -17,16 +17,15 @@ Color for Thumbnail gradient (red, yellow, green, blue, indigo, purple, pink, gr
 Color for Thumbnail gradient (red, yellow, green, blue, indigo, purple, pink, gray).  
 
 **`sdk`** : _string_  
-Can be either `gradio`, `streamlit`, `docker`, or `static`.  
+Can be either `gradio`, `docker`, or `static`.  
 
 **`python_version`**: _string_  
 Any valid Python `3.x` or `3.x.x` version.  
 Defaults to `3.10`.  
 
 **`sdk_version`** : _string_  
-Specify the version of the selected SDK (Streamlit or Gradio).  
+Specify the version of Gradio to use.
 All versions of Gradio are supported.  
-All versions of Streamlit from `0.79.0` are supported.
 
 **`suggested_hardware`** : _string_  
 Specify the suggested [hardware](https://huggingface.co/docs/hub/spaces-gpus) on which this Space must be run.  
@@ -46,7 +45,7 @@ Setting this value will not automatically assign a permanent storage to this Spa
 Value must be one of `"small"`, `"medium"` or `"large"`.  
 
 **`app_file`** : _string_  
-Path to your main application file (which contains either `gradio` or `streamlit` Python code, or `static` html code).  
+Path to your main application file (which contains either `gradio` Python code or `static` html code).  
 Path is relative to the root of the repository.  
 
 **`app_build_command`** : _string_  

--- a/docs/hub/spaces-dependencies.md
+++ b/docs/hub/spaces-dependencies.md
@@ -12,7 +12,8 @@ The default Spaces environment comes with several pre-installed dependencies:
 
 * [`datasets`](https://github.com/huggingface/datasets) allows you to fetch or display any dataset from the Hub inside your app.
 
-* The SDK you specified, which could be either `streamlit` or `gradio`. The version is specified in the `README.md` file.
+* Gradio version is specified by the `sdk_version` in the `README.md` file.
+
 
 * Common Debian packages, such as `ffmpeg`, `cmake`, `libsm6`, and few others.
 

--- a/docs/hub/spaces-dependencies.md
+++ b/docs/hub/spaces-dependencies.md
@@ -1,8 +1,8 @@
-# Handling Spaces Dependencies
+# Handling Spaces Dependencies in Gradio Spaces
 
 ## Default dependencies
 
-The default Spaces environment comes with several pre-installed dependencies:
+The default Gradio Spaces environment comes with several pre-installed dependencies:
 
 * The [`huggingface_hub`](https://huggingface.co/docs/huggingface_hub/index) client library allows you to manage your repository and files on the Hub with Python and programmatically access the Inference API from your Space. If you choose to instantiate the model in your app with the Inference API, you can benefit from the built-in acceleration optimizations. This option also consumes less computing resources, which is always nice for the environment! 🌎 
 

--- a/docs/hub/spaces-dependencies.md
+++ b/docs/hub/spaces-dependencies.md
@@ -12,7 +12,7 @@ The default Spaces environment comes with several pre-installed dependencies:
 
 * [`datasets`](https://github.com/huggingface/datasets) allows you to fetch or display any dataset from the Hub inside your app.
 
-* Gradio version is specified by the `sdk_version` in the `README.md` file.
+* [`gradio`](https://github.com/gradio-app/gradio). You can optionally require a specific version using [`sdk_version` in the `README.md` file](spaces-config-reference).
 
 
 * Common Debian packages, such as `ffmpeg`, `cmake`, `libsm6`, and few others.

--- a/docs/hub/spaces-dev-mode.md
+++ b/docs/hub/spaces-dev-mode.md
@@ -37,7 +37,7 @@ Once the Dev Mode is enabled on your Space, you should see a modal like the foll
 The application does not restart automatically when you change the code. For your changes to appear in the Space, you need to use the `Refresh` button that will restart the app.
 
 <div class="alert alert-warning">
-  If you're using the Streamlit or Gradio SDK, or if your application is Python-based, note that requirements are not installed automatically.
+  If you're using the Gradio SDK, or if your application is Python-based, note that requirements are not installed automatically.
   You will need to manually run `pip install` from VS Code or SSH.
 </div>
 

--- a/docs/hub/spaces-overview.md
+++ b/docs/hub/spaces-overview.md
@@ -8,7 +8,7 @@ In the following sections, you'll learn the basics of creating a Space, configur
 
 ## Creating a new Space
 
-**To make a new Space**, visit the [Spaces main page](https://huggingface.co/spaces) and click on **Create new Space**. Along with choosing a name for your Space, selecting an optional license, and setting your Space's visibility, you'll be prompted to choose the **SDK** for your Space. The Hub offers four SDK options: Gradio, Streamlit, Docker and static HTML. If you select "Gradio" as your SDK, you'll be navigated to a new repo showing the following page:
+**To make a new Space**, visit the [Spaces main page](https://huggingface.co/spaces) and click on **Create new Space**. Along with choosing a name for your Space, selecting an optional license, and setting your Space's visibility, you'll be prompted to choose the **SDK** for your Space. The Hub offers four SDK options: Gradio, Docker and static HTML. If you select "Gradio" as your SDK, you'll be navigated to a new repo showing the following page:
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-blank-space.png"/>
@@ -19,7 +19,6 @@ Under the hood, Spaces stores your code inside a git repository, just like the m
 
 For step-by-step tutorials to creating your first Space, see the guides below:
 * [Creating a Gradio Space](./spaces-sdks-gradio)
-* [Creating a Streamlit Space](./spaces-sdks-streamlit)
 * [Creating a Docker Space](./spaces-sdks-docker-first-demo)
 
 ## Hardware resources
@@ -76,7 +75,6 @@ Accessing secrets and variables is different depending on your Space SDK:
 
 - For Static Spaces, both are available through client-side JavaScript in `window.huggingface.variables`
 - For Docker Spaces, check out [environment management with Docker](./spaces-sdks-docker#secrets-and-variables-management)
-- For Streamlit Spaces, secrets are exposed to your app through [Streamlit Secrets Management](https://blog.streamlit.io/secrets-in-sharing-apps/), and public variables are directly available as environment variables
 
 For other Spaces, both are exposed to your app as environment variables. Here is a very simple example of accessing the previously declared `MODEL_REPO_ID` variable in Python (it would be the same for secrets):
 ```py

--- a/docs/hub/spaces-overview.md
+++ b/docs/hub/spaces-overview.md
@@ -8,7 +8,7 @@ In the following sections, you'll learn the basics of creating a Space, configur
 
 ## Creating a new Space
 
-**To make a new Space**, visit the [Spaces main page](https://huggingface.co/spaces) and click on **Create new Space**. Along with choosing a name for your Space, selecting an optional license, and setting your Space's visibility, you'll be prompted to choose the **SDK** for your Space. The Hub offers four SDK options: Gradio, Docker and static HTML. If you select "Gradio" as your SDK, you'll be navigated to a new repo showing the following page:
+**To make a new Space**, visit the [Spaces main page](https://huggingface.co/spaces) and click on **Create new Space**. Along with choosing a name for your Space, selecting an optional license, and setting your Space's visibility, you'll be prompted to choose the **SDK** for your Space. The Hub offers three SDK options: Gradio, Docker and static HTML. If you select "Gradio" as your SDK, you'll be navigated to a new repo showing the following page:
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-blank-space.png"/>

--- a/docs/hub/spaces-sdks-streamlit.md
+++ b/docs/hub/spaces-sdks-streamlit.md
@@ -1,3 +1,10 @@
+<Tip warning={true}>
+
+The option to use Streamlit as the default built-in SDK for Spaces is deprecated.
+If you wish to deploy a Space with Streamlit, please use the Docker SDK instead.
+
+</Tip>
+
 # Streamlit Spaces
 
 **Streamlit** gives users freedom to build a full-featured web app with Python in a *reactive* way. Your code is rerun each time the state of the app changes. Streamlit is also great for data visualization and supports several charting libraries such as Bokeh, Plotly, and Altair. Read this [blog post](https://huggingface.co/blog/streamlit-spaces) about building and hosting Streamlit apps in Spaces.

--- a/docs/hub/spaces-sdks-streamlit.md
+++ b/docs/hub/spaces-sdks-streamlit.md
@@ -1,7 +1,7 @@
 <Tip warning={true}>
 
 The option to use Streamlit as the default built-in SDK for Spaces is deprecated.
-If you wish to deploy a Space with Streamlit, please use the Docker SDK instead.
+If you wish to deploy a Space with Streamlit, please pick the Docker SDK, then use the Streamlit template.
 
 </Tip>
 

--- a/docs/hub/spaces-sdks-streamlit.md
+++ b/docs/hub/spaces-sdks-streamlit.md
@@ -3,6 +3,10 @@
 The option to use Streamlit as the default built-in SDK for Spaces is deprecated.
 If you wish to deploy a Space with Streamlit, please pick the Docker SDK, then use the Streamlit template.
 
+<div class="flex justify-center">
+<img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-streamlit-docker-sdk.png"/>
+</div>
+
 </Tip>
 
 # Streamlit Spaces

--- a/docs/hub/spaces-using-opencv.md
+++ b/docs/hub/spaces-using-opencv.md
@@ -1,6 +1,6 @@
 # Using OpenCV in Spaces
 
-In order to use OpenCV in your Gradio or Streamlit Spaces, you'll need to make the Space install both the Python and Debian dependencies
+In order to use OpenCV in your Gradio or Python Spaces, you'll need to make the Space install both the Python and Debian dependencies
 
 This means adding `python3-opencv` to the `packages.txt` file, and adding `opencv-python` to the `requirements.txt` file. If those files don't exist, you'll need to create them. 
 

--- a/docs/hub/spaces.md
+++ b/docs/hub/spaces.md
@@ -2,7 +2,7 @@
 
 [Hugging Face Spaces](https://huggingface.co/spaces) offer a simple way to host ML demo apps directly on your profile or your organization's  profile. This allows you to create your ML portfolio, showcase your projects at conferences or to stakeholders, and work collaboratively with other people in the ML ecosystem.
 
-We have built-in support for two awesome SDKs that let you build cool apps in Python in a matter of minutes: **[Streamlit](https://streamlit.io/)** and **[Gradio](https://gradio.app/)**, but you can also unlock the whole power of Docker and host an arbitrary Dockerfile. Finally, you can create static Spaces using JavaScript and HTML.
+We have built-in support for an awesome SDK that let you build cool apps in Python in a matter of minutes: **[Gradio](https://gradio.app/)**, but you can also unlock the whole power of Docker and host an arbitrary Dockerfile. Finally, you can create static Spaces using JavaScript and HTML.
 
 You'll also be able to upgrade your Space to run [on a GPU or other accelerated hardware](./spaces-gpus). ⚡️
 
@@ -20,7 +20,6 @@ You'll also be able to upgrade your Space to run [on a GPU or other accelerated 
 - [Spaces GPU Upgrades](./spaces-gpus)
 - [Spaces Persistent Storage](./spaces-storage)
 - [Gradio Spaces](./spaces-sdks-gradio)
-- [Streamlit Spaces](./spaces-sdks-streamlit)
 - [Docker Spaces](./spaces-sdks-docker)
 - [Static HTML Spaces](./spaces-sdks-static)
 - [Custom Python Spaces](./spaces-sdks-python)


### PR DESCRIPTION
This PR updates the documentation to reflect that Streamlit has been moved under Docker section.