### PR TITLE
Add MCP connection guides for Claude, ChatGPT, and Codex

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -442,6 +442,12 @@
     title: Agents on Hub
   - local: hf-mcp-server
     title: Hugging Face MCP Server
+  - local: hf-mcp-claude
+    title: Connect MCP to Claude
+  - local: hf-mcp-chatgpt
+    title: Connect MCP to ChatGPT
+  - local: hf-mcp-codex-cli
+    title: Connect MCP to Codex CLI
   - local: moderation
     title: Moderation
   - local: paper-pages

--- a/docs/hub/hf-mcp-chatgpt.md
+++ b/docs/hub/hf-mcp-chatgpt.md
@@ -1,0 +1,13 @@
+# Connect the Hugging Face MCP Server to ChatGPT
+
+Use ChatGPT's connector gallery to link the Hugging Face MCP Server.
+
+## Steps
+
+1. Open the ChatGPT web or desktop app, click your name → **Settings**, then open **Connectors**.
+2. Choose **Browse connectors**, search for **Hugging Face**, and click **Add**.
+3. Approve the sign-in window at `https://huggingface.co/mcp?login` to authorize access to your Hugging Face account.
+4. Back in ChatGPT, verify that **Hugging Face** is listed under **Available connectors**, then enable it in a chat to call Hub tools.
+
+> [!TIP]
+> You can manage which Hugging Face MCP tools are exposed by visiting [your MCP settings](https://huggingface.co/settings/mcp); ChatGPT will pick up new tools automatically.

--- a/docs/hub/hf-mcp-claude.md
+++ b/docs/hub/hf-mcp-claude.md
@@ -1,0 +1,13 @@
+# Connect the Hugging Face MCP Server to Claude Desktop
+
+Use the Claude connectors flow to authorize the Hugging Face MCP Server.
+
+## Steps
+
+1. Open the [Claude connectors settings](https://claude.ai/settings/connectors) in Claude Desktop or Claude.ai and sign in if needed.
+2. Select **Browse connectors**, pick **Hugging Face**, and confirm.
+3. When the browser opens `https://huggingface.co/mcp?login`, follow the prompts to sign in and approve access.
+4. Return to Claude and make sure **Hugging Face** appears under **Connected connectors** before using it in a chat.
+
+> [!TIP]
+> Once connected you can add more Hugging Face MCP tools from [your MCP settings](https://huggingface.co/settings/mcp) and they will appear automatically in Claude.

--- a/docs/hub/hf-mcp-codex-cli.md
+++ b/docs/hub/hf-mcp-codex-cli.md
@@ -1,0 +1,20 @@
+# Connect the Hugging Face MCP Server to Codex CLI
+
+Configure the Codex CLI to launch the Hugging Face MCP Server via `mcp-remote`.
+
+## Steps
+
+1. Follow the [Codex CLI setup guide](https://github.com/openai/codex) to install the tool and create your `~/.codex/config.toml`.
+2. Add the Hugging Face MCP server block to the config:
+
+   ```toml
+   [mcp_servers.huggingface]
+   command = "npx"
+   args = ["-y", "mcp-remote@latest", "https://huggingface.co/mcp?login"]
+   ```
+
+3. Save the file and restart the Codex CLI (or run `codex mcp list`) to confirm that the **huggingface** server is available.
+4. Invoke Hugging Face tools from Codex by asking it to use the `huggingface` MCP server in your next command or chat.
+
+> [!NOTE]
+> The `mcp-remote` helper opens a browser window the first time to complete the Hugging Face sign-in and authorization flow.


### PR DESCRIPTION
## Summary
- add short guides for connecting the Hugging Face MCP server to Claude Desktop, ChatGPT, and Codex CLI
- link the new pages from the hub documentation table of contents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e92c6b42c08331894eb3f8ddffe8c5