### PR TITLE
Updated the MLX-LM documentation link

### DIFF
--- a/docs/hub/mlx.md
+++ b/docs/hub/mlx.md
@@ -98,5 +98,5 @@ python -m mlx_lm.convert \
 * [MLX Repository](https://github.com/ml-explore/mlx)
 * [MLX Docs](https://ml-explore.github.io/mlx/)
 * [MLX Examples](https://github.com/ml-explore/mlx-examples/tree/main)
-* [MLX-LM](https://github.com/ml-explore/mlx-examples/tree/main/llms/mlx_lm)
+* [MLX-LM](https://github.com/ml-explore/mlx-lm/tree/main/mlx_lm/examples)
 * [All MLX models on Hub](https://huggingface.co/models?library=mlx&sort=trending)


### PR DESCRIPTION
The MLX-LM repository was moved to a new repo, the current link 404s. See the MOVE NOTICE here: https://github.com/ml-explore/mlx-examples/tree/main/llms/. 
This commit updates the link.