### PR TITLE
Device code oauth docs

### DIFF
--- a/docs/hub/oauth.md
+++ b/docs/hub/oauth.md
@@ -83,7 +83,7 @@ echo "Enter the user code: $USER_CODE"
 echo ""
 read -p "Press Enter after authorizing..."
 
-# Step 3: Exchange for token
+# Step 3: Get token
 curl -X POST https://huggingface.co/oauth/token \
   -d "grant_type=urn:ietf:params:oauth:grant-type:device_code" \
   -d "device_code=$DEVICE_CODE" \


### PR DESCRIPTION
cc @Wauplin 

For https://github.com/huggingface-internal/moon-landing/pull/14206

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no product code or security-sensitive logic is modified.
> 
> **Overview**
> Updates `docs/hub/oauth.md` to document **public OAuth apps without a client secret**, including how to create or convert an app and when to use `client_id`-only auth vs `Authorization: Basic`.
> 
> Adds a new **Device Code OAuth** section describing the flow and providing a curl-based test script, with notes on handling apps that do have a secret.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22c4423af19bf9a66ac778ea66ad47a38a9ee1d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->