### PR TITLE
Add optional notes field to eval results spec

### DIFF
--- a/docs/hub/eval-results.md
+++ b/docs/hub/eval-results.md
@@ -54,6 +54,7 @@ Create a YAML file in `.eval_results/*.yaml` in your model repo:
     url: https://huggingface.co/spaces/SaylorTwift/smollm3-mmlu-pro  # Required if source provided
     name: Eval traces             # Optional. Display name
     user: SaylorTwift             # Optional. HF username/org
+  notes: "no-tools"               # Optional. Details about the evaluation setup (e.g., "tools", "no-tools", etc.)
 ```
 
 Or, with only the required attributes:

--- a/eval_results.yaml
+++ b/eval_results.yaml
@@ -19,6 +19,8 @@
     user: {username}              # Optional. A HF user name.
     org: {orgname}                # Optional. A HF org name.
 
+  notes: "{notes}"                # Optional. Details about the evaluation setup (e.g., "tools", "no-tools", "chain-of-thought", etc.)
+
 # or, with only the required attributes:
 
 - dataset:


### PR DESCRIPTION
## Summary
- Adds an optional `notes` field to the eval results spec
- Allows capturing evaluation setup details (e.g., "tools", "no-tools", "chain-of-thought", etc.)
- Updates both the spec file and documentation

## Test plan
- [ ] Verify YAML spec is valid
- [ ] Verify documentation example is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an optional `notes` field to the eval results schema and documentation to capture evaluation setup details.
> 
> - Updates `eval_results.yaml` to include `notes` with examples (e.g., "tools", "no-tools", "chain-of-thought")
> - Updates `docs/hub/eval-results.md` example YAML to show `notes` usage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7260d6b704cee54a4a9f01cc85bd460787812513. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->