### PR TITLE
Hub user email documentation

### DIFF
--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -43,7 +43,7 @@ After creating a resource group and giving it a meaningful name, you can start a
 </div>
 
 > [!TIP]
-> When adding users to a Resource Group, you can search by email address if the user has an organization-specific email (e.g., `user@your-company.com`).
+> When adding users to a Resource Group, you can search by email address if the user has an organization-specific email (e.g., `user@your-company.com`) matching your organization email domain.
 
 Remember that a repository can be part of only one Resource Group. You'll be warned when trying to add a repository that already belongs to another Resource Group.
 


### PR DESCRIPTION
Add documentation for searching users by email when adding them to resource groups to assist organizations that identify users by email.

---
[Slack Thread](https://huggingface.slack.com/archives/C05N4JUSK29/p1771501188512289?thread_ts=1771501188.512289&cid=C05N4JUSK29)

<p><a href="https://cursor.com/background-agent?bcId=bc-5545da94-1cf5-5290-b961-c2e6a1af24be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5545da94-1cf5-5290-b961-c2e6a1af24be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change with no runtime or behavior impact.
> 
> **Overview**
> Adds a *documentation tip* to `docs/hub/security-resource-groups.md` noting that when adding users to a Resource Group, admins can search by email address if the user has an organization-specific email matching the org’s email domain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df7b30bebc9724ade13a0e6290badaee951427f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->