### PR TITLE
Docs: Add SCIM documentation for Enterprise Hub

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -348,6 +348,8 @@
       title: Single Sign-On (SSO)
     - local: enterprise-hub-advanced-sso
       title: Advanced Single Sign-On (SSO)
+    - local: enterprise-hub-scim
+      title: User Provisioning (SCIM)
     - local: audit-logs
       title: Audit Logs
     - local: storage-regions
@@ -392,6 +394,8 @@
         title: How to configure SAML with Azure in the Hub
       - local: security-sso-azure-oidc
         title: How to configure OIDC with Azure in the Hub
+      - local: security-sso-entra-id-scim
+        title: How to configure SCIM with Microsoft Entra ID (Azure AD)
     - local: security-resource-groups
       title: Advanced Access Control (Resource Groups)
     - local: security-malware

--- a/docs/hub/enterprise-hub-advanced-sso.md
+++ b/docs/hub/enterprise-hub-advanced-sso.md
@@ -24,6 +24,8 @@ Advanced SSO introduces automated user provisioning, which simplifies the onboar
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/sso/scim-flow-chart-dark.png"/>
 </div>
 
+Learn more about how to set up and manage SCIM in our [dedicated guide](./enterprise-hub-scim).
+
 ## Global SSO Enforcement 
 
 Beyond gating access to specific organizational content, Advanced SSO can be configured to make your IdP the mandatory authentication route for all your organization's members interacting with any part of the Hugging Face platform. Your organization's members will be required to authenticate via your IdP for all Hugging Face services, not just when accessing private or organizational repositories.

--- a/docs/hub/enterprise-hub-scim.md
+++ b/docs/hub/enterprise-hub-scim.md
@@ -1,0 +1,33 @@
+# User Provisioning (SCIM)
+
+<Tip warning={true}>
+This feature is part of the <a href="https://huggingface.co/contact/sales?from=enterprise" target="_blank">Enterprise Plus</a> plan.
+</Tip>
+
+SCIM, or System for Cross-domain Identity Management, is a standard for automating user provisioning. It allows you to connect your Identity Provider (IdP) to Hugging Face to automatically manage your organization's members.
+
+With SCIM, you can:
+- **Provision users**: Automatically create user accounts in your Hugging Face organization when they are assigned the application in your IdP.
+- **Update user attributes**: Changes made to user profiles in your IdP (like name or email) are automatically synced to Hugging Face.
+- **Provision groups**: Create groups in your Hugging Face organization based on groups in your IdP.
+- **Deprovision users**: Automatically deactivate user accounts in your Hugging Face organization when they are unassigned from the application or deactivated in your IdP.
+
+This ensures that your Hugging Face organization's member list is always in sync with your IdP, streamlining user lifecycle management and improving security.
+
+## How to enable SCIM
+
+To enable SCIM, go to your organization's settings, navigate to the **SSO** tab, and then select the **SCIM** sub-tab.
+
+You will find the **SCIM Tenant URL** and a button to generate an **access token**. You will need both of these to configure your IdP. The SCIM token is a secret and should be stored securely in your IdP's configuration.
+
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/sso/scim-settings.png"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/sso/scim-settings-dark.png"/>
+</div>
+
+Once SCIM is enabled in your IdP, users and groups provisioned will appear in the "Users Management" and "SCIM" tabs respectively.
+
+## Supported Identity Providers
+
+We support SCIM with any IdP that implements the SCIM 2.0 protocol. We have specific guides for some of the most popular providers:
+- [How to configure SCIM with Microsoft Entra ID](./security-sso-entra-id-scim)

--- a/docs/hub/enterprise-hub.md
+++ b/docs/hub/enterprise-hub.md
@@ -15,6 +15,7 @@ In this section we will document the following Enterprise Hub features:
 
 - [Single Sign-On (SSO)](./enterprise-sso)
 - [Advanced Single Sign-On (SSO)](./enterprise-hub-advanced-sso)
+- [User Provisioning (SCIM)](./enterprise-hub-scim)
 - [Audit Logs](./audit-logs)
 - [Storage Regions](./storage-regions)
 - [Dataset viewer for Private datasets](./enterprise-hub-datasets)

--- a/docs/hub/organizations.md
+++ b/docs/hub/organizations.md
@@ -12,6 +12,7 @@ If an organization needs to track user access to a dataset or a model due to lic
 - [Enterprise Hub features](./enterprise-hub)
   - [SSO](./enterprise-sso)
   - [Advanced SSO](./enterprise-hub-advanced-sso)
+  - [User Provisioning (SCIM)](./enterprise-hub-scim)
   - [Audit Logs](./audit-logs)
   - [Storage Regions](./storage-regions)
   - [Dataset viewer for Private datasets](./enterprise-hub-datasets)

--- a/docs/hub/security-sso-entra-id-scim.md
+++ b/docs/hub/security-sso-entra-id-scim.md
@@ -1,0 +1,111 @@
+# How to configure SCIM with Microsoft Entra ID (Azure AD)
+
+This guide explains how to set up automatic user and group provisioning between Microsoft Entra ID and your Hugging Face organization using SCIM.
+
+<Tip warning={true}>
+This feature is part of the <a href="https://huggingface.co/contact/sales?from=enterprise" target="_blank">Enterprise Plus</a> plan.
+</Tip>
+
+### Step 1: Get SCIM configuration from Hugging Face
+
+1.  Navigate to your organization's settings page on Hugging Face.
+2.  Go to the **SSO** tab, then click on the **SCIM** sub-tab.
+3.  Copy the **SCIM Tenant URL**. You will need this for the Entra ID configuration.
+4.  Click **Generate an access token**. A new SCIM token will be generated. Copy this token immediately and store it securely, as you will not be able to see it again.
+
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/sso/scim-settings.png"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/sso/scim-settings-dark.png"/>
+</div>
+
+### Step 2: Configure Provisioning in Microsoft Entra ID
+
+1.  In the Microsoft Entra admin center, navigate to your Hugging Face Enterprise Application.
+2.  In the left-hand menu, select **Provisioning**.
+3.  Click **Get started**.
+4.  Change the **Provisioning Mode** from "Manual" to **Automatic**.
+
+### Step 3: Enter Admin Credentials
+
+1.  In the **Admin Credentials** section, paste the **SCIM Tenant URL** from Hugging Face into the **Tenant URL** field.
+2.  Paste the **SCIM token** from Hugging Face into the **Secret Token** field.
+3.  Click **Test Connection**. You should see a success notification.
+4.  Click **Save**.
+
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/sso/scim-entra-creds.png" alt="Entra ID SCIM Admin Credentials"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/sso/scim-entra-creds-dark.png" alt="Entra ID SCIM Admin Credentials"/>
+</div>
+
+### Step 4: Configure Attribute Mappings
+
+1.  Under the **Mappings** section, click on **Provision Microsoft Entra ID Users**.
+2.  The default attribute mappings often require adjustments for robust provisioning. We recommend using the following configuration. You can delete attributes that are not listed here:
+
+    | `customappsso` Attribute | Microsoft Entra ID Attribute | Matching precedence |
+    |---|---|---|
+    | `userName` | `Replace([mailNickname], ".", "", "", "", "", "")` | |
+    | `active` | `Switch([IsSoftDeleted], , "False", "True", "True", "False")` | |
+    | `emails[type eq "work"].value` | `userPrincipalName` | |
+    | `name.givenName` | `givenName` | |
+    | `name.familyName` | `surname` | |
+    | `name.formatted` | `Join(" ", [givenName], [surname])` | |
+    | `externalId` | `objectId` | `1` |
+
+3.  After configuring the user mappings, go back to the Provisioning screen and click on **Provision Microsoft Entra ID Groups** to review group mappings. The default settings for groups are usually sufficient.
+
+### Step 5: Start Provisioning
+
+1.  On the main Provisioning screen, set the **Provisioning Status** to **On**.
+2.  Under **Settings**, you can configure the **Scope** to either "Sync only assigned users and groups" or "Sync all users and groups". We recommend starting with "Sync only assigned users and groups".
+3.  Save your changes.
+
+The initial synchronization can take up to 40 minutes to start. You can monitor the progress in the **Provisioning logs** tab.
+
+#### Assigning Users and Groups for Provisioning
+
+To control which users and groups are provisioned to your Hugging Face organization, you need to assign them to the Hugging Face Enterprise Application in Microsoft Entra ID. This is done in the **Users and groups** tab of your application.
+
+1.  Navigate to your Hugging Face Enterprise Application in the Microsoft Entra admin center.
+2.  Go to the **Users and groups** tab.
+3.  Click **Add user/group**.
+4.  Select the users and groups you want to provision and click **Assign**.
+
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/sso/scim-entra-users-groups.png" alt="Entra ID SCIM User and Group Assignment"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/sso/scim-entra-users-groups-dark.png" alt="Entra ID SCIM User and Group Assignment"/>
+</div>
+
+Only the users and groups you assign here will be provisioned to Hugging Face if you have set the **Scope** to "Sync only assigned users and groups".
+
+<Tip>
+<p><strong>Active Directory Plan Considerations</strong></p>
+<ul>
+<li>With <strong>Free, Office 365, and Premium P1/P2 plans</strong>, you can assign individual users to the application for provisioning.</li>
+<li>With <strong>Premium P1/P2 plans</strong>, you can also assign groups. This is the recommended approach for managing access at scale, as you can manage group membership in AD, and the changes will automatically be reflected in Hugging Face.</li>
+</ul>
+</Tip>
+
+### Step 6: Verify Provisioning in Hugging Face
+
+Once the synchronization is complete, navigate back to your Hugging Face organization settings:
+-   Provisioned users will appear in the **Users Management** tab.
+-   Provisioned groups will appear in the **SCIM** tab under **SCIM Groups**. These groups can then be assigned to [Resource Groups](./security-resource-groups) for fine-grained access control.
+
+### Step 7: Link SCIM Groups to Hugging Face Resource Groups
+
+Once your groups are provisioned from Entra ID, you can link them to Hugging Face Resource Groups to manage permissions at scale. This allows all members of a SCIM group to automatically receive specific roles (like read or write) for a collection of resources.
+
+1.  In your Hugging Face organization settings, navigate to the **SSO** -> **SCIM** tab, You will see a list of your provisioned groups under **SCIM Groups**.
+
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/sso/scim-provisioned-group.png" alt="Link SCIM group to a resource group"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/sso/scim-provisioned-group-dark.png" alt="Link SCIM group to a resource group"/>
+</div>
+
+3.  Locate the group you wish to configure and click **Link resource groups** in its row.
+4.  A dialog will appear. Click **Link a Resource Group**.
+5.  From the dropdown menus, select the **Resource Group** you want to link and the **Role Assignment** you want to grant to the members of the SCIM group.
+6.  Click **Link to SCIM group** and save the mapping.
+
+


### PR DESCRIPTION
This PR adds documentation for SCIM-based user provisioning with Microsoft Entra ID for Enterprise Hub customers. It includes a new setup guide, an overview of the SCIM feature, and updates to existing documentation to integrate the new content.