### PR TITLE
docs(hub-api): Add organization overview and followers endpoints to API documentation

### DIFF
--- a/docs/hub/api.md
+++ b/docs/hub/api.md
@@ -273,7 +273,7 @@ This is equivalent to `huggingface_hub.whoami()`.
 
 ## Organization API
 
-The following endpoint gets a list of the Organization members.
+The following endpoints handle organization like getting overview of an organization, listing members and followers.
 
 ### GET /api/organizations/{organization_name}/overview
 


### PR DESCRIPTION
Hello,

Add two organization endpoints to the API docs.
`GET /api/organizations/{organization_name}/overview` (equivalent to `huggingface_hub.get_organization_overview()`) returns the org overview, 

and 

`GET /api/organizations/{organization_name}/followers` returns the org followers list.

I did not include the new “list_organization_followers” method that I developed because it is not yet available.   (https://github.com/huggingface/huggingface_hub/pull/3467)

EDIT : added list_organization_followers 