### PR TITLE
docs: add Public Storage add-on to storage-limits

### DIFF
--- a/docs/hub/storage-limits.md
+++ b/docs/hub/storage-limits.md
@@ -1,13 +1,15 @@
 # Storage limits
 
-At Hugging Face we aim to provide the AI community with significant volumes of **free storage space for public repositories**. We bill for storage space for **private repositories**, above a free tier (see table below).
+<!-- STRETCH TABLES -->
+
+At Hugging Face we aim to provide the AI community with significant volumes of **free storage space for public repositories**, with options to buy more storage if necessary. We also bill for storage space for **private repositories**, above a free tier (see table below).
 
 > [!TIP]
-> Storage limits and policies apply to both model and dataset repositories on the Hub.
+> Storage limits and policies apply to all types of repositories (models, datasets, …) on the Hub.
 
 We [optimize our infrastructure](https://huggingface.co/blog/xethub-joins-hf) continuously to [scale our storage](https://x.com/julien_c/status/1821540661973160339) for the coming years of growth in AI and Machine learning.
 
-We do have mitigations in place to prevent abuse of free public storage, and in general we ask users and organizations to make sure any uploaded large model or dataset is **as useful to the community as possible** (as represented by numbers of likes or downloads, for instance). Finally, upgrade to a paid Organization or User (PRO) account to unlock higher limits.
+We do have mitigations in place to prevent abuse of free public storage, and in general we ask users and organizations to make sure any uploaded large model or dataset is **as useful to the community as possible** (as represented by numbers of likes or downloads, for instance). Upgrade to a paid Organization or User (PRO) account to unlock higher limits.
 
 ## Storage plans
 
@@ -36,9 +38,9 @@ Users on a paid plan (PRO, Team, or Enterprise) can subscribe to a **Public Stor
 | 20 TB          | $240/month     | $12/TB/month     |
 | 50 TB          | $500/month     | $10/TB/month     |
 
-You can subscribe or change your tier from the **Billing** settings page of your account or organization. Upgrades take effect immediately; downgrades are scheduled to take effect at the start of the next month.
+You can subscribe or change your tier from the **Billing** settings page of your account or organization. Upgrades take effect immediately; downgrades are scheduled to take effect at the start of the next month. If you need more storage, you can [contact us](https://huggingface.co/contact/sales) to take advantage of [custom large-scale pricing](https://huggingface.co/pricing#storage).
 
-### Pay-as-you-go price for private storage
+### Private storage Pay-as-you-go
 
 Above the included 1TB (or 1TB per seat) of private storage in [PRO](https://huggingface.co/subscribe/pro) and [Team or Enterprise Organizations](https://huggingface.co/enterprise), private storage is invoiced at **$25/TB/month**, in 1TB increments. See our [billing doc](./billing) for more details.
 


### PR DESCRIPTION
btw this page is a bit too verbose imo.

<img width="721" height="383" alt="image" src="https://github.com/user-attachments/assets/6cc4c834-3941-4a7a-b69b-6ec01038678a" />


## Summary

- Adds a new **Public Storage add-on** section with the 5 pricing tiers (1TB/$12 – 50TB/$500/month)
- Explains that the add-on stacks on top of the plan's base public storage limit, and documents upgrade/downgrade behavior
- Updates 4 existing references in the doc (repo size tip, repository size explanation, sharing large datasets, sharing large models) to mention the add-on as an option alongside Team/Enterprise upgrades
- Removes the specific "usually up to 5TB" claim from the Free tier row (the best-effort framing already covers it)
- Renames "Pay-as-you-go price" → "Pay-as-you-go price for private storage" for clarity

## Test plan

- [ ] Verify pricing tiers match production (cross-referenced with `BillingProducts.ts` in moon-landing)
- [ ] Check anchor link `#public-storage-add-on` resolves correctly on the rendered page
- [ ] Review wording with billing/product team

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes with no code paths affected; main risk is potential customer confusion if pricing/links/anchors are incorrect.
> 
> **Overview**
> Adds documentation for a new **Public Storage add-on** (pricing tiers, how to subscribe, and upgrade/downgrade behavior) and links it from the paid plan rows in the storage table.
> 
> Updates copy across the page to reflect that paid users can buy extra *public* storage (and removes the prior “usually up to 5TB” claim for free public storage), plus retitles the pay-as-you-go section to explicitly be for *private* storage and adjusts several “>1TB” guidance references to point to upgrading the storage plan.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c5ae44d9971a37ef09405886182700da4cc789c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->