### PR TITLE
Improve eval-results badge docs and add moderation note

### DIFF
--- a/docs/hub/eval-results.md
+++ b/docs/hub/eval-results.md
@@ -72,6 +72,9 @@ Anyone can submit evaluation results to any model via Pull Request:
 
 For help evaluating a model, see the [Evaluating models with Inspect](https://huggingface.co/docs/inference-providers/guides/evaluation-inspect-ai) guide.
 
+> [!TIP]
+> Community scores are visible while the PR is open. If a score is disputed, the model author can close the PR to remove it. The goal is to surface existing evaluation data transparently while building toward a fully reproducible standard via verified scores.
+
 ## Registering a Benchmark
 
 To register your dataset as a benchmark:


### PR DESCRIPTION
## Summary
- Clarify badge table descriptions to match actual implementation in moon-landing (e.g. `verified` = valid `verifyToken` reproduced via Inspect AI, `community` = open PR, `leaderboard` = benchmark has a leaderboard, `source` = external URL provided)
- Add a tip after Community Contributions explaining how community scores can be moderated (author can close the PR to remove a disputed score)

## Context
User feedback surfaced two common questions:
1. "Who runs the evals?" — badge descriptions now make provenance clearer
2. "Can someone submit false scores?" — new tip explains the PR-based moderation model

## Test plan
- [ ] Review rendered markdown for clarity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds guidance on how community-provided eval scores are displayed and can be removed if disputed.
> 
> **Overview**
> Clarifies the `eval-results` documentation by adding a **TIP** under *Community Contributions* explaining that community-submitted scores are visible while a PR is open and can be removed by closing the PR if disputed, emphasizing the intent to move toward reproducible *verified* scores.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 892b57e52cf0c986d1b52ee1fa8a5d9057a25a3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->