### PR TITLE
[SageMaker] Add warning about SageMaker SDK v3 breaking changes

### DIFF
--- a/docs/sagemaker/notebooks/sagemaker-sdk/deploy-embedding-models/sagemaker-notebook.ipynb
+++ b/docs/sagemaker/notebooks/sagemaker-sdk/deploy-embedding-models/sagemaker-notebook.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "source": [
     "> [!WARNING]\n",
-    "> As per the time of writing, a new version of the sagemaker python SDK has been released [(v3)](https://github.com/aws/sagemaker-python-sdk/tree/master) with major and breaking changes. Unless otherwise specified, all the documentation and tutorials are using the previous version of the SDK [(v2)](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the content to reflect the new changes in the SDK. For now, please make sure to use the previous version of the SDK by running `pip install 'sagemaker<3.0.0'`."
+    "> [SageMaker Python SDK v3 has been recently released](https://github.com/aws/sagemaker-python-sdk), so unless specified otherwise, all the documentation and tutorials are still using the [SageMaker Python SDK v2](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the tutorials and examples, but in the meantime make sure to install the SageMaker SDK as `pip install \"sagemaker<3.0.0\"`."
    ]
   },
   {

--- a/docs/sagemaker/notebooks/sagemaker-sdk/deploy-llama-3-3-70b-inferentia2/sagemaker-notebook.ipynb
+++ b/docs/sagemaker/notebooks/sagemaker-sdk/deploy-llama-3-3-70b-inferentia2/sagemaker-notebook.ipynb
@@ -54,7 +54,7 @@
    "metadata": {},
    "source": [
     "> [!WARNING]\n",
-    "> As per the time of writing, a new version of the sagemaker python SDK has been released [(v3)](https://github.com/aws/sagemaker-python-sdk/tree/master) with major and breaking changes. Unless otherwise specified, all the documentation and tutorials are using the previous version of the SDK [(v2)](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the content to reflect the new changes in the SDK. For now, please make sure to use the previous version of the SDK by running `pip install 'sagemaker<3.0.0'`."
+    "> [SageMaker Python SDK v3 has been recently released](https://github.com/aws/sagemaker-python-sdk), so unless specified otherwise, all the documentation and tutorials are still using the [SageMaker Python SDK v2](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the tutorials and examples, but in the meantime make sure to install the SageMaker SDK as `pip install \"sagemaker<3.0.0\"`."
    ]
   },
   {

--- a/docs/sagemaker/notebooks/sagemaker-sdk/evaluate-llm-lighteval/sagemaker-notebook.ipynb
+++ b/docs/sagemaker/notebooks/sagemaker-sdk/evaluate-llm-lighteval/sagemaker-notebook.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "source": [
     "> [!WARNING]\n",
-    "> As per the time of writing, a new version of the sagemaker python SDK has been released [(v3)](https://github.com/aws/sagemaker-python-sdk/tree/master) with major and breaking changes. Unless otherwise specified, all the documentation and tutorials are using the previous version of the SDK [(v2)](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the content to reflect the new changes in the SDK. For now, please make sure to use the previous version of the SDK by running `pip install 'sagemaker<3.0.0'`."
+    "> [SageMaker Python SDK v3 has been recently released](https://github.com/aws/sagemaker-python-sdk), so unless specified otherwise, all the documentation and tutorials are still using the [SageMaker Python SDK v2](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the tutorials and examples, but in the meantime make sure to install the SageMaker SDK as `pip install \"sagemaker<3.0.0\"`."
    ]
   },
   {

--- a/docs/sagemaker/notebooks/sagemaker-sdk/fine-tune-embedding-models/sagemaker-notebook.ipynb
+++ b/docs/sagemaker/notebooks/sagemaker-sdk/fine-tune-embedding-models/sagemaker-notebook.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "source": [
     "> [!WARNING]\n",
-    "> As per the time of writing, a new version of the sagemaker python SDK has been released [(v3)](https://github.com/aws/sagemaker-python-sdk/tree/master) with major and breaking changes. Unless otherwise specified, all the documentation and tutorials are using the previous version of the SDK [(v2)](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the content to reflect the new changes in the SDK. For now, please make sure to use the previous version of the SDK by running `pip install 'sagemaker<3.0.0'`."
+    "> [SageMaker Python SDK v3 has been recently released](https://github.com/aws/sagemaker-python-sdk), so unless specified otherwise, all the documentation and tutorials are still using the [SageMaker Python SDK v2](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the tutorials and examples, but in the meantime make sure to install the SageMaker SDK as `pip install \"sagemaker<3.0.0\"`."
    ]
   },
   {

--- a/docs/sagemaker/source/dlcs/available.md
+++ b/docs/sagemaker/source/dlcs/available.md
@@ -73,7 +73,7 @@ Let's say you want to use the training DLC for GPUs in
 The Python SagemMaker SDK util functions are not always up to date but it is much simpler than reconstructing the image URI yourself. 
 
 > [!WARNING]
-> As per the time of writing, a new version of the sagemaker python SDK has been released [(v3)](https://github.com/aws/sagemaker-python-sdk/tree/master) with major and breaking changes. Unless otherwise specified, all the documentation and tutorials are using the previous version of the SDK [(v2)](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the content to reflect the new changes in the SDK. For now, please make sure to use the previous version of the SDK by running `pip install 'sagemaker<3.0.0'`.
+> [SageMaker Python SDK v3 has been recently released](https://github.com/aws/sagemaker-python-sdk), so unless specified otherwise, all the documentation and tutorials are still using the [SageMaker Python SDK v2](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the tutorials and examples, but in the meantime make sure to install the SageMaker SDK as `pip install "sagemaker<3.0.0"`.
 
 ```python
 from sagemaker.huggingface import HuggingFaceModel, get_huggingface_llm_image_uri

--- a/docs/sagemaker/source/index.md
+++ b/docs/sagemaker/source/index.md
@@ -13,7 +13,7 @@ We develop new tools to simplify the adoption of custom AI accelerators like AWS
 By combining Hugging Face's open-source models and libraries with AWS's scalable and secure cloud services, developers can more easily and affordably incorporate advanced AI capabilities into their applications.
 
 > [!WARNING]
-> As per the time of writing, a new version of the sagemaker python SDK has been released [(v3)](https://github.com/aws/sagemaker-python-sdk/tree/master) with major and breaking changes. Unless otherwise specified, all the documentation and tutorials are using the previous version of the SDK [(v2)](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the content to reflect the new changes in the SDK. For now, please make sure to use the previous version of the SDK by running `pip install 'sagemaker<3.0.0'`.
+> [SageMaker Python SDK v3 has been recently released](https://github.com/aws/sagemaker-python-sdk), so unless specified otherwise, all the documentation and tutorials are still using the [SageMaker Python SDK v2](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the tutorials and examples, but in the meantime make sure to install the SageMaker SDK as `pip install "sagemaker<3.0.0"`.
 
 ## Deploy models on AWS
 

--- a/docs/sagemaker/source/tutorials/jumpstart/jumpstart-quickstart.md
+++ b/docs/sagemaker/source/tutorials/jumpstart/jumpstart-quickstart.md
@@ -16,7 +16,7 @@ In this quickstart guide, we will deploy [Qwen/Qwen2.5-14B-Instruct](https://hug
 | Service quotas | Most LLMs need GPU instances (e.g. ml.g5). Verify you have quota for `ml.g5.24xlarge` or [request it](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas-requesting-quota-increases.html). | 
 
 > [!WARNING]
-> As per the time of writing, a new version of the sagemaker python SDK has been released [(v3)](https://github.com/aws/sagemaker-python-sdk/tree/master) with major and breaking changes. Unless otherwise specified, all the documentation and tutorials are using the previous version of the SDK [(v2)](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the content to reflect the new changes in the SDK. For now, please make sure to use the previous version of the SDK by running `pip install 'sagemaker<3.0.0'`.
+> [SageMaker Python SDK v3 has been recently released](https://github.com/aws/sagemaker-python-sdk), so unless specified otherwise, all the documentation and tutorials are still using the [SageMaker Python SDK v2](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the tutorials and examples, but in the meantime make sure to install the SageMaker SDK as `pip install "sagemaker<3.0.0"`.
 
 ## 2· Endpoint deployment
 

--- a/docs/sagemaker/source/tutorials/sagemaker-sdk/deploy-sagemaker-sdk.md
+++ b/docs/sagemaker/source/tutorials/sagemaker-sdk/deploy-sagemaker-sdk.md
@@ -36,7 +36,7 @@ pip install 'sagemaker<3.0.0'
 ```
 
 > [!WARNING]
-> As per the time of writing, a new version of the sagemaker python SDK has been released [(v3)](https://github.com/aws/sagemaker-python-sdk/tree/master) with major and breaking changes. Unless otherwise specified, all the documentation and tutorials are using the previous version of the SDK [(v2)](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the content to reflect the new changes in the SDK. For now, please make sure to use the previous version of the SDK by running `pip install 'sagemaker<3.0.0'`.
+> [SageMaker Python SDK v3 has been recently released](https://github.com/aws/sagemaker-python-sdk), so unless specified otherwise, all the documentation and tutorials are still using the [SageMaker Python SDK v2](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the tutorials and examples, but in the meantime make sure to install the SageMaker SDK as `pip install "sagemaker<3.0.0"`.
 
 **SageMaker environment**
 

--- a/docs/sagemaker/source/tutorials/sagemaker-sdk/sagemaker-sdk-quickstart.md
+++ b/docs/sagemaker/source/tutorials/sagemaker-sdk/sagemaker-sdk-quickstart.md
@@ -15,7 +15,7 @@ pip install "sagemaker<3.0.0" "transformers==4.26.1" "datasets[s3]==2.10.1" --up
 ```
 
 > [!WARNING]
-> As per the time of writing, a new version of the sagemaker python SDK has been released [(v3)](https://github.com/aws/sagemaker-python-sdk/tree/master) with major and breaking changes. Unless otherwise specified, all the documentation and tutorials are using the previous version of the SDK [(v2)](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the content to reflect the new changes in the SDK. For now, please make sure to use the previous version of the SDK by running `pip install 'sagemaker<3.0.0'`.
+> [SageMaker Python SDK v3 has been recently released](https://github.com/aws/sagemaker-python-sdk), so unless specified otherwise, all the documentation and tutorials are still using the [SageMaker Python SDK v2](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the tutorials and examples, but in the meantime make sure to install the SageMaker SDK as `pip install "sagemaker<3.0.0"`.
 
 If you want to run this example in [SageMaker Studio](https://docs.aws.amazon.com/sagemaker/latest/dg/studio.html), upgrade [ipywidgets](https://ipywidgets.readthedocs.io/en/latest/) for the 🤗 Datasets library and restart the kernel:
 

--- a/docs/sagemaker/source/tutorials/sagemaker-sdk/training-sagemaker-sdk.md
+++ b/docs/sagemaker/source/tutorials/sagemaker-sdk/training-sagemaker-sdk.md
@@ -34,7 +34,7 @@ pip install 'sagemaker<3.0.0'
 ```
 
 > [!WARNING]
-> As per the time of writing, a new version of the sagemaker python SDK has been released [(v3)](https://github.com/aws/sagemaker-python-sdk/tree/master) with major and breaking changes. Unless otherwise specified, all the documentation and tutorials are using the previous version of the SDK [(v2)](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the content to reflect the new changes in the SDK. For now, please make sure to use the previous version of the SDK by running `pip install 'sagemaker<3.0.0'`.
+> [SageMaker Python SDK v3 has been recently released](https://github.com/aws/sagemaker-python-sdk), so unless specified otherwise, all the documentation and tutorials are still using the [SageMaker Python SDK v2](https://github.com/aws/sagemaker-python-sdk/tree/master-v2). We are actively working on updating all the tutorials and examples, but in the meantime make sure to install the SageMaker SDK as `pip install "sagemaker<3.0.0"`.
 
 **SageMaker environment**
 


### PR DESCRIPTION
## Background

Sagemaker team has recently released a new major version of their `sagemaker-python-sdk` with a big refactoring and some breaking changes that directly affect HF's integrations. While we are already working on this new release, all the tutorials and docs related to sagemaker won't work in this new version until updated.

## Description

This PR adds some warnings to explicitly advice the user about these changes and how to avoid errors by using the previous version (v2).