### PR TITLE
Update rate limits documentation with warning tip

### DIFF
--- a/docs/hub/rate-limits.md
+++ b/docs/hub/rate-limits.md
@@ -70,10 +70,10 @@ Here are the current rate limits (in September '25) based on your plan:
 | Enterprise Plus organization <br> When Organization IP Ranges are defined | 100,000  | 500,000   | 10,000 |
 | Academia Hub organization                                                 | 2,500    | 12,000    | 400    |
 
+\* Anonymous and Free users are subject to change over time depending on platform health 🤞
+
 > [!NOTE]
 > All quotas are calculated over 5-minute fixed windows.
-
-\* Anonymous and Free users are subject to change over time depending on platform health 🤞
 
 Note: For organizations, rate limits are applied individually to each member, not shared among members.
 


### PR DESCRIPTION
Added a warning tip about rate limit quotas being calculated over a 5-minute rolling window.