### PR TITLE
[Inference Providers] Fix task links 

### DIFF
--- a/docs/inference-providers/providers/fal-ai.md
+++ b/docs/inference-providers/providers/fal-ai.md
@@ -43,7 +43,7 @@ Founded in 2021 by [Burkay Gur](https://huggingface.co/burkaygur) and [Gorkem Yu
 
 ### Automatic Speech Recognition
 
-Find out more about Automatic Speech Recognition [here](../tasks/automatic_speech_recognition).
+Find out more about Automatic Speech Recognition [here](../tasks/automatic-speech-recognition).
 
 <InferenceSnippet
     pipeline=automatic-speech-recognition
@@ -53,7 +53,7 @@ Find out more about Automatic Speech Recognition [here](../tasks/automatic_speec
 
 ### Image Segmentation
 
-Find out more about Image Segmentation [here](../tasks/image_segmentation).
+Find out more about Image Segmentation [here](../tasks/image-segmentation).
 
 <InferenceSnippet
     pipeline=image-segmentation
@@ -63,7 +63,7 @@ Find out more about Image Segmentation [here](../tasks/image_segmentation).
 
 ### Image To Image
 
-Find out more about Image To Image [here](../tasks/image_to_image).
+Find out more about Image To Image [here](../tasks/image-to-image).
 
 <InferenceSnippet
     pipeline=image-to-image

--- a/docs/inference-providers/providers/featherless-ai.md
+++ b/docs/inference-providers/providers/featherless-ai.md
@@ -65,7 +65,7 @@ conversational />
 
 ### Text Generation
 
-Find out more about Text Generation [here](../tasks/text_generation).
+Find out more about Text Generation [here](../tasks/text-generation).
 
 <InferenceSnippet
     pipeline=text-generation

--- a/docs/inference-providers/providers/hf-inference.md
+++ b/docs/inference-providers/providers/hf-inference.md
@@ -46,7 +46,7 @@ As of July 2025, hf-inference focuses mostly on CPU inference (e.g. embedding, t
 
 ### Automatic Speech Recognition
 
-Find out more about Automatic Speech Recognition [here](../tasks/automatic_speech_recognition).
+Find out more about Automatic Speech Recognition [here](../tasks/automatic-speech-recognition).
 
 <InferenceSnippet
     pipeline=automatic-speech-recognition
@@ -66,7 +66,7 @@ conversational />
 
 ### Feature Extraction
 
-Find out more about Feature Extraction [here](../tasks/feature_extraction).
+Find out more about Feature Extraction [here](../tasks/feature-extraction).
 
 <InferenceSnippet
     pipeline=feature-extraction
@@ -76,7 +76,7 @@ Find out more about Feature Extraction [here](../tasks/feature_extraction).
 
 ### Fill Mask
 
-Find out more about Fill Mask [here](../tasks/fill_mask).
+Find out more about Fill Mask [here](../tasks/fill-mask).
 
 <InferenceSnippet
     pipeline=fill-mask
@@ -86,7 +86,7 @@ Find out more about Fill Mask [here](../tasks/fill_mask).
 
 ### Image Classification
 
-Find out more about Image Classification [here](../tasks/image_classification).
+Find out more about Image Classification [here](../tasks/image-classification).
 
 <InferenceSnippet
     pipeline=image-classification
@@ -96,7 +96,7 @@ Find out more about Image Classification [here](../tasks/image_classification).
 
 ### Image Segmentation
 
-Find out more about Image Segmentation [here](../tasks/image_segmentation).
+Find out more about Image Segmentation [here](../tasks/image-segmentation).
 
 <InferenceSnippet
     pipeline=image-segmentation
@@ -106,7 +106,7 @@ Find out more about Image Segmentation [here](../tasks/image_segmentation).
 
 ### Object Detection
 
-Find out more about Object Detection [here](../tasks/object_detection).
+Find out more about Object Detection [here](../tasks/object-detection).
 
 <InferenceSnippet
     pipeline=object-detection
@@ -116,7 +116,7 @@ Find out more about Object Detection [here](../tasks/object_detection).
 
 ### Question Answering
 
-Find out more about Question Answering [here](../tasks/question_answering).
+Find out more about Question Answering [here](../tasks/question-answering).
 
 <InferenceSnippet
     pipeline=question-answering
@@ -136,7 +136,7 @@ Find out more about Summarization [here](../tasks/summarization).
 
 ### Table Question Answering
 
-Find out more about Table Question Answering [here](../tasks/table_question_answering).
+Find out more about Table Question Answering [here](../tasks/table-question-answering).
 
 <InferenceSnippet
     pipeline=table-question-answering
@@ -146,7 +146,7 @@ Find out more about Table Question Answering [here](../tasks/table_question_answ
 
 ### Text Classification
 
-Find out more about Text Classification [here](../tasks/text_classification).
+Find out more about Text Classification [here](../tasks/text-classification).
 
 <InferenceSnippet
     pipeline=text-classification
@@ -156,7 +156,7 @@ Find out more about Text Classification [here](../tasks/text_classification).
 
 ### Text Generation
 
-Find out more about Text Generation [here](../tasks/text_generation).
+Find out more about Text Generation [here](../tasks/text-generation).
 
 <InferenceSnippet
     pipeline=text-generation
@@ -176,7 +176,7 @@ Find out more about Text To Image [here](../tasks/text-to-image).
 
 ### Token Classification
 
-Find out more about Token Classification [here](../tasks/token_classification).
+Find out more about Token Classification [here](../tasks/token-classification).
 
 <InferenceSnippet
     pipeline=token-classification
@@ -196,7 +196,7 @@ Find out more about Translation [here](../tasks/translation).
 
 ### Zero Shot Classification
 
-Find out more about Zero Shot Classification [here](../tasks/zero_shot_classification).
+Find out more about Zero Shot Classification [here](../tasks/zero-shot-classification).
 
 <InferenceSnippet
     pipeline=zero-shot-classification

--- a/docs/inference-providers/providers/nebius.md
+++ b/docs/inference-providers/providers/nebius.md
@@ -47,7 +47,7 @@ Find out more about Chat Completion (LLM) [here](../tasks/chat-completion).
 
 <InferenceSnippet
     pipeline=text-generation
-    providersMapping={ {"nebius":{"modelId":"meta-llama/Llama-3.1-8B-Instruct","providerModelId":"meta-llama/Meta-Llama-3.1-8B-Instruct-fast"} } }
+    providersMapping={ {"nebius":{"modelId":"moonshotai/Kimi-K2-Thinking","providerModelId":"moonshotai/Kimi-K2-Thinking"} } }
 conversational />
 
 
@@ -63,7 +63,7 @@ conversational />
 
 ### Feature Extraction
 
-Find out more about Feature Extraction [here](../tasks/feature_extraction).
+Find out more about Feature Extraction [here](../tasks/feature-extraction).
 
 <InferenceSnippet
     pipeline=feature-extraction

--- a/docs/inference-providers/providers/replicate.md
+++ b/docs/inference-providers/providers/replicate.md
@@ -43,7 +43,7 @@ Replicate is building tools so all software engineers can use AI as if it were n
 
 ### Automatic Speech Recognition
 
-Find out more about Automatic Speech Recognition [here](../tasks/automatic_speech_recognition).
+Find out more about Automatic Speech Recognition [here](../tasks/automatic-speech-recognition).
 
 <InferenceSnippet
     pipeline=automatic-speech-recognition
@@ -53,7 +53,7 @@ Find out more about Automatic Speech Recognition [here](../tasks/automatic_speec
 
 ### Image To Image
 
-Find out more about Image To Image [here](../tasks/image_to_image).
+Find out more about Image To Image [here](../tasks/image-to-image).
 
 <InferenceSnippet
     pipeline=image-to-image

--- a/docs/inference-providers/providers/sambanova.md
+++ b/docs/inference-providers/providers/sambanova.md
@@ -54,7 +54,7 @@ conversational />
 
 ### Feature Extraction
 
-Find out more about Feature Extraction [here](../tasks/feature_extraction).
+Find out more about Feature Extraction [here](../tasks/feature-extraction).
 
 <InferenceSnippet
     pipeline=feature-extraction

--- a/docs/inference-providers/providers/scaleway.md
+++ b/docs/inference-providers/providers/scaleway.md
@@ -63,7 +63,7 @@ conversational />
 
 ### Feature Extraction
 
-Find out more about Feature Extraction [here](../tasks/feature_extraction).
+Find out more about Feature Extraction [here](../tasks/feature-extraction).
 
 <InferenceSnippet
     pipeline=feature-extraction

--- a/docs/inference-providers/providers/wavespeed.md
+++ b/docs/inference-providers/providers/wavespeed.md
@@ -43,7 +43,7 @@ For more details, check out the `generate.ts` script: https://github.com/hugging
 
 ### Image To Image
 
-Find out more about Image To Image [here](../tasks/image_to_image).
+Find out more about Image To Image [here](../tasks/image-to-image).
 
 <InferenceSnippet
     pipeline=image-to-image

--- a/scripts/inference-providers/scripts/generate.ts
+++ b/scripts/inference-providers/scripts/generate.ts
@@ -718,9 +718,7 @@ Object.entries(DATA.perProviderWarmModels).forEach(([task, models]) => {
           .map((word) => word[0].toUpperCase() + word.slice(1))
           .join(" ");
 
-    let linkAnchor = conversational
-      ? "chat-completion"
-      : task.replaceAll("-", "_");
+    let linkAnchor = conversational ? "chat-completion" : task;
 
     let pipelineTag = task === "chat-completion" ? "text-generation" : task;
 


### PR DESCRIPTION
Follow-up to #2093. 
This PR fixes the task links in the inference providers docs. Note that almost all inference providers docs are auto-generated. Fixes should be made to the script or templates in `scripts/inference-providers/`, not to the generated markdown files directly.