### PR TITLE
Fix warning format

### DIFF
--- a/docs/hub/spaces-config-reference.md
+++ b/docs/hub/spaces-config-reference.md
@@ -137,5 +137,7 @@ preload_from_hub:
 In this example, the Space will preload specific .safetensors files from `warp-ai/wuerstchen-prior`, the complete `coqui/XTTS-v1` repository, and a specific revision of the `config.json` file in the `openai-community/gpt2` repository from the Hugging Face Hub during build time.
 
 <Tip warning={true}>
-  Files are saved in the default `huggingface_hub` disk cache `~/.cache/huggingface/hub`. If you application expects them elsewhere or you changed your `HF_HOME` variable, this pre-loading does not follow that at this time.
+
+Files are saved in the default `huggingface_hub` disk cache `~/.cache/huggingface/hub`. If you application expects them elsewhere or you changed your `HF_HOME` variable, this pre-loading does not follow that at this time.
+
 </Tip>


### PR DESCRIPTION
<img width="826" height="152" alt="Screenshot 2025-08-29 at 5 40 06 PM" src="https://github.com/user-attachments/assets/725f28ae-6ba0-4f62-9988-c44922293cc0" />


currently code block doesn't render