### PR TITLE
Jobs schedule page labels

### DIFF
--- a/docs/hub/jobs-schedule.md
+++ b/docs/hub/jobs-schedule.md
@@ -16,9 +16,12 @@ Use `hf jobs uv run ` or `hf jobs run` with a schedule of `@annually`, `@yearly`
 
 # Schedule with a Docker image
 >>> hf jobs scheduled run @hourly python:3.12 python -c "print('This runs every hour!')"
+
+# Schedule a Python script with a label
+>>> hf jobs scheduled uv run --label fine-tuning @hourly my_script.py
 ```
 
-Use the same parameters as `hf jobs uv run` and `hf jobs run` to pass environment variables, secrets, timeout, etc.
+Use the same parameters as `hf jobs uv run` and `hf jobs run` to pass environment variables, secrets, timeout, labels, etc.
 
 Manage scheduled jobs using `hf jobs scheduled ps`, `hf jobs scheduled inspect`, `hf jobs scheduled suspend`, `hf jobs scheduled resume`, and `hf jobs scheduled delete`:
 


### PR DESCRIPTION
Mention labels in the `jobs-schedule` documentation and add an example for `hf jobs uv run` with a label.

---
[Slack Thread](https://huggingface.slack.com/archives/C07RD3RVD5W/p1772014460161289?thread_ts=1772014460.161289&cid=C07RD3RVD5W)

<p><a href="https://cursor.com/agents/bc-0ff66f7f-793f-552b-a5f8-9eb0feea9607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ff66f7f-793f-552b-a5f8-9eb0feea9607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a new CLI example and clarifies supported flags; no runtime behavior is modified.
> 
> **Overview**
> Updates the scheduled jobs documentation to **surface label support**: adds an example showing `hf jobs scheduled uv run --label ...` and explicitly includes *labels* in the list of parameters you can pass through when scheduling jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0501f6df4a79e3be3fef26cadd5961bab870d654. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->