### PR TITLE
Update provider registration instructions for org plans

### DIFF
--- a/docs/inference-providers/register-as-a-provider.md
+++ b/docs/inference-providers/register-as-a-provider.md
@@ -204,7 +204,7 @@ for TogetherAI) with **Write** permissions to be able to access this endpoint.
 The endpoint validates that:
 - `hfModel` is indeed of `pipeline_tag == task` OR `task` is "conversational" and the model is
 compatible (i.e. the `pipeline_tag` is either "text-generation" or "image-text-to-text" AND the model is tagged as "conversational").
-- (in the future) we auto-test that the Partner's API successfully responds to a
+- we auto-test that the Partner's API successfully responds to a
 huggingface.js/inference call of the corresponding task i.e. the API specs are valid.
 
 ### Delete a mapping item

--- a/docs/inference-providers/register-as-a-provider.md
+++ b/docs/inference-providers/register-as-a-provider.md
@@ -129,7 +129,7 @@ First step is to use the Model Mapping API to register which HF models are suppo
 
 <Tip>
 
-To proceed with this step, we have to enable your account server-side. Make sure you have an organization on the Hub for your enterprise.
+To proceed with this step, we have to enable your account server-side. Make sure you have an organization on the Hub for your company, and upgrade it to a Team or Enterprise plan.
 
 </Tip>
 

--- a/docs/inference-providers/register-as-a-provider.md
+++ b/docs/inference-providers/register-as-a-provider.md
@@ -152,7 +152,7 @@ Create a new mapping item, with the following body (JSON-encoded):
 - `task`, also known as `pipeline_tag` in the HF ecosystem, is the type of model / type of API
 (examples: "text-to-image", "text-generation", but you should use "conversational" for chat models)
 - `hfModel` is the model id on the Hub's side.
-- `providerModel` is the model id on your side (can be the same or different).
+- `providerModel` is the model id on your side (can be the same or different. In general, we encourage you to use the HF model ids on your side as well, but this is up to you).
 
 The output of this route is a mapping ID that you can later use to update the mapping's status or delete it.
 
@@ -204,8 +204,7 @@ for TogetherAI) with **Write** permissions to be able to access this endpoint.
 The endpoint validates that:
 - `hfModel` is indeed of `pipeline_tag == task` OR `task` is "conversational" and the model is
 compatible (i.e. the `pipeline_tag` is either "text-generation" or "image-text-to-text" AND the model is tagged as "conversational").
-- we auto-test that the Partner's API successfully responds to a
-huggingface.js/inference call of the corresponding task i.e. the API specs are valid.
+- After the mapping creation (asynchronously) we automatically test whether the Partner API correctly handles huggingface.js/inference calls for the relevant task, ensuring the API specifications are valid. See the [Automatic validation](#automatic-validation) section below.
 
 ### Delete a mapping item
 

--- a/docs/inference-providers/register-as-a-provider.md
+++ b/docs/inference-providers/register-as-a-provider.md
@@ -156,6 +156,19 @@ Create a new mapping item, with the following body (JSON-encoded):
 
 The output of this route is a mapping ID that you can later use to update the mapping's status or delete it.
 
+#### Authentication
+
+You need to be in the _provider_ Hub organization (e.g. https://huggingface.co/togethercomputer
+for TogetherAI) with **Write** permissions to be able to access this endpoint.
+
+#### Validation
+
+The endpoint validates that:
+- `hfModel` is indeed of `pipeline_tag == task` OR `task` is "conversational" and the model is
+compatible (i.e. the `pipeline_tag` is either "text-generation" or "image-text-to-text" AND the model is tagged as "conversational").
+- After the mapping creation (asynchronously) we automatically test whether the Partner API correctly handles huggingface.js/inference calls for the relevant task, ensuring the API specifications are valid. See the [Automatic validation](#automatic-validation) section below.
+
+
 ### Using a tag-filter to map several HF models to a single inference endpoint
 
 We also support mapping HF models based on their `tags`. Using tag filters, you can automatically map multiple HF models to a single inference endpoint on your side.
@@ -193,18 +206,6 @@ Create a new mapping item, with the following body (JSON-encoded):
 - `adapterType` is a literal value that helps client libraries interpret how to call your API. The only supported value at the moment is `"lora"`.
 
 The output of this route is a mapping ID that you can later use to update the mapping's status or delete it.
-
-#### Authentication
-
-You need to be in the _provider_ Hub organization (e.g. https://huggingface.co/togethercomputer
-for TogetherAI) with **Write** permissions to be able to access this endpoint.
-
-#### Validation
-
-The endpoint validates that:
-- `hfModel` is indeed of `pipeline_tag == task` OR `task` is "conversational" and the model is
-compatible (i.e. the `pipeline_tag` is either "text-generation" or "image-text-to-text" AND the model is tagged as "conversational").
-- After the mapping creation (asynchronously) we automatically test whether the Partner API correctly handles huggingface.js/inference calls for the relevant task, ensuring the API specifications are valid. See the [Automatic validation](#automatic-validation) section below.
 
 ### Delete a mapping item
 


### PR DESCRIPTION
Clarifies that organizations must be upgraded to a Team or Enterprise plan to proceed with provider registration.