### PR TITLE
Add examples on create index and training

### DIFF
--- a/docs/hub/datasets-lance.md
+++ b/docs/hub/datasets-lance.md
@@ -239,7 +239,7 @@ with open("video_0.mp4", "wb") as f:
 
 ## Prepare data for training
 
-Training is another area where Lance's fast random access and scan performance can be useful. You can use Lance datasets as the storage mechanism for your training data, shuffling it and loadint into batches as part of your training pipelines.
+Training is another area where Lance's fast random access and scan performance can be useful. You can use Lance datasets as the storage mechanism for your training data, shuffling it and loading into batches as part of your training pipelines.
 
 The blob API in Lance is compatible with `torchcodec`, so you can easily decode video blobs as `torch` tensors:
 


### PR DESCRIPTION
Updates the Lance docs on HF with the following:
- [x] Show how to create an index if it doesn't yet exist in Lance
- [x] Point to `torchcodec` and training examples to show that Lance can help power HF users' training pipelines too.
- [x] Point to the new [Openvid-1M](https://huggingface.co/datasets/lance-format/Openvid-1M) dataset where video blob column is the first column in the list