### PR TITLE
fix: broken chat completion url

### DIFF
--- a/scripts/inference-providers/templates/task/text-generation.handlebars
+++ b/scripts/inference-providers/templates/task/text-generation.handlebars
@@ -2,7 +2,7 @@
 
 Generate text based on a prompt.
 
-If you are interested in a Chat Completion task, which generates a response based on a list of messages, check out the [`chat-completion`](./chat_completion) task.
+If you are interested in a Chat Completion task, which generates a response based on a list of messages, check out the [`chat-completion`](./chat-completion) task.
 
 {{{tips.linksToTaskPage.text-generation}}}
 


### PR DESCRIPTION
Fix broken cross-page link from [text-generation](https://huggingface.co/docs/inference-providers/en/tasks/text-generation) to chat-completion.