### PR TITLE
Fix unclosed HTML link tag in security-sso.md

### DIFF
--- a/docs/hub/security-sso.md
+++ b/docs/hub/security-sso.md
@@ -5,7 +5,7 @@ The Hugging Face Hub gives you the ability to implement mandatory Single Sign-On
 We support both SAML 2.0 and OpenID Connect (OIDC) protocols.
 
 > [!WARNING]
-> This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans. For enhanced capabilities like automated user provisioning (JIT/SCIM) and global SSO enforcement, see our <a href="./enterprise-hub-advanced-sso">Advanced SSO documentation
+> This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans. For enhanced capabilities like automated user provisioning (JIT/SCIM) and global SSO enforcement, see our <a href="./enterprise-hub-advanced-sso">Advanced SSO documentation</a>
 
 ## How does it work?
 


### PR DESCRIPTION
## Fix unclosed HTML link tag in security-sso.md

Fixed an unclosed `<a>` tag in a WARNING admonition that was breaking markdown link rendering on the page.

**Changes:**
- Added missing `</a>` closing tag in `security-sso.md` line 8
- The unclosed HTML link within the blockquote was causing subsequent markdown links to not render properly

**File affected:**
- hub-docs/docs/hub/security-sso.md`

<img width="730" height="324" alt="image" src="https://github.com/user-attachments/assets/82bed7be-baa9-4c8e-8b76-5eb3a4f7eb20" />
