### PR TITLE
Update git-xet instructions

### DIFF
--- a/docs/hub/xet/using-xet-storage.md
+++ b/docs/hub/xet/using-xet-storage.md
@@ -50,23 +50,23 @@ git xet install
 
 To verify the installation, run:
 ```
-git-xet --version
+git xet --version
 ```
 
 ### Windows (amd64)
 
 Using an installer: 
- - Download `git-xet-windows-installer-x86_64.zip` ([available here](https://github.com/huggingface/xet-core/releases/download/git-xet-v0.1.0/git-xet-windows-installer-x86_64.zip)) and unzip. 
+ - Download `git-xet-windows-installer-x86_64.zip` ([available here](https://github.com/huggingface/xet-core/releases/download/git-xet-v0.2.0/git-xet-windows-installer-x86_64.zip)) and unzip. 
  - Run the `msi` installer file and follow the prompts.
 
 Manual installation:
- - Download `git-xet-windows-x86_64.zip` ([available here](https://github.com/huggingface/xet-core/releases/download/git-xet-v0.1.0/git-xet-windows-x86_64.zip)) and unzip. 
+ - Download `git-xet-windows-x86_64.zip` ([available here](https://github.com/huggingface/xet-core/releases/download/git-xet-v0.2.0/git-xet-windows-x86_64.zip)) and unzip. 
  - Place the extracted `git-xet.exe` under a `PATH` directory.
  - Run `git xet install` in a terminal.
 
 To verify the installation, run:
   ```
-  git-xet --version
+  git xet --version
   ```
 
 ### Using Git Xet
@@ -87,12 +87,12 @@ Under the hood, the [Xet protocol](https://huggingface.co/docs/xet/index) is inv
 
 Using Homebrew:
 ```bash
-git-xet uninstall
+git xet uninstall
 brew uninstall git-xet
 ```
 If you used the installation script (for MacOS or Linux), run the following in your terminal:
 ```bash
-git-xet uninstall
+git xet uninstall
 sudo rm $(which git-xet)
 ```
 ### Uninstall on Windows
@@ -103,7 +103,7 @@ If you used the installer:
 - Select the "Uninstall" option available in the context menu.
 
 If you manually installed:
-- Run `git-xet uninstall` in a terminal. 
+- Run `git xet uninstall` in a terminal. 
 - Delete the `git-xet.exe` file from the location where it was originally placed.
 
 ## Recommendations


### PR DESCRIPTION
- Unify the command format, it seems we prefer "git xet [command]" over "git-xet [command]"
- Update git-xet Windows binary and installer links to the new [release](https://github.com/huggingface/xet-core/releases/tag/git-xet-v0.2.0)