### PR TITLE
Resource group wording

### DIFF
--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -20,7 +20,7 @@ Members are assigned a role in each Resource Group that determines their permiss
 - `write`: Offers write access to all repositories in the Resource Group. Users can create, delete, or rename any repository in the Resource Group.
 - `admin`: In addition to write permissions on repositories, admin members can administer the Resource Group — add, remove, and alter the roles of other members. They can also manage already existing repositories in a Resource Group.
 
-In addition, Organization admins can manage all resource groups inside the organization.
+In addition, Organization admins can manage all resource groups inside the organization. This includes moving repositories in and out of any Resource Group.
 
 Resource Groups also affect the visibility of private repositories inside the organization. A private repository that is part of a Resource Group will only be visible to members of that Resource Group. Public repositories, on the other hand, are visible to anyone, inside and outside the organization.
 


### PR DESCRIPTION
a resource group admin that is not an org admin can manage already existing repos in a resource group and administer the users of the resource group but they cannot add a repo to the resource group

reference: https://github.com/huggingface-internal/moon-landing/commit/2b66cac6226fac1a8287f63b4fe424c38dd8cd8a
