### PR TITLE
Add Pi integration doc for Inference Providers

### DIFF
--- a/docs/inference-providers/_toctree.yml
+++ b/docs/inference-providers/_toctree.yml
@@ -44,6 +44,8 @@
     title: MacWhisper
   - local: integrations/opencode
     title: OpenCode
+  - local: integrations/pi
+    title: Pi
   - local: integrations/visionagents
     title: Vision Agents
   - local: integrations/vscode

--- a/docs/inference-providers/integrations/index.md
+++ b/docs/inference-providers/integrations/index.md
@@ -28,6 +28,7 @@ This table lists _some_ tools, libraries, and applications that work with Huggin
 | [LlamaIndex](https://www.llamaindex.ai/) | Data framework for LLM applications                            | [Official docs](https://developers.llamaindex.ai/python/examples/llm/huggingface/#use-a-model-via-inference-providers) |
 | [MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper)                                                           | Speech-to-text application for macOS                           | [HF docs](./macwhisper)                                                                                                     |
 | [OpenCode](https://opencode.ai/)                                                                                             | AI coding agent built for the terminal                         | [Official docs](https://opencode.ai/docs/providers#hugging-face) / [HF docs](./opencode)                             |
+| [Pi](https://github.com/badlogic/pi-mono)                                                                                    | Minimalist terminal-based coding assistant                     | [Official docs](https://github.com/badlogic/pi-mono) / [HF docs](./pi)                                               |
 | [PydanticAI](https://ai.pydantic.dev/)                                                                         | Framework for building AI agents with Python                   | [Official docs](https://ai.pydantic.dev/models/huggingface/)                                                           |
 | [Roo Code](https://roocode.com/)                                                                               | AI-powered code generation and refactoring                     | [Official docs](https://docs.roocode.com/providers/huggingface)                                                        |
 | [smolagents](https://huggingface.co/docs/smolagents)                                                           | Framework for building LLM agents with tool integration        | [Official docs](https://huggingface.co/docs/smolagents/reference/models#smolagents.InferenceClientModel)               |
@@ -53,6 +54,7 @@ AI-powered coding assistants and development environments.
 
 - [GitHub Copilot Chat](https://docs.github.com/en/copilot) - AI pair programmer in VS Code ([HF docs](./vscode))
 - [OpenCode](https://opencode.ai/) - AI coding agent built for the terminal ([Official docs](https://opencode.ai/docs/providers#hugging-face) / [HF docs](./opencode))
+- [Pi](https://github.com/badlogic/pi-mono) - Minimalist terminal-based coding assistant ([Official docs](https://github.com/badlogic/pi-mono) / [HF docs](./pi))
 - [Roo Code](https://roocode.com/) - AI-powered code generation and refactoring ([Official docs](https://docs.roocode.com/providers/huggingface))
 
 ### Evaluation Frameworks

--- a/docs/inference-providers/integrations/pi.md
+++ b/docs/inference-providers/integrations/pi.md
@@ -1,0 +1,69 @@
+# Pi
+
+[Pi](https://github.com/badlogic/pi-mono) is a minimalist, extensible terminal-based coding assistant designed to adapt to your workflows rather than the other way around.
+
+## Overview
+
+Pi natively supports Hugging Face Inference Providers, giving you access to open models from 17+ providers through a single interface.
+
+## Prerequisites
+
+- Pi installed (`npm install -g @mariozechner/pi-coding-agent`)
+- A Hugging Face account with [API token](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained) (needs "Make calls to Inference Providers" permission)
+
+## Configuration
+
+### Quick Setup
+
+1. Create a Hugging Face token with Inference Providers permissions at [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained)
+
+2. Set your token as an environment variable:
+
+```bash
+export HF_TOKEN=hf_...
+```
+
+Alternatively, store it in `~/.pi/agent/auth.json`:
+
+```json
+{
+  "huggingface": {
+    "type": "api_key",
+    "key": "hf_..."
+  }
+}
+```
+
+3. Set Hugging Face as your default provider in `~/.pi/agent/settings.json`:
+
+```json
+{
+  "defaultProvider": "huggingface",
+  "defaultModel": "moonshotai/Kimi-K2.5"
+}
+```
+
+4. Start pi and run the `/model` command (or press **Ctrl+L**) to open the interactive model selector. You can also press **Ctrl+P** to cycle through your scoped models.
+
+### Billing to an Organization
+
+To bill inference usage to a Hugging Face organization instead of your personal account, add the `X-HF-Bill-To` header in your provider configuration (`~/.pi/agent/models.json`):
+
+```json
+{
+  "providers": {
+    "huggingface": {
+      "headers": {
+        "X-HF-Bill-To": "your-org-name"
+      }
+    }
+  }
+}
+```
+
+Replace `"your-org-name"` with the name of the organization you want to bill to.
+
+## Resources
+
+- [Pi Documentation](https://github.com/badlogic/pi-mono)
+- [Available models on Inference Providers](https://huggingface.co/models?pipeline_tag=text-generation&inference_provider=all&sort=trending)


### PR DESCRIPTION
## Summary

- Adds a new integration page for [Pi](https://github.com/badlogic/pi-mono), a minimalist terminal-based coding assistant with native Hugging Face Inference Providers support
- Covers quick setup (HF_TOKEN, auth.json, settings.json), model selection (Ctrl+L / `/model`), and org billing via `X-HF-Bill-To` header
- Adds Pi to the integrations overview table and Developer Tools category in index.md
- Adds Pi entry to `_toctree.yml`

## Test plan

- [ ] Verify the doc renders correctly on the Inference Providers docs site
- [ ] Confirm all links resolve (GitHub repo, HF token settings page, models page)
- [ ] Verify toctree ordering (Pi appears alphabetically between OpenCode and Vision Agents)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new integration page and navigation entries; no runtime code or behavior is affected.
> 
> **Overview**
> Adds a new `integrations/pi.md` page documenting how to use Pi with Inference Providers (token setup via `HF_TOKEN` or `~/.pi/agent/auth.json`, default provider/model config, model selection, and org billing via `X-HF-Bill-To`).
> 
> Updates the integrations overview (`integrations/index.md`) and the docs navigation (`_toctree.yml`) to include Pi in the list of supported developer tools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d03ad3f4c859509738925d13d5101ed4ebcabba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->