### PR TITLE
Update git-xet brew installation instruction

### DIFF
--- a/docs/hub/xet/using-xet-storage.md
+++ b/docs/hub/xet/using-xet-storage.md
@@ -44,6 +44,7 @@ Install [Git](https://git-scm.com/) and [Git LFS](https://git-lfs.com/).
    ```
    brew tap huggingface/tap
    brew install git-xet
+   git-xet install
    ```
 
   To verify the installation, run:


### PR DESCRIPTION
Users need to run `git-xet install` after `brew install git-xet`. This instruction is printed out at the end of the `brew install git-xet` step but people may not pay attention to that.