### PR TITLE
Reorder main TOC to list Jobs before Agents

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -409,21 +409,6 @@
     - local: spaces-get-user-plan
       title: Get User Plan and Status
 
-- local: agents
-  title: Agents
-  isExpanded: true
-  sections:
-  - local: agents-overview
-    title: Agents on the Hub
-  - local: agents-mcp
-    title: Hugging Face MCP Server
-  - local: agents-skills
-    title: Hugging Face Agent Skills
-  - local: agents-cli
-    title: Agents and the `hf` CLI
-  - local: agents-sdk
-    title: Building agents with the SDK
-
 - local: jobs
   title: Jobs
   isExpanded: true
@@ -446,6 +431,21 @@
     title: Webhook Automation
   - local: jobs-reference
     title: Reference
+
+- local: agents
+  title: Agents
+  isExpanded: true
+  sections:
+  - local: agents-overview
+    title: Agents on the Hub
+  - local: agents-mcp
+    title: Hugging Face MCP Server
+  - local: agents-skills
+    title: Hugging Face Agent Skills
+  - local: agents-cli
+    title: Agents and the `hf` CLI
+  - local: agents-sdk
+    title: Building agents with the SDK
 
 - local: other
   title: Other


### PR DESCRIPTION
## Summary
- move the Jobs section above Agents in the main Hub docs TOC (docs/hub/_toctree.yml)
- keep section contents unchanged

## Testing
- not run (docs ordering change only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs TOC reordering only; no runtime logic or content changes beyond navigation order.
> 
> **Overview**
> Reorders the main Hub docs table-of-contents (`docs/hub/_toctree.yml`) so **`Jobs` appears before `Agents`**.
> 
> No section content changes; this is a navigation/ordering-only update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d344c30e443a0919955e06f332b6b6c867b23e11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->