### PR TITLE
Add org field to eval_results.yaml source section

### DIFF
--- a/eval_results.yaml
+++ b/eval_results.yaml
@@ -16,7 +16,8 @@
   source:                         # Optional. Attribution for this result, for instance a repo containing output traces or a Paper
     url: {source_url}             # Required if source is provided. A link to the source. Example: https://huggingface.co/spaces/SaylorTwift/smollm3-mmlu-pro.
     name: {source_name}           # Optional. The name of the source. Example: Eval Logs.
-    user: {username}              # Optional. A HF user or org name.
+    user: {username}              # Optional. A HF user name.
+    org: {orgname}                # Optional. A HF org name.
 
 # or, with only the required attributes:
 


### PR DESCRIPTION
Introduces an optional 'org' attribute for specifying a Hugging Face organization name in the source section, clarifying that 'user' is for user names.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Schema comment update for eval results**
> 
> - Add optional `org` field under `source` for a Hugging Face org name
> - Clarify `source.user` comment to indicate it is a HF username (not org)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85cc16f6e8bf5b6ede2381aef97719ea7de68ec3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->