### PR TITLE
Add local agent (`Pi` + `llama.cpp`) guide

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -447,7 +447,7 @@
   - local: agents-cli
     title: Agents and the `hf` CLI
   - local: agents-sdk
-    title: Building agents with the SDK
+    title: Building agents with the HF SDK
   - local: agents-local
     title: Local Agents with llama.cpp and Pi
 

--- a/docs/hub/agents-local.md
+++ b/docs/hub/agents-local.md
@@ -11,15 +11,15 @@ You can run a coding agent entirely on your own hardware. [Pi](https://pi.dev) c
 
 Set your local hardware so it can show you which models are compatible with your setup.
 
-Go to [huggingface.co/settings/local-apps](https://huggingface.co/settings/local-apps) and configure your local hardware profile.
+Go to [huggingface.co/settings/local-apps](https://huggingface.co/settings/local-apps) and configure your local hardware profile. Select `llama.cpp` in the Local Apps section as this will be the engine you'll use.
 
 ### 2. Find a Compatible Model
 
-Browse models for compatible models for Pi: [huggingface.co/models?apps=pi&sort=trending](https://huggingface.co/models?apps=pi&sort=trending)
+Browse for models compatible with Pi: [huggingface.co/models?apps=pi&sort=trending](https://huggingface.co/models?apps=pi&sort=trending)
 
 ### 3. Launch the llama.cpp Server
 
-On the model page, click the **"Use this model"** button. Pi will show you the exact commands for your setup. The first step is to start a llama.cpp server, e.g.
+On the model page, click the **"Use this model"** button and select `llama.cpp`. Pi will show you the exact commands for your setup. The first step is to start a llama.cpp server, e.g.
 
 ```bash
 # Start a local OpenAI-compatible server:


### PR DESCRIPTION
This PR adds new local agents documentation how to run a local coding agent using `Pi` and `llama.cpp`. basically, converting this https://x.com/victormustar/status/2026380975425388964?s=46&t=lrQZREKBjsU0EhXX8L2fHg into a Guide. 