### PR TITLE
Add cross-reference to Hub datasets guide in Data Designer integration

### DIFF
--- a/docs/inference-providers/integrations/datadesigner.md
+++ b/docs/inference-providers/integrations/datadesigner.md
@@ -113,7 +113,7 @@ url = results.push_to_hub(
 )
 ```
 
-For loading Hub datasets as seed data and more details on Hub integration, see the [Data Designer Hub datasets guide](https://huggingface.co/docs/hub/en/datasets-data-designer).
+For loading Hub datasets as seed data and more details on the Hub integration, see the [Data Designer Hub datasets guide](https://huggingface.co/docs/hub/en/datasets-data-designer).
 
 ## Resources
 


### PR DESCRIPTION
Links the Inference Providers Data Designer page to the new Hub datasets guide (from PR #2204), adding a "Push to Hub" section and a Resources link so users can discover both the compute and data sides of the integration. Merged after https://github.com/huggingface/hub-docs/pull/2204 is merged