### PR TITLE
Add 'Streaming Datasets' to hub docs TOC

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -223,6 +223,8 @@
     title: Uploading Datasets (for LLMs)
   - local: datasets-downloading
     title: Downloading Datasets
+  - local: datasets-streaming
+    title: Streaming Datasets
   - local: datasets-libraries
     title: Integrated Libraries
     sections:


### PR DESCRIPTION
wdyt @lhoestq @davanstrien

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds navigation to the new `datasets-streaming` page in the Hub documentation.
> 
> - Updates `docs/hub/_toctree.yml` to include `datasets-streaming` under the Datasets section, enabling it in the sidebar
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cfa99d83cb62c4607100cf3dfce8b60089c5061. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->