### PR TITLE
inference providers pricing change

### DIFF
--- a/docs/hub/enterprise.md
+++ b/docs/hub/enterprise.md
@@ -34,7 +34,7 @@ Team & Enterprise organization plans add advanced capabilities to organizations,
 
 | Feature                                                                                                                | Free    | Team                              | Enterprise                        | Enterprise Plus                   |
 | ---------------------------------------------------------------------------------------------------------------------- | ------- | --------------------------------- | --------------------------------- | --------------------------------- |
-| Serve models with Inference Providers                                                                                  | ❌      | ✅ <br>$2/seat/mo included + PAYG | ✅ <br>$2/seat/mo included + PAYG | ✅ <br>$2/seat/mo included + PAYG |
+| Serve models with Inference Providers                                                                                  | ✅ <br>PAYG | ✅ <br>$2/seat/mo included + PAYG | ✅ <br>$2/seat/mo included + PAYG | ✅ <br>$2/seat/mo included + PAYG |
 | [Usage & billing control](https://huggingface.co/docs/inference-providers/pricing#inference-providers-usage-breakdown) | ❌      | ✅                                | ✅                                | ✅                                |
 | Scale deployment with Inference Endpoints                                                                              | ✅ PAYG | ✅ PAYG                           | ✅ PAYG                           | ✅ PAYG                           |
 | Hub credits\* included in plan                                                                                         | ❌      | ❌ (bulk purchase available)      | $2k included                      | 5% of ACV included                |

--- a/docs/inference-providers/guides/gpt-oss.md
+++ b/docs/inference-providers/guides/gpt-oss.md
@@ -17,7 +17,7 @@ export HF_TOKEN="your_token_here"
 ```
 
 > [!TIP]
-> 💡 Pro tip: The free tier gives you monthly inference credits to start building and experimenting. Upgrade to [Hugging Face PRO](https://huggingface.co/pro) for even more flexibility, $2 in monthly credits plus pay‑as‑you‑go access to all providers!
+> 💡 Pro tip: The free tier gives you monthly inference credits to start building and experimenting. All users can purchase additional credits for pay‑as‑you‑go access. Upgrade to [Hugging Face PRO](https://huggingface.co/pro) for $2 in monthly credits!
 
 2. Install the official OpenAI SDK.
 

--- a/docs/inference-providers/integrations/vscode.md
+++ b/docs/inference-providers/integrations/vscode.md
@@ -23,7 +23,7 @@ Use frontier open LLMs like Kimi K2, DeepSeek V3.1, GLM 4.5 and more in VS Code 
 - Built for high availability (across providers) and low latency.
 - Transparent pricing: what the provider charges is what you pay.
 
-💡 The free Hugging Face user tier gives you a small amount of monthly inference credits to experiment. Upgrade to [Hugging Face PRO](https://huggingface.co/pro) or [Team or Enterprise](https://huggingface.co/enterprise) for $2 in monthly credits plus pay‑as‑you‑go access across all providers!
+💡 Every Hugging Face user gets monthly inference credits to experiment, and can purchase additional credits for pay‑as‑you‑go access. Upgrade to [Hugging Face PRO](https://huggingface.co/pro) or [Team or Enterprise](https://huggingface.co/enterprise) for $2 in monthly credits!
 
 Check out the whole workflow in action in the video below:
 

--- a/docs/inference-providers/pricing.md
+++ b/docs/inference-providers/pricing.md
@@ -6,11 +6,11 @@ Access 200+ models from leading AI inference providers with centralized, transpa
 
 Every Hugging Face user receives monthly credits to experiment with Inference Providers:
 
-| Account Type                     | Monthly Credits          | Extra usage (pay-as-you-go) |
-| -------------------------------- | ------------------------ | --------------------------- |
-| Free Users                       | $0.10, subject to change | no                          |
-| PRO Users                        | $2.00                    | yes                         |
-| Team or Enterprise Organizations | $2.00 per seat           | yes                         |
+| Account Type                     | Monthly Credits          | Extra usage (pay-as-you-go)     |
+| -------------------------------- | ------------------------ | ------------------------------- |
+| Free Users                       | $0.10, subject to change | yes (credits purchase required) |
+| PRO Users                        | $2.00                    | yes                             |
+| Team or Enterprise Organizations | $2.00 per seat           | yes                             |
 
 > [!TIP]
 > Your monthly credits automatically apply when you route requests through Hugging Face. For Team or Enterprise organizations, credits are shared among all members.
@@ -38,7 +38,7 @@ Inference Providers offers flexibility in how you're billed. Understanding these
 To benefit from Team or Enterprise included credits, you need to explicitly specify the organization to be billed when performing the inference requests.
 See the [Organization Billing section](#organization-billing) below for more details.
 
-**PRO users or Team or Enterprise organizations** can continue using the API after exhausting their monthly credits. This ensures uninterrupted access to models for production workloads.
+**All users** can continue using the API after exhausting their monthly credits by purchasing additional credits. This ensures uninterrupted access to models for production workloads.
 
 
 > [!TIP]
@@ -69,7 +69,7 @@ Here is a table that sums up what we've seen so far:
 
 |                                    | HF routing | Billed by    | Free-tier included | Pay-as-you-go                                   | Integration                               |
 | ---------------------------------- | ---------- | ------------ | ------------------ | ----------------------------------------------- | ----------------------------------------- |
-| **Routed Requests**                 | Yes        | Hugging Face | Yes                | Only for PRO users and for integrated providers | SDKs, Playground, widgets, Data AI Studio |
+| **Routed Requests**                 | Yes        | Hugging Face | Yes                | Yes (credits purchase required)                 | SDKs, Playground, widgets, Data AI Studio |
 | **Custom Provider Key** | Yes        | Provider     | No                 | Yes                                             | SDKs, Playground, widgets, Data AI Studio |
 
 > [!TIP]


### PR DESCRIPTION
Companion PR of https://github.com/huggingface-internal/moon-landing/pull/16900 (private)

Update the documentation about Inference Providers pricing and access

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that update pricing/access wording; no runtime or billing logic is modified.
> 
> **Overview**
> Updates Inference Providers docs to reflect that **free users can use routed Inference Providers via pay-as-you-go by purchasing credits**, rather than being blocked after the monthly free credits.
> 
> Adjusts the pricing table and billing comparison in `docs/inference-providers/pricing.md`, updates “pro tip” messaging in the `gpt-oss` and VS Code integration guides, and updates the Team/Enterprise plan matrix to mark Inference Providers as available for Free with PAYG.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 947e897a91a66d051a2aa567f68f0e28b4c66d0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->