### PR TITLE
[many small tweaks] Update docs for Team & Enterprise plans terminology

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -25,10 +25,10 @@
         title: "How-to: Create automatic metadata quality reports"
   - local: notebooks
     title: Notebooks
-  - local: storage-backends
-    title: Storage Backends
   - local: storage-limits
     title: Storage Limits
+  - local: storage-backends
+    title: Storage Backends
   - local: repositories-next-steps
     title: Next Steps
   - local: repositories-licenses
@@ -346,7 +346,7 @@
     - local: organizations-security
       title: Access Control in Organizations
   - local: enterprise-hub
-    title: Enterprise Hub
+    title: Team & Enterprise plans
     sections:
     - local: enterprise-sso
       title: Single Sign-On (SSO)
@@ -369,7 +369,7 @@
     - local: enterprise-hub-tokens-management
       title: Tokens Management
     - local: enterprise-hub-analytics
-      title: Analytics
+      title: Publisher Analytics
     - local: enterprise-hub-network-security
       title: Network Security
     - local: enterprise-hub-gating-group-collections

--- a/docs/hub/enterprise-hub-analytics.md
+++ b/docs/hub/enterprise-hub-analytics.md
@@ -4,9 +4,9 @@
 This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 </Tip>
 
-## Analytics Dashboard
+## Publisher Analytics Dashboard
 
-Track all your repository activity with a detailed downloads overview that shows total downloads for all your Models and Datasets. Toggle between "All Time" and "Last Month" views to gain insights into your repository's downloads over different periods.
+Track all your repository activity with a detailed downloads overview that shows total downloads for all the Models and Datasets published by your organization. Toggle between "All Time" and "Last Month" views to gain insights into your repository's downloads over different periods.
 
 <div class="flex justify-center" style="max-width: 550px">
 <img class="block dark:hidden m-0!" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise-analytics.png" alt="screenshot of the Dataset Viewer on a private dataset owned by an Enterprise Hub organization."/>
@@ -17,7 +17,7 @@ Track all your repository activity with a detailed downloads overview that shows
 
 Explore the metrics of individual repositories with the per-repository drill-down table. Utilize the built-in search feature to quickly locate specific repositories. Each row also features a time-series graph that illustrates the trend of downloads over time.
 
-## Export Analytics as CSV
+## Export Publisher Analytics as CSV
 
 Download a comprehensive CSV file containing analytics for all your repositories, including model and dataset download activity.
 

--- a/docs/hub/enterprise-hub.md
+++ b/docs/hub/enterprise-hub.md
@@ -1,10 +1,10 @@
-# Enterprise Hub
+# Team & Enterprise plans
 
 <Tip>
 <a href="https://huggingface.co/enterprise" target="_blank">Subscribe to a Team or Enterprise plan</a> to get access to advanced features for your organization.
 </Tip>
 
-Enterprise Hub adds advanced capabilities to organizations, enabling safe, compliant and managed collaboration for companies and teams on Hugging Face.
+Team & Enterprise organization plans add advanced capabilities to organizations, enabling safe, compliant and managed collaboration for companies and teams on Hugging Face.
 
 <a href="https://huggingface.co/enterprise" class="flex justify-center">
     <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/enterprise-header.png" />

--- a/docs/hub/index.md
+++ b/docs/hub/index.md
@@ -70,7 +70,7 @@ The Hugging Face Hub is a platform with over 1.7M models, 400k datasets, and 600
 <div class="flex items-center py-0.5 text-lg font-semibold text-green-600 dark:text-gray-400 mb-1">
 <svg class="shrink-0 mr-1.5 text-green-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" viewBox="0 0 24 24"><path fill="currentColor" stroke="currentColor" d="M8.892 21.854a6.25 6.25 0 0 1-4.42-10.67l7.955-7.955a4.5 4.5 0 0 1 6.364 6.364l-6.895 6.894a2.816 2.816 0 0 1-3.89 0a2.75 2.75 0 0 1 .002-3.888l5.126-5.127a1 1 0 1 1 1.414 1.414l-5.126 5.127a.75.75 0 0 0 0 1.06a.768.768 0 0 0 1.06 0l6.895-6.894a2.503 2.503 0 0 0 0-3.535a2.56 2.56 0 0 0-3.536 0l-7.955 7.955a4.25 4.25 0 1 0 6.01 6.01l6.188-6.187a1 1 0 1 1 1.414 1.414l-6.187 6.186a6.206 6.206 0 0 1-4.42 1.832z"></path></svg> Other</div>
 <a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./organizations">Organizations</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./enterprise-hub">Enterprise Hub</a>
+<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./enterprise-hub">Team & Enterprise plans</a>
 <a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./billing">Billing</a>
 <a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./security">Security</a>
 <a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./moderation">Moderation</a>
@@ -123,7 +123,7 @@ The [🤗 `datasets`](https://huggingface.co/docs/datasets/index) library allows
 
 [Spaces](https://huggingface.co/spaces) is a simple way to host ML demo apps on the Hub. They allow you to build your ML portfolio, showcase your projects at conferences or to stakeholders, and work collaboratively with other people in the ML ecosystem.
 
-We currently support two awesome Python SDKs (**[Gradio](https://gradio.app/)** and **[Streamlit](https://streamlit.io/)**) that let you build cool apps in a matter of minutes. Users can also create static Spaces which are simple HTML/CSS/JavaScript page within a Space.
+We currently support two awesome Python SDKs (**[Gradio](https://gradio.app/)** and **[Streamlit](https://streamlit.io/)**) that let you build cool apps in a matter of minutes. Users can also create static Spaces which are simple HTML/CSS/JavaScript page within a Space, or deploy any Docker-based application.
 
 After you've explored a few Spaces (take a look at our [Space of the Week!](https://huggingface.co/spaces)), dive into the [**Spaces documentation**](./spaces-overview) to learn all about how you can create your own Space. You'll also be able to upgrade your Space to run on a GPU or other accelerated hardware. ⚡️
 

--- a/docs/hub/notebooks.md
+++ b/docs/hub/notebooks.md
@@ -22,7 +22,7 @@ If a model repository includes a file called `notebook.ipynb`, we will use it fo
 
 ![](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/blog/hf-google-colab/genstruct-notebook-dark.png)
 
-## Rendering Jupyter notebooks on the Hub
+## Rendering .ipynb Jupyter notebooks on the Hub
 
 Under the hood, Jupyter Notebook files (usually shared with a `.ipynb` extension) are JSON files. While viewing these files directly is possible, it's not a format intended to be read by humans. The Hub has rendering support for notebooks hosted on the Hub. This means that notebooks are displayed in a human-readable format.
 
@@ -30,6 +30,8 @@ Under the hood, Jupyter Notebook files (usually shared with a `.ipynb` extension
 
 Notebooks will be rendered when included in any type of repository on the Hub. This includes models, datasets, and Spaces.
 
-## Launch in Google Colab
+### Launch in Google Colab
 
-[Google Colab](https://colab.google/) is a free Jupyter Notebook environment that requires no setup and runs entirely in the cloud. It's a great way to run Jupyter Notebooks without having to install anything on your local machine. Notebooks hosted on the Hub are automatically given a "Open in Colab" button. This allows you to open the notebook in Colab with a single click.
+[Google Colab](https://colab.google/) is a free Jupyter Notebook environment that requires no setup and runs entirely in the cloud. It's a great way to run Jupyter Notebooks without having to install anything on your local machine. 
+
+All .ipynb files hosted on the Hub are automatically given a "Open in Colab" button. This allows you to open the notebook in Colab with a single click.

--- a/docs/hub/storage-limits.md
+++ b/docs/hub/storage-limits.md
@@ -1,14 +1,14 @@
 # Storage limits
 
-At Hugging Face our intent is to provide the AI community with **free storage space for public repositories**. We do bill for storage space for **private repositories**, above a free tier (see table below).
+At Hugging Face our intent is to provide the AI community with as much **free storage space for public repositories** as we can. We do bill for storage space for **private repositories**, above a free tier (see table below).
 
 <Tip>
 Storage limits and policies apply to both model and dataset repositories on the Hub.
 </Tip>
 
-We [optimize our infrastructure](https://huggingface.co/blog/xethub-joins-hf) continuously to [scale our storage](https://x.com/julien_c/status/1821540661973160339) for the coming years of growth in Machine learning.
+We [optimize our infrastructure](https://huggingface.co/blog/xethub-joins-hf) continuously to [scale our storage](https://x.com/julien_c/status/1821540661973160339) for the coming years of growth in AI and Machine learning.
 
-We do have mitigations in place to prevent abuse of free public storage, and in general we ask users and organizations to make sure any uploaded large model or dataset is **as useful to the community as possible** (as represented by numbers of likes or downloads, for instance).
+We do have mitigations in place to prevent abuse of free public storage, and in general we ask users and organizations to make sure any uploaded large model or dataset is **as useful to the community as possible** (as represented by numbers of likes or downloads, for instance). Finally, upgrade to a paid Organization or User (PRO) account to unlock higher limits.
 
 ## Storage plans
 
@@ -20,7 +20,7 @@ We do have mitigations in place to prevent abuse of free public storage, and in 
 
 💡 [Team or Enterprise Organizations](https://huggingface.co/enterprise) include 1TB of private storage per seat in the subscription: for example, if your organization has 40 members, then you have 40TB of included private storage.
 
-\*We aim to continue providing the AI community with free storage space for public repositories. Please use this resource responsibly by uploading content that offers genuine value to other users - not dozens of TBs with limited community interest. If you need substantial storage space, you should upgrade to [PRO, Team or Enterprise](https://huggingface.co/pricing).
+\*We aim to continue providing the AI community with free storage space for public repositories. Please use this resource responsibly by uploading content that offers genuine value to other users - not dozens of TBs with limited community interest. If you need substantial storage space, you need to upgrade to [PRO, Team or Enterprise](https://huggingface.co/pricing).
 
 
 ### Pay-as-you-go price


### PR DESCRIPTION
- Renamed 'Enterprise Hub' references to 'Team & Enterprise plans' across documentation files for consistency.
- revised storage limits language to reflect current offerings and encourage responsible usage.
- Updated analytics section to 'Publisher Analytics',
- clarified notebook rendering and Colab launch details