### PR TITLE
[Jobs] Document built-in environment variables in Jobs docs (JOB_ID, MEMORY, etc.)

### DIFF
--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -67,14 +67,9 @@ Jobs automatically provide the following environment variables inside the contai
 
 You can use these variables to track outputs, adapt your code to available resources, or reference the current job programmatically:
 
-```python
-import os
-job_id = os.environ.get("JOB_ID")
-accelerator = os.environ.get("ACCELERATOR")
-cpu_cores = os.environ.get("CPU_CORES")
-memory = os.environ.get("MEMORY")
-print(f"Running job {job_id} with {accelerator} accelerator, {cpu_cores} CPU cores, and {memory} memory")
-```
+```bash
+# Access job environment information
+>>> hf jobs run python:3.12 python -c "import os; print(f'Job: {os.environ.get(\"JOB_ID\")}, CPU: {os.environ.get(\"CPU_CORES\")}, Mem: {os.environ.get(\"MEMORY\")}')"
 
 ### User-defined environment variables
 


### PR DESCRIPTION
Document the `JOB_ID` built-in environment variable in the Jobs guide to address a feature request.

The `JOB_ID` environment variable is available inside job containers and provides a unique identifier for the running job. Documenting it helps users leverage this information, as requested in huggingface/huggingface_hub#3828.

---
[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1771931737116779?thread_ts=1771931737.116779&cid=D0A9313SS3G)

<p><a href="https://cursor.com/agents/bc-39d341c1-dfe6-5531-a2d7-3300152ba36b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39d341c1-dfe6-5531-a2d7-3300152ba36b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change with no impact on runtime behavior; risk limited to potential documentation inaccuracies.
> 
> **Overview**
> Documents **built-in Jobs runtime environment variables** in `docs/hub/jobs-configuration.md`, adding a table for `JOB_ID`, `ACCELERATOR`, `CPU_CORES`, and `MEMORY` plus a small example showing how to read them inside a job.
> 
> Splits the section to distinguish built-in variables from *user-defined environment variables* passed via CLI flags/files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a390973678ca92204e27e39d682302458b74637c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->