### PR TITLE
docs: add speciesist bias to model card bias documentation

### DIFF
--- a/docs/hub/model-card-annotated.md
+++ b/docs/hub/model-card-annotated.md
@@ -137,7 +137,7 @@ _List how the model may foreseeably be misused (used in a way it will not work f
 
 `bias_risks_limitations`
 
-_What are the known or foreseeable issues stemming from this model?_
+_What are the known or foreseeable issues stemming from this model? Consider biases related to, for example: race, gender, religion, age, disability, sexual orientation, nationality, and species (speciesism). Speciesist bias — in which models associate certain animals with harm or lower moral status based on their categorization as farmed vs. companion animals — has been documented in language models ([Hagendorff et al., 2023](https://doi.org/10.1007/s43681-023-00302-w); [Takeshita et al., 2022](https://doi.org/10.1016/j.ipm.2022.103070); [Hagendorff et al., 2025](https://doi.org/10.48550/arXiv.2406.15668)) and is particularly relevant for models processing text about animals, food recommendation systems, and agricultural NLP._
 
 
 


### PR DESCRIPTION
## Summary

Adds speciesist bias as a recognized bias category in the model card documentation guidance, alongside existing categories (racial, gender, religious, etc.).

## Context

Multiple peer-reviewed papers have documented speciesist bias in language models:

- Hagendorff, Bossert, Tse & Singer (2023). "Speciesist bias in AI." *AI and Ethics*. Found GPT-3 associates farmed animals with violence; the Delphi moral AI judged killing a factory-farmed pig as acceptable but killing a dog as wrong.
- Takeshita et al. (2022). Found BERT, RoBERTa, and other models associate harmful words with nonhuman animals. *Information Processing & Management*.
- Hagendorff et al. (2025). Introduced SpeciesismBench (1,003 items) showing LLMs "frequently normalized harm toward farmed animals while refusing to do so for non-farmed animals."

This bias is particularly relevant for food recommendation systems, agricultural NLP, and any model processing text about animals.

## Changes

Minimal documentation update adding speciesism to the list of recognized bias categories in the model card guidance, with academic citations.

## Test plan

- [ ] Documentation renders correctly
- [ ] Addition integrates naturally with existing bias categories