### PR TITLE
docs(xet): update to V2 reconstruction + document missing public CAS endpoints

### DIFF
--- a/docs/xet/api.md
+++ b/docs/xet/api.md
@@ -36,14 +36,15 @@ It is: `07060504030201000f0e0d0c0b0a0908171615141312111f1e1d1c1b1a1918`.
 
 ### 1. Get File Reconstruction
 
-- **Description**: Retrieves reconstruction information for a specific file, includes byte range support when `Range` header is set.
-- **Path**: `/v1/reconstructions/{file_id}`
+- **Description**: Retrieves reconstruction information for a specific file. Returns URLs optimized for multi-range fetching: multiple byte ranges for the same xorb are combined into a single URL. Supports byte range via the optional `Range` header.
+- **Path**: `/v2/reconstructions/{file_id}`
 - **Method**: `GET`
 - **Parameters**:
   - `file_id`: File hash in hex format (64 lowercase hexadecimal characters).
 See [file hashes](./hashing#file-hashes) for computing the file hash and [converting hashes to strings](./api#converting-hashes-to-strings).
 - **Headers**:
   - `Range`: OPTIONAL. Format: `bytes={start}-{end}` (end is inclusive).
+  - `Accept-Encoding`: OPTIONAL. The server supports `gzip` and `zstd` compression on the JSON response. Clients SHOULD send `Accept-Encoding: gzip` or `Accept-Encoding: zstd` to reduce reconstruction response size.
 - **Minimum Token Scope**: `read`
 - **Body**: None.
 - **Response**: JSON (`QueryReconstructionResponse`)
@@ -52,7 +53,7 @@ See [file hashes](./hashing#file-hashes) for computing the file hash and [conver
   {
     "offset_into_first_range": 0,
     "terms": [...],
-    "fetch_info": {...}
+    "xorbs": {...}
   }
   ```
 
@@ -63,7 +64,7 @@ See [file hashes](./hashing#file-hashes) for computing the file hash and [conver
   - `416 Range Not Satisfiable`: The requested byte range start exceeds the end of the file. Not retryable.
 
 ```txt
-GET /v1/reconstructions/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+GET /v2/reconstructions/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 -H "Authorization: Bearer <token>"
 OPTIONAL: -H Range: "bytes=0-100000"
 ```

--- a/docs/xet/api.md
+++ b/docs/xet/api.md
@@ -175,7 +175,7 @@ An example shard request body can be found in [Xet reference files](https://hugg
 
 ### 5. Batch File Reconstruction
 
-- **Description**: Retrieves reconstruction information for multiple files in a single request. Useful for clients that need to fetch reconstruction data for a batch of files without issuing N separate requests.
+- **Description**: Retrieves reconstruction information for multiple files in a single request, avoiding N separate calls.
 - **Path**: `/v1/reconstructions`
 - **Method**: `POST`
 - **Headers**:
@@ -260,7 +260,7 @@ HEAD /v1/files/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 
 ### 8. Get File Chunk Hashes
 
-- **Description**: For a file and a set of "dirty" byte ranges (regions the client intends to re-chunk), returns the chunk windows the client must re-chunk plus opaque hash subtrees that cover the unchanged gaps. Used by delta uploads to compose a new shard without re-uploading already-known chunks. The response covers the full file: gaps between dirty windows are summarized as `MerkleHashSubtree` entries; each stable segment outside any dirty range also gets a verification hash.
+- **Description**: For a file and a set of "dirty" byte ranges (regions the client intends to re-chunk), returns the chunk windows the client must re-chunk plus opaque hash subtrees covering the unchanged gaps. Used by delta uploads to compose a new shard without re-uploading already-known chunks. The response covers the full file; see the field notes below for how windows, gaps, and verification hashes fit together.
 - **Path**: `/v2/file-chunk-hashes/{file_id}`
 - **Method**: `GET`
 - **Parameters**:

--- a/docs/xet/api.md
+++ b/docs/xet/api.md
@@ -173,7 +173,70 @@ POST /v1/shards
 
 An example shard request body can be found in [Xet reference files](https://huggingface.co/datasets/xet-team/xet-spec-reference-files/blob/main/Electric_Vehicle_Population_Data_20250917.csv.shard.verification-no-footer).
 
-### 5. Batch File Reconstruction
+### 5. Streaming Shard Upload
+
+- **Description**: Runs the exact same validation and registration as [Upload Shard](./api#4-upload-shard), but streams finalization progress back as newline-delimited JSON so clients can show real progress instead of a bar frozen at 100%.
+Large or heavily-deduplicated shards can take several seconds to finalize: the server verifies every file reconstruction entry against its xorb metadata, and a cache miss there is an S3 fetch.
+- **Path**: `/v2/shards`
+- **Method**: `POST`
+- **Minimum Token Scope**: `write`
+- **Body**: Serialized Shard data as bytes (`application/octet-stream`), identical to [`/v1/shards`](./api#4-upload-shard). See [Shard format guide](./shard#shard-upload).
+- **Response**: A newline-delimited JSON stream (`Content-Type: application/x-ndjson`, `Cache-Control: no-cache`), one JSON object ("event") per line.
+
+The HTTP status is `200 OK` as soon as the stream starts, so success or failure is carried by the terminal event, NOT by the status code.
+Clients MUST read the stream to completion and inspect the terminal event.
+
+Each event has a `type` field:
+
+  - `validating`: verification progress. `verified` is the number of completed verification tasks, `total` the number spawned so far. While the shard is still being received `total` grows, so treat `verified / total` as a live ratio, not a final percentage.
+
+    ```json
+    {"type":"validating","verified":120,"total":512}
+    ```
+
+  - `committing`: the shard is being durably written. `stage` identifies the sub-step, so a stalled commit points at the responsible system:
+    - `uploading`: uploading the shard object to S3.
+    - `syncing`: registering the shard in DynamoDB (file ids, global dedup, shard list).
+
+    ```json
+    {"type":"committing","stage":"uploading"}
+    ```
+
+  - `result`: terminal success. `result` carries the same [`UploadShardResponse`](./api#4-upload-shard) semantics (`0`: the shard already exists, `1`: the shard was registered) and, as with `/v1/shards`, the value carries no further meaning: a `result` event means the upload succeeded.
+
+    ```json
+    {"type":"result","result":1}
+    ```
+
+  - `error`: terminal failure with a sanitized message. Because the status is already `200 OK`, this event is the only failure signal once streaming has started.
+
+    ```json
+    {"type":"error","message":"..."}
+    ```
+
+A typical successful stream:
+
+```txt
+{"type":"validating","verified":0,"total":512}
+{"type":"validating","verified":256,"total":512}
+{"type":"committing","stage":"uploading"}
+{"type":"committing","stage":"syncing"}
+{"type":"result","result":1}
+```
+
+If validation stalls (for example on a slow xorb-metadata fetch), the server re-emits the last progress event as a heartbeat after roughly 20 seconds of silence so the connection stays alive.
+
+- **Compatibility**: Additive. `/v1/shards` is unchanged. Clients SHOULD try `/v2/shards` and fall back to `/v1/shards` on `404 Not Found`.
+- **Error Responses**: A malformed or unauthorized request can still fail before streaming starts; see [Error Cases](./api#error-cases). Once the stream has started (`200 OK`), validation and registration failures are reported through the terminal `error` event instead.
+  - `401 Unauthorized`: Refresh the token to continue making requests, or provide a token in the `Authorization` header.
+  - `403 Forbidden`: Token provided but does not have a wide enough scope (for example, a `read` token was provided).
+
+```txt
+POST /v2/shards
+-H "Authorization: Bearer <token>"
+```
+
+### 6. Batch File Reconstruction
 
 - **Description**: Retrieves reconstruction information for multiple files in a single request, avoiding N separate calls.
 - **Path**: `/v1/reconstructions`
@@ -215,7 +278,7 @@ POST /v1/reconstructions
 -H "Content-Type: application/json"
 ```
 
-### 6. Head Xorb
+### 7. Head Xorb
 
 - **Description**: Existence check for a Xorb. Returns no body; the `Content-Length` response header carries the stored Xorb size in bytes.
 - **Path**: `/v1/xorbs/{prefix}/{hash}`
@@ -238,7 +301,7 @@ HEAD /v1/xorbs/default/0123456789abcdef0123456789abcdef0123456789abcdef012345678
 -H "Authorization: Bearer <token>"
 ```
 
-### 7. Head File
+### 8. Head File
 
 - **Description**: Existence check for a file. Returns no body; the `Content-Length` response header carries the full file size in bytes.
 - **Path**: `/v1/files/{file_id}`
@@ -260,7 +323,7 @@ HEAD /v1/files/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 -H "Authorization: Bearer <token>"
 ```
 
-### 8. Get File Chunk Hashes
+### 9. Get File Chunk Hashes
 
 - **Description**: For a file and a set of "dirty" byte ranges (regions the client intends to re-chunk), returns the chunk windows the client must re-chunk plus opaque hash subtrees covering the unchanged gaps. Used by delta uploads to compose a new shard without re-uploading already-known chunks. The response covers the full file; see the field notes below for how windows, gaps, and verification hashes fit together.
 - **Path**: `/v2/file-chunk-hashes/{file_id}`
@@ -307,7 +370,7 @@ GET /v2/file-chunk-hashes/0123456789abcdef0123456789abcdef0123456789abcdef012345
 -H "X-Range-Dirty: bytes=0-65535,200000-299999"
 ```
 
-### 9. Get File Reconstruction (v1)
+### 10. Get File Reconstruction (v1)
 
 > [!WARNING]
 > **Deprecated.** Use [`GET /v2/reconstructions/{file_id}`](./api#1-get-file-reconstruction) instead. This v1 endpoint is still served for existing clients but will be removed once they migrate. The v2 endpoint returns the multi-range optimized response described in section 1.

--- a/docs/xet/api.md
+++ b/docs/xet/api.md
@@ -36,6 +36,9 @@ It is: `07060504030201000f0e0d0c0b0a0908171615141312111f1e1d1c1b1a1918`.
 
 ### 1. Get File Reconstruction
 
+> [!NOTE]
+> This v2 endpoint is the recommended default. Because older CAS deployments may not serve `/v2/`, clients SHOULD fall back to the deprecated [`GET /v1/reconstructions/{file_id}`](./api#10-get-file-reconstruction-v1) on a `404` or `501`.
+
 - **Description**: Retrieves reconstruction information for a specific file. Returns URLs optimized for multi-range fetching: multiple byte ranges for the same xorb are combined into a single URL. Supports byte range via the optional `Range` header.
 - **Path**: `/v2/reconstructions/{file_id}`
 - **Method**: `GET`
@@ -356,7 +359,7 @@ See [file hashes](./hashing#file-hashes) and [converting hashes to strings](./ap
   }
   ```
 
-  - `windows`: one entry per dirty range (adjacent dirty ranges that share the same chunk are merged). Bounds are chunk-aligned, expanded outward to fully contain the requested dirty range; the client re-chunks this exact span.
+  - `windows`: one entry per dirty range (adjacent dirty ranges that share the same chunk are merged). Each `dirtyByteRange` is `[start, end)` with an **exclusive** end (note: the `X-Range-Dirty` request header uses inclusive ends). Bounds are chunk-aligned, expanded outward to fully contain the requested dirty range; the client re-chunks this exact span.
   - `hashRanges`: `N + 1` entries for `N` windows — `[before_w0, between_w0_w1, ..., after_wN]`. Each entry is an opaque `MerkleHashSubtree`; pass as-is to the client merge routine. `null` when the gap is empty (for example, a window starts at chunk 0).
   - `gapVerification`: one hash per stable original segment (a segment lying entirely in a gap between dirty windows or before/after them, in segment order). The client wraps each into a `FileVerificationEntry` for the verification section of the composed shard. Empty when every segment overlaps a dirty range.
 

--- a/docs/xet/api.md
+++ b/docs/xet/api.md
@@ -305,6 +305,43 @@ GET /v2/file-chunk-hashes/0123456789abcdef0123456789abcdef0123456789abcdef012345
 -H "X-Range-Dirty: bytes=0-65535,200000-299999"
 ```
 
+### 9. Get File Reconstruction (v1)
+
+> [!WARNING]
+> **Deprecated.** Use [`GET /v2/reconstructions/{file_id}`](./api#1-get-file-reconstruction) instead. This v1 endpoint is still served for existing clients but will be removed once they migrate. The v2 endpoint returns the multi-range optimized response described in section 1.
+
+- **Description**: Retrieves reconstruction information for a specific file, includes byte range support when `Range` header is set. Returns the v1 response shape (`terms` + `fetch_info`).
+- **Path**: `/v1/reconstructions/{file_id}`
+- **Method**: `GET`
+- **Parameters**:
+  - `file_id`: File hash in hex format (64 lowercase hexadecimal characters).
+See [file hashes](./hashing#file-hashes) for computing the file hash and [converting hashes to strings](./api#converting-hashes-to-strings).
+- **Headers**:
+  - `Range`: OPTIONAL. Format: `bytes={start}-{end}` (end is inclusive).
+- **Minimum Token Scope**: `read`
+- **Body**: None.
+- **Response**: JSON (`QueryReconstructionResponse`)
+
+  ```json
+  {
+    "offset_into_first_range": 0,
+    "terms": [...],
+    "fetch_info": {...}
+  }
+  ```
+
+- **Error Responses**: See [Error Cases](./api#error-cases)
+  - `400 Bad Request`: Malformed `file_id` in the path. Fix the path before retrying.
+  - `401 Unauthorized`: Refresh the token to continue making requests, or provide a token in the `Authorization` header.
+  - `404 Not Found`: The file does not exist. Not retryable.
+  - `416 Range Not Satisfiable`: The requested byte range start exceeds the end of the file. Not retryable.
+
+```txt
+GET /v1/reconstructions/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+-H "Authorization: Bearer <token>"
+OPTIONAL: -H Range: "bytes=0-100000"
+```
+
 ## Error Cases
 
 ### Non-Retryable Errors

--- a/docs/xet/api.md
+++ b/docs/xet/api.md
@@ -173,6 +173,138 @@ POST /v1/shards
 
 An example shard request body can be found in [Xet reference files](https://huggingface.co/datasets/xet-team/xet-spec-reference-files/blob/main/Electric_Vehicle_Population_Data_20250917.csv.shard.verification-no-footer).
 
+### 5. Batch File Reconstruction
+
+- **Description**: Retrieves reconstruction information for multiple files in a single request. Useful for clients that need to fetch reconstruction data for a batch of files without issuing N separate requests.
+- **Path**: `/v1/reconstructions`
+- **Method**: `POST`
+- **Headers**:
+  - `Accept-Encoding`: OPTIONAL. The server supports `gzip` and `zstd` compression on the JSON response. Clients SHOULD send `Accept-Encoding: gzip` or `Accept-Encoding: zstd` to reduce response size.
+- **Minimum Token Scope**: `read`
+- **Body**: JSON array of file ids (hex strings, 64 lowercase hexadecimal characters). Duplicate ids are de-duplicated server-side.
+
+  ```json
+  ["0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "..."]
+  ```
+
+- **Response**: JSON (`BatchQueryReconstructionResponse`)
+
+  ```json
+  {
+    "files": {
+      "0123...": [/* CASReconstructionTerm, ... */]
+    },
+    "fetch_info": {
+      "0123...": [/* CASReconstructionFetchInfo, ... */]
+    }
+  }
+  ```
+
+  `files` maps each file id to its reconstruction terms; `fetch_info` is shared across files and keyed by xorb hash. This endpoint returns the v1 response shape; for the multi-range optimized format, call `/v2/reconstructions/{file_id}` per file.
+
+- **Error Responses**: See [Error Cases](./api#error-cases)
+  - `400 Bad Request`: Malformed body or invalid file id in the request.
+  - `401 Unauthorized`: Refresh the token to continue making requests, or provide a token in the `Authorization` header.
+  - `404 Not Found`: One or more files do not exist. Not retryable.
+
+```txt
+POST /v1/reconstructions
+-H "Authorization: Bearer <token>"
+-H "Content-Type: application/json"
+```
+
+### 6. Head Xorb
+
+- **Description**: Existence check for a Xorb. Returns no body; the `Content-Length` response header carries the stored Xorb size in bytes.
+- **Path**: `/v1/xorbs/{prefix}/{hash}`
+- **Method**: `HEAD`
+- **Parameters**:
+  - `prefix`: The only acceptable prefix for Xorbs is `default`.
+  - `hash`: Xorb hash in hex format (64 lowercase hexadecimal characters).
+See [Xorb Hashes](./hashing#xorb-hashes) and [converting hashes to strings](./api#converting-hashes-to-strings).
+- **Minimum Token Scope**: `read`
+- **Body**: None.
+- **Response**: Empty body. Response headers:
+  - `Content-Length`: size in bytes of the stored Xorb.
+- **Error Responses**: See [Error Cases](./api#error-cases)
+  - `400 Bad Request`: Malformed hash in the path.
+  - `401 Unauthorized`: Refresh the token to continue making requests, or provide a token in the `Authorization` header.
+  - `404 Not Found`: The Xorb does not exist. Not retryable.
+
+```txt
+HEAD /v1/xorbs/default/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+-H "Authorization: Bearer <token>"
+```
+
+### 7. Head File
+
+- **Description**: Existence check for a file. Returns no body; the `Content-Length` response header carries the full file size in bytes.
+- **Path**: `/v1/files/{file_id}`
+- **Method**: `HEAD`
+- **Parameters**:
+  - `file_id`: File hash in hex format (64 lowercase hexadecimal characters).
+See [file hashes](./hashing#file-hashes) and [converting hashes to strings](./api#converting-hashes-to-strings).
+- **Minimum Token Scope**: `read`
+- **Body**: None.
+- **Response**: Empty body. Response headers:
+  - `Content-Length`: size in bytes of the full file.
+- **Error Responses**: See [Error Cases](./api#error-cases)
+  - `400 Bad Request`: Malformed `file_id` in the path.
+  - `401 Unauthorized`: Refresh the token to continue making requests, or provide a token in the `Authorization` header.
+  - `404 Not Found`: The file does not exist. Not retryable.
+
+```txt
+HEAD /v1/files/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+-H "Authorization: Bearer <token>"
+```
+
+### 8. Get File Chunk Hashes
+
+- **Description**: For a file and a set of "dirty" byte ranges (regions the client intends to re-chunk), returns the chunk windows the client must re-chunk plus opaque hash subtrees that cover the unchanged gaps. Used by delta uploads to compose a new shard without re-uploading already-known chunks. The response covers the full file: gaps between dirty windows are summarized as `MerkleHashSubtree` entries; each stable segment outside any dirty range also gets a verification hash.
+- **Path**: `/v2/file-chunk-hashes/{file_id}`
+- **Method**: `GET`
+- **Parameters**:
+  - `file_id`: File hash in hex format (64 lowercase hexadecimal characters).
+See [file hashes](./hashing#file-hashes) and [converting hashes to strings](./api#converting-hashes-to-strings).
+- **Headers**:
+  - `X-Range-Dirty`: REQUIRED. One or more byte ranges using the standard `bytes=` syntax (inclusive ends, comma-separated), e.g. `bytes=0-1023,5000-9999`. Ranges are sorted and merged server-side. At least one range MUST be present.
+  - `Accept-Encoding`: OPTIONAL. The server supports `gzip` and `zstd` compression on the JSON response.
+- **Minimum Token Scope**: `read`
+- **Body**: None.
+- **Response**: JSON (`FileChunkHashesResponse`)
+
+  ```json
+  {
+    "totalChunks": 1234,
+    "fileSize": 9876543,
+    "windows": [
+      { "dirtyByteRange": [0, 65536] }
+    ],
+    "hashRanges": [
+      null,
+      "<opaque MerkleHashSubtree>"
+    ],
+    "gapVerification": [
+      "<hex MerkleHash>"
+    ]
+  }
+  ```
+
+  - `windows`: one entry per dirty range (adjacent dirty ranges that share the same chunk are merged). Bounds are chunk-aligned, expanded outward to fully contain the requested dirty range; the client re-chunks this exact span.
+  - `hashRanges`: `N + 1` entries for `N` windows — `[before_w0, between_w0_w1, ..., after_wN]`. Each entry is an opaque `MerkleHashSubtree`; pass as-is to the client merge routine. `null` when the gap is empty (for example, a window starts at chunk 0).
+  - `gapVerification`: one hash per stable original segment (a segment lying entirely in a gap between dirty windows or before/after them, in segment order). The client wraps each into a `FileVerificationEntry` for the verification section of the composed shard. Empty when every segment overlaps a dirty range.
+
+- **Error Responses**: See [Error Cases](./api#error-cases)
+  - `400 Bad Request`: Missing or malformed `X-Range-Dirty` header, malformed `file_id`, or no range survives clamping to the file.
+  - `401 Unauthorized`: Refresh the token to continue making requests, or provide a token in the `Authorization` header.
+  - `404 Not Found`: The file does not exist. Not retryable.
+
+```txt
+GET /v2/file-chunk-hashes/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+-H "Authorization: Bearer <token>"
+-H "X-Range-Dirty: bytes=0-65535,200000-299999"
+```
+
 ## Error Cases
 
 ### Non-Retryable Errors

--- a/docs/xet/api.md
+++ b/docs/xet/api.md
@@ -181,10 +181,12 @@ An example shard request body can be found in [Xet reference files](https://hugg
 - **Headers**:
   - `Accept-Encoding`: OPTIONAL. The server supports `gzip` and `zstd` compression on the JSON response. Clients SHOULD send `Accept-Encoding: gzip` or `Accept-Encoding: zstd` to reduce response size.
 - **Minimum Token Scope**: `read`
-- **Body**: JSON array of file ids (hex strings, 64 lowercase hexadecimal characters). Duplicate ids are de-duplicated server-side.
+- **Body**: JSON array of keys, each a `{ "prefix", "hash" }` object. `prefix` is `default`; `hash` is the file hash in hex format (64 lowercase hexadecimal characters). Duplicate keys are de-duplicated server-side.
 
   ```json
-  ["0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "..."]
+  [
+    { "prefix": "default", "hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" }
+  ]
   ```
 
 - **Response**: JSON (`BatchQueryReconstructionResponse`)

--- a/docs/xet/api.md
+++ b/docs/xet/api.md
@@ -175,8 +175,7 @@ An example shard request body can be found in [Xet reference files](https://hugg
 
 ### 5. Streaming Shard Upload
 
-- **Description**: Runs the exact same validation and registration as [Upload Shard](./api#4-upload-shard), but streams finalization progress back as newline-delimited JSON so clients can show real progress instead of a bar frozen at 100%.
-Large or heavily-deduplicated shards can take several seconds to finalize: the server verifies every file reconstruction entry against its xorb metadata, and a cache miss there is an S3 fetch.
+- **Description**: Runs the same validation and registration as [Upload Shard](./api#4-upload-shard), but streams finalization progress back as newline-delimited JSON so clients can show real progress on large shards, which can take several seconds to finalize server-side.
 - **Path**: `/v2/shards`
 - **Method**: `POST`
 - **Minimum Token Scope**: `write`
@@ -194,15 +193,15 @@ Each event has a `type` field:
     {"type":"validating","verified":120,"total":512}
     ```
 
-  - `committing`: the shard is being durably written. `stage` identifies the sub-step, so a stalled commit points at the responsible system:
-    - `uploading`: uploading the shard object to S3.
-    - `syncing`: registering the shard in DynamoDB (file ids, global dedup, shard list).
+  - `committing`: the shard is being durably written. `stage` identifies the sub-step, so a stalled commit shows where it is stuck:
+    - `uploading`: persisting the shard object to storage.
+    - `syncing`: registering the shard (file ids, global dedup, shard list).
 
     ```json
     {"type":"committing","stage":"uploading"}
     ```
 
-  - `result`: terminal success. `result` carries the same [`UploadShardResponse`](./api#4-upload-shard) semantics (`0`: the shard already exists, `1`: the shard was registered) and, as with `/v1/shards`, the value carries no further meaning: a `result` event means the upload succeeded.
+  - `result`: terminal success. Carries the same [`UploadShardResponse`](./api#4-upload-shard) values (`0`: already existed, `1`: registered); as with `/v1/shards` the value is informational, a `result` event means the upload succeeded.
 
     ```json
     {"type":"result","result":1}
@@ -224,9 +223,11 @@ A typical successful stream:
 {"type":"result","result":1}
 ```
 
-If validation stalls (for example on a slow xorb-metadata fetch), the server re-emits the last progress event as a heartbeat after roughly 20 seconds of silence so the connection stays alive.
+If validation stalls, the server periodically re-emits the last progress event as a heartbeat so the stream never looks dead, which lets clients keep a short read timeout.
 
-- **Compatibility**: Additive. `/v1/shards` is unchanged. Clients SHOULD try `/v2/shards` and fall back to `/v1/shards` on `404 Not Found`.
+> [!NOTE]
+> Additive change: `/v1/shards` is unchanged. Clients SHOULD try `/v2/shards` and fall back to `/v1/shards` on `404 Not Found`.
+
 - **Error Responses**: A malformed or unauthorized request can still fail before streaming starts; see [Error Cases](./api#error-cases). Once the stream has started (`200 OK`), validation and registration failures are reported through the terminal `error` event instead.
   - `401 Unauthorized`: Refresh the token to continue making requests, or provide a token in the `Authorization` header.
   - `403 Forbidden`: Token provided but does not have a wide enough scope (for example, a `read` token was provided).
@@ -280,7 +281,7 @@ POST /v1/reconstructions
 
 ### 7. Head Xorb
 
-- **Description**: Existence check for a Xorb. Returns no body; the `Content-Length` response header carries the stored Xorb size in bytes.
+- **Description**: Existence check for a Xorb.
 - **Path**: `/v1/xorbs/{prefix}/{hash}`
 - **Method**: `HEAD`
 - **Parameters**:
@@ -303,7 +304,7 @@ HEAD /v1/xorbs/default/0123456789abcdef0123456789abcdef0123456789abcdef012345678
 
 ### 8. Head File
 
-- **Description**: Existence check for a file. Returns no body; the `Content-Length` response header carries the full file size in bytes.
+- **Description**: Existence check for a file.
 - **Path**: `/v1/files/{file_id}`
 - **Method**: `HEAD`
 - **Parameters**:
@@ -325,7 +326,7 @@ HEAD /v1/files/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 
 ### 9. Get File Chunk Hashes
 
-- **Description**: For a file and a set of "dirty" byte ranges (regions the client intends to re-chunk), returns the chunk windows the client must re-chunk plus opaque hash subtrees covering the unchanged gaps. Used by delta uploads to compose a new shard without re-uploading already-known chunks. The response covers the full file; see the field notes below for how windows, gaps, and verification hashes fit together.
+- **Description**: For a file and a set of "dirty" byte ranges (regions the client intends to re-chunk), returns the chunk windows the client must re-chunk plus opaque hash subtrees covering the unchanged gaps. Used by delta uploads to compose a new shard without re-uploading already-known chunks. The response covers the full file.
 - **Path**: `/v2/file-chunk-hashes/{file_id}`
 - **Method**: `GET`
 - **Parameters**:
@@ -336,7 +337,7 @@ See [file hashes](./hashing#file-hashes) and [converting hashes to strings](./ap
   - `Accept-Encoding`: OPTIONAL. The server supports `gzip` and `zstd` compression on the JSON response.
 - **Minimum Token Scope**: `read`
 - **Body**: None.
-- **Response**: JSON (`FileChunkHashesResponse`)
+- **Response**: JSON (`FileChunkHashesResponse`). Unlike other endpoints in this spec, this response uses `camelCase` field names, matching the server.
 
   ```json
   {

--- a/docs/xet/download-protocol.md
+++ b/docs/xet/download-protocol.md
@@ -40,20 +40,17 @@ The reconstruction API returns a `QueryReconstructionResponse` object with three
     },
     ...
   ],
-  "fetch_info": {
+  "xorbs": {
     "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456": [
       {
-        "range": {
-          "start": 0,
-          "end": 4
-        },
-        "url": "https://transfer.xethub.hf.co/xorb/default/a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456",
-        "url_range": {
-          "start": 0,
-          "end": 131071
-        }
-      },
-      ...
+        "url": "https://transfer.xethub.hf.co/xorb/default/a1b2c3d4...?<signed-params>",
+        "ranges": [
+          {
+            "chunks": { "start": 0, "end": 4 },
+            "bytes": { "start": 0, "end": 131071 }
+          }
+        ]
+      }
     ],
     ...
   }
@@ -75,146 +72,117 @@ The reconstruction API returns a `QueryReconstructionResponse` object with three
 - Ordered list of reconstruction terms describing what chunks to download from which xorb
 - Each `CASReconstructionTerm` contains:
   - `hash`: The xorb hash (64-character lowercase hex string)
-  - `range`: Chunk index range`{ start: number, end: number }` within the xorb; end-exclusive `[start, end)`
+  - `range`: Chunk index range `{ start: number, end: number }` within the xorb; end-exclusive `[start, end)`
   - `unpacked_length`: Expected length after decompression (for validation)
 
-#### fetch_info
+#### xorbs
 
-- Type: `Map<Xorb Hash (64 character lowercase hex string), Array<CASReconstructionFetchInfo>>`
-- Maps xorb hashes to required information to download some of their chunks.
-  - The mapping is to an array of 1 or more `CASReconstructionFetchInfo`
-- Each `CASReconstructionFetchInfo` contains:
-  - `url`: HTTP URL for downloading the xorb data, presigned URL containing authorization information
-  - `url_range` (bytes_start, bytes_end): Byte range `{ start: number, end: number }` for the Range header; end-inclusive `[start, end]`
-    - The `Range` header MUST be set as `Range: bytes=<start>-<end>` when downloading this chunk range
-  - `range` (index_start, index_end): Chunk index range `{ start: number, end: number }` that this URL provides; end-exclusive `[start, end)`
-    - This range indicates which range of chunk indices within this xorb that this fetch info term is describing
+- Type: `Map<Xorb Hash (64 character lowercase hex string), Array<XorbMultiRangeFetch>>`
+- Maps xorb hashes to a list of multi-range fetch entries.
+- Typically 1 entry per xorb. Multiple entries only when the URL would exceed the URL length limit.
+- Each `XorbMultiRangeFetch` contains:
+  - `url`: Signed URL with all byte ranges encoded. The client MUST send exactly the signed range value as the `Range` header.
+  - `ranges`: Array of `XorbRangeDescriptor`, sorted by chunk start. Each descriptor contains:
+    - `chunks`: Chunk index range `{ start: number, end: number }`; end-exclusive `[start, end)`
+    - `bytes`: Physical byte range `{ start: number, end: number }` for the HTTP Range header; end-inclusive `[start, end]`
+
+> [!IMPORTANT]
+> The URL encodes the exact set of byte ranges that MUST be requested. Requesting individual sub-ranges separately will result in an authorization failure. The client MUST send all ranges from a single `XorbMultiRangeFetch` entry in a single request.
 
 ## Stage 3: Downloading and Reconstructing the File
 
 ### Process Overview
 
-1. Process each `CASReconstructionTerm` in order from the `terms` array
-2. For each `CASReconstructionTerm`, find matching fetch info using the term's hash
+1. For each entry in the `xorbs` map, download xorb data using multi-range HTTP requests
+2. Process each `CASReconstructionTerm` in order from the `terms` array, using the downloaded chunk data
+3. (for the first term only) skip `offset_into_first_range` bytes
+4. Concatenate the results in term order to reconstruct the file
 
-    1. get the list of fetch_info items under the xorb hash from the `CASReconstructionTerm`. The xorb hash is guaranteed to exist as a key in the fetch_info map.
-    2. linearly iterate through the list of `CASReconstructionFetchInfo` and find one which refers to a chunk range that is equal or encompassing the term's chunk range.
-        - Such a fetch_info item is guaranteed to exist. If none exist the server is at fault.
-3. Download the required data using HTTP `GET` request and MUST set the `Range` header
-4. Deserialize the downloaded xorb data to extract chunks
-
-    1. This series of chunks contains chunks at indices specified by the `CASReconstructionFetchInfo`'s `range` field. Trim chunks at the beginning or end to match the chunks specified by the reconstruction term's `range` field.
-    2. (for the first term only) skip `offset_into_first_range` bytes
-5. Concatenate the results in term order to reconstruct the file
+> [!TIP]
+> Clients MAY interleave downloading and processing to reduce memory usage, as long as terms are assembled in order. It is not necessary to download all xorb data before processing terms.
 
 ### Detailed Download Process
 
-#### Download Reconstruction
+#### Step 1: Download Reconstruction
 
-- use the reconstruction api to download the reconstruction object for a given file
+Use the reconstruction API to download the reconstruction object for a given file.
 
 ```python
 file_id = "0123...abcdef"
 api_endpoint, token = get_token() # follow auth instructions
-url = api_endpoint + "/reconstructions/" + file_id
-reconstruction = get(url, headers={"Authorization": "Bearer: " + token})
+url = api_endpoint + "/v2/reconstructions/" + file_id
+reconstruction = get(url, headers={"Authorization": "Bearer " + token})
 
 # break the reconstruction into components
 terms = reconstruction["terms"]
-fetch_info = reconstruction["fetch_info"]
+xorbs = reconstruction["xorbs"]
 offset_into_first_range = reconstruction["offset_into_first_range"]
-```
-
-#### Match Terms to Fetch Info
-
-For each `CASReconstructionTerm` in the `terms` array:
-
-- Look up the term's `hash` in the `fetch_info` map to get a list of `CASReconstructionFetchInfo`
-- Find a `CASReconstructionFetchInfo` entry where the fetch info's `range` contains the term's `range`
-  - linearly search through the array of `CASReconstructionFetchInfo` and find the element where the range block (`{ "start": number, "end": number }`) of the `CASReconstructionFetchInfo` has start <= term's range start AND end >= term's range end.
-  - The server is meant to guarantee a match, if there isn't a match this download is considered failed and the server made an error.
-
-```python
-for term in terms:
-  xorb_hash = term["hash"]
-  fetch_info_entries = fetch_info[xorb_hash]
-  fetch_info_entry = None
-  for entry in fetch_info_entries:
-    if entry["range"][start] <= term["range"]["start"] and entry["range"]["end"] >= term["range"]["end"]:
-      fetch_info_entry = entry
-      break
-  if fetch_info_entry is None:
-    # Error!
 ```
 
 #### Step 2: Download Xorb Data
 
-For each matched fetch info:
+For each xorb, for each fetch entry, send a single multi-range HTTP GET request:
 
-1. Make an HTTP GET request to the `url` in the fetch info entry
-2. Include a `Range` header: `bytes={url_range.start}-{url_range.end}`
-
-```python
-for term in terms:
-  ...
-  data_url = fetch_info_entry["url"]
-  range_header = "bytes=" + fetch_info_entry["url_range"]["start"] + "-" + fetch_info_entry["url_range"]["end"]
-  data = get(data_url, headers={"Range": range_header})
-```
-
-#### Deserialize Downloaded Data
-
-The downloaded data is in xorb format and MUST be deserialized:
-
-1. **Parse xorb structure**: The data contains compressed chunks with headers
-2. **Decompress chunks**: Each chunk has a header followed by compressed data
-3. **Extract byte indices**: Track byte boundaries between chunks for range extraction
-4. **Validate length**: Decompressed length MUST match `unpacked_length` from the term
-
-**Note**: The deserialization process depends on the [Xorb format](./xorb).
+1. Build the `Range` header from all `bytes` ranges: `Range: bytes=0-131071,500000-600000`
+2. Send a single HTTP `GET` request to the `url` with this `Range` header
+3. If there is a single range, the response is a `206 Partial Content` with the xorb data directly
+4. If there are multiple ranges, the response is a `206 Partial Content` with `Content-Type: multipart/byteranges`. Parse each part to get the xorb data for each range.
+5. Deserialize each part as xorb data to extract chunks
 
 ```python
-for term in terms:
-  ...
-  chunks = {}
-  for i in range(fetch_info_entry["range"]["start"], fetch_info_entry["range"]["end"]):
-    chunk = deserialize_chunk(data) # assume data is a reader that advances forwards
-    chunks[i] = chunk
-  # at this point data should be fully consumed
+# Download all xorb data upfront
+downloaded_chunks = {}  # (xorb_hash, chunk_index) -> chunk_data
+
+for xorb_hash, fetch_entries in xorbs.items():
+  for fetch_entry in fetch_entries:
+    url = fetch_entry["url"]
+    ranges = fetch_entry["ranges"]
+
+    # Build multi-range header
+    range_parts = [f'{r["bytes"]["start"]}-{r["bytes"]["end"]}' for r in ranges]
+    range_header = "bytes=" + ",".join(range_parts)
+
+    response = get(url, headers={"Range": range_header})
+
+    # Parse response (multipart/byteranges if multiple ranges)
+    parts = parse_multipart_response(response) if len(ranges) > 1 else [response.content]
+
+    for part, range_desc in zip(parts, ranges):
+      # Deserialize xorb data to extract chunks
+      for i in range(range_desc["chunks"]["start"], range_desc["chunks"]["end"]):
+        chunk = deserialize_chunk(part)
+        downloaded_chunks[(xorb_hash, i)] = chunk
 ```
 
-#### Step 4: Extract Term Data
+#### Step 3: Extract Term Data and Reconstruct
 
-From the deserialized xorb data:
-
-1. Use the term's `range` to identify which chunks are needed
-2. Extract only the chunks specified by `range.start` to `range.end-1` (end-exclusive)
-3. Apply any range offsets if processing a partial file download
+Process the `terms` array in order, using the downloaded chunk data:
 
 ```python
 file_chunks = []
 for term in terms:
-  ...
+  xorb_hash = term["hash"]
   for i in range(term["range"]["start"], term["range"]["end"]):
-    chunk = chunks[i]
-    # it is possible that the offset captures multiple chunks, so we may need to skip whole chunks
+    chunk = downloaded_chunks[(xorb_hash, i)]
+
+    # skip offset_into_first_range bytes from the beginning
     if offset_into_first_range > len(chunk):
       offset_into_first_range -= len(chunk)
       continue
-    if offset_info_first_range > 0:
+    if offset_into_first_range > 0:
       chunk = chunk[offset_into_first_range:]
-      offset_info_first_range = 0
-    
-    file_chunks.push(chunk)
+      offset_into_first_range = 0
+
+    file_chunks.append(chunk)
 ```
 
-#### Step 5: Stitch Results Together
+#### Step 4: Stitch Results Together
 
 Write all of the chunks to the output file or buffer.
 
 If a range was specified then the total data will need to be truncated to the amount of bytes requested.
 When a range is specified but the range does not end on a chunk boundary the last byte of the requested range will be in the middle of the last chunk.
-A client knows the start of the data from `offset_into_first_range` and can then use the length of the specified range to know end end offset.
+A client knows the start of the data from `offset_into_first_range` and can then use the length of the specified range to know the end offset.
 
 ```python
 with open(file_path) as f:
@@ -226,23 +194,19 @@ with open(file_path) as f:
 
 For partial file downloads, the reconstruction API supports range queries:
 
-- Include `Range: bytes=start-end` header in reconstruction request
+- Include `Range: bytes=start-end` header in the reconstruction request
 - The `offset_into_first_range` field indicates where your range starts within the first term
 - The end of the content will need to be truncated to fit the requested range.
   - Except if the requested range exceeds the total file length, then the returned content will be shorter and no truncation is necessary.
 
-When downloading individual term data:
+When downloading xorb data:
 
-A client MUST include the `Range` header formed with the values from the `url_range` field to specify the exact range of data of a xorb that they are accessing. Not specifying this header will cause result in an authorization failure.
-
-Xet global deduplication requires that access to xorbs is only granted to authorized ranges.
-Not specifying this header will result in an authorization failure.
+A client MUST include the `Range` header formed with the byte range values from the `XorbMultiRangeFetch` entry. The signed URL authorizes access only to the specific ranges listed. Not specifying the correct `Range` header will result in an authorization failure.
 
 ## Performance Considerations
 
-- **Range coalescing**: Multiple terms may share the same fetch info for efficiency, so a single fetch info may be larger than any 1 term and could be used to fulfil multiple terms.
-Consider downloading such content only once and reusing the data.
-- **Parallel downloads**: Terms can be downloaded in parallel, but MUST be assembled in order
+- **Fewer HTTP requests**: Multiple byte ranges for the same xorb are combined into a single URL, allowing one HTTP request per xorb instead of one per chunk range
+- **Parallel downloads**: Xorb data can be downloaded in parallel, but terms MUST be assembled in order
   - On file systems with fast seeking, it MAY be advantageous to open the output file in different threads and writing contents at different offsets
 - **Caching**: Clients SHOULD consider caching downloaded xorb ranges to avoid redundant requests
 - **Retry logic**: Implement exponential backoff for transient failures
@@ -250,15 +214,15 @@ Consider downloading such content only once and reusing the data.
 ### Caching recommendations
 
 1. It can be ineffective to cache the reconstruction object
-    1. The fetch_info section provides short-expiration pre-signed URL's hence Clients SHOULD NOT cache the urls beyond their short expiration
-    2. To get those URL's to access the data you will need to call the reconstruction API again anyway
+    1. The xorbs section provides short-expiration pre-signed URLs hence clients SHOULD NOT cache the URLs beyond their short expiration
+    2. To get those URLs to access the data you will need to call the reconstruction API again anyway
 2. Cache chunks by range not just individually
     1. If you need a chunk from a xorb it is very likely that you will need another, so cache them close
 3. Caching helps when downloading similar contents. May not be worth to cache data if you are always downloading different things
 
 ## More complex QueryReconstruction Example
 
-Here's an example of a serialized `QueryReconstructionResponse` struct that shows how file reconstruction would work across multiple xorbs:
+Here's an example of a `QueryReconstructionResponse` that shows how file reconstruction works across multiple xorbs:
 
 ```json
 {
@@ -287,33 +251,29 @@ Here's an example of a serialized `QueryReconstructionResponse` struct that show
         "start": 3,
         "end": 43
       }
-    },
+    }
   ],
-  "fetch_info": {
+  "xorbs": {
     "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456": [
       {
-        "range": {
-          "start": 1,
-          "end": 43
-        },
-        "url": "https://transfer.xethub.hf.co/xorb/default/a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130721%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130721T201207Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=d6796aa6097c82ba7e33b4725e8396f8a9638f7c3d4b5a6b7c8d9e0f1a2b3c4d",
-        "url_range": {
-          "start": 57980,
-          "end": 1433008
-        }
+        "url": "https://transfer.xethub.hf.co/xorb/default/a1b2c3d4...?<signed-params>",
+        "ranges": [
+          {
+            "chunks": { "start": 1, "end": 43 },
+            "bytes": { "start": 57980, "end": 1433008 }
+          }
+        ]
       }
     ],
     "fedcba0987654321098765432109876543210fedcba098765432109876543": [
       {
-        "range": {
-          "start": 0,
-          "end": 3
-        },
-        "url": "https://transfer.xethub.hf.co/xorb/default/fedcba0987654321098765432109876543210fedcba098765432109876543?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130721%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130721T201207Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=d6796aa6097c82ba7e33b4725e8396f8a9638f7c3d4b5a6b7c8d9e0f1a2b3c4d",
-        "url_range": {
-          "start": 0,
-          "end": 65670
-        }
+        "url": "https://transfer.xethub.hf.co/xorb/default/fedcba09...?<signed-params>",
+        "ranges": [
+          {
+            "chunks": { "start": 0, "end": 3 },
+            "bytes": { "start": 0, "end": 65670 }
+          }
+        ]
       }
     ]
   }
@@ -323,16 +283,16 @@ Here's an example of a serialized `QueryReconstructionResponse` struct that show
 This example shows reconstruction of a file that requires:
 
 - Chunks `[1, 4)` from the first xorb (~264KB of unpacked data)
-- Chunks `[0, 2)` from the second xorb (~144KB of unpacked data)
-- Chunks `[3, 43)` from the same xorb from the first term (~3MB of unpacked data)
+- Chunks `[0, 3)` from the second xorb (~144KB of unpacked data)
+- Chunks `[3, 43)` from the first xorb again (~3MB of unpacked data)
 
-The `fetch_info` provides the HTTP URLs and byte ranges needed to download the required chunk data from each xorb. The ranges provided within `fetch_info` and term sections are always end-exclusive i.e. `{ "start": 0, "end": 3 }` is a range of 3 chunks at indices 0, 1 and 2.
-The ranges provided under a `fetch_info` items' `url_range` key are to be used to form the `Range` header when downloading the chunk range.
-A `"url_range"` value of `{ "start": X, "end": Y }` creates a `Range` header value of `bytes=X-Y`.
+The `xorbs` map provides signed URLs and byte ranges needed to download the chunk data from each xorb. The `chunks` ranges are always end-exclusive i.e. `{ "start": 0, "end": 3 }` is a range of 3 chunks at indices 0, 1 and 2.
+The `bytes` ranges are end-inclusive and used to form the `Range` header when downloading.
+A `"bytes"` value of `{ "start": X, "end": Y }` creates a `Range` header value of `bytes=X-Y`.
 
-When downloading and deserializing the chunks from xorb `a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456` we will have the chunks at indices `[1, 43)`.
-We will need to only use the chunks at `[1, 4)` to fulfill the first term and then chunks `[3, 43)` to fulfill the third term.
-Note that in this example the chunk at index 3 is used twice! This is the benefit of deduplication; we only need to download the chunk content once.
+When downloading and deserializing the chunks from xorb `a1b2c3d4...` we get chunks at indices `[1, 43)`.
+We use chunks `[1, 4)` to fulfill the first term, then chunks `[3, 43)` to fulfill the third term.
+Note that chunk at index 3 is used twice! This is the benefit of deduplication; we only need to download the chunk content once.
 
 ## Diagram
 
@@ -343,17 +303,19 @@ sequenceDiagram
   participant S as CAS API
   participant Transfer as Transfer Service (Xet storage)
 
-  client->>S: GET /reconstructions/{file_id}<br/>Authorization: Bearer <token><br/>Range: bytes=start-end (optional)
-  S-->>client: 200 OK<br/>QueryReconstructionResponse {offset_into_first_range, terms[], fetch_info{}}
+  client->>S: GET /v2/reconstructions/{file_id}<br/>Authorization: Bearer <token><br/>Range: bytes=start-end (optional)
+  S-->>client: 200 OK<br/>QueryReconstructionResponse {offset_into_first_range, terms[], xorbs{}}
 
-  loop For each term in terms (ordered)
-    client->>client: Find fetch_info by xorb hash, entry whose range contains term.range
-    client->>Transfer: GET {url}<br/>Range: bytes=url_range.start-url_range.end
-    Transfer-->>client: 206 Partial Content<br/>xorb byte range
-    client->>client: Deserialize xorb → chunks for fetch_info.range
-    client->>client: Trim to term.range, apply offset for first term
-    client->>client: Append chunks to output
+  loop For each xorb in xorbs
+    loop For each fetch entry
+      client->>Transfer: GET {url}<br/>Range: bytes=r1_start-r1_end,r2_start-r2_end,...
+      Transfer-->>client: 206 Partial Content<br/>multipart/byteranges
+      client->>client: Parse multipart, deserialize xorb parts into chunks
+    end
   end
+
+  client->>client: Process terms in order using downloaded chunks
+  client->>client: Apply offset_into_first_range, concatenate output
 
   alt Range requested
     client->>client: Truncate output to requested length

--- a/docs/xet/download-protocol.md
+++ b/docs/xet/download-protocol.md
@@ -82,7 +82,7 @@ This example describes a small file made of a single term: chunks `[0, 4)` from 
 - Typically 1 entry per xorb. Multiple entries only when the URL would exceed the URL length limit.
 - Each `XorbMultiRangeFetch` contains:
   - `url`: Signed URL with all byte ranges encoded in the query string: `X-Xet-Signed-Range` (URL-encoded, e.g. `bytes%3D0-131071`) plus the CDN signature parameters (`Expires`, `Policy`, `Signature`, `Key-Pair-Id`). These are short-lived; do not cache or rewrite them.
-  - `ranges`: Array of `XorbRangeDescriptor`, sorted by chunk start. Each descriptor contains:
+  - `ranges`: Array of `XorbRangeDescriptor`, ordered by ascending `chunks.start` (equivalently ascending `bytes.start`, since chunks are laid out sequentially within a xorb). Each descriptor contains:
     - `chunks`: Chunk index range `{ start: number, end: number }`; end-exclusive `[start, end)`
     - `bytes`: Physical byte range `{ start: number, end: number }` for the HTTP Range header; end-inclusive `[start, end]`
 
@@ -123,7 +123,7 @@ offset_into_first_range = reconstruction["offset_into_first_range"]
 
 For each xorb, for each fetch entry, send a single multi-range HTTP GET request:
 
-1. Build the `Range` header from all `bytes` ranges: `Range: bytes=0-131071,500000-600000`
+1. Build the `Range` header from the `bytes` ranges in the order given (ascending start), matching the `X-Xet-Signed-Range` value: `Range: bytes=0-131071,500000-600000`
 2. Send a single HTTP `GET` request to the `url` with this `Range` header
 3. If there is a single range, the response is a `206 Partial Content` with the xorb data directly
 4. If there are multiple ranges, the response is a `206 Partial Content` with `Content-Type: multipart/byteranges`. Parse each part to get the xorb data for each range.

--- a/docs/xet/download-protocol.md
+++ b/docs/xet/download-protocol.md
@@ -148,23 +148,28 @@ for xorb_hash, fetch_entries in xorbs.items():
     parts = parse_multipart_response(response) if len(ranges) > 1 else [response.content]
 
     for part, range_desc in zip(parts, ranges):
-      # Deserialize xorb data to extract chunks
+      # `part` is a reader over the xorb bytes that advances forwards on each read
       for i in range(range_desc["chunks"]["start"], range_desc["chunks"]["end"]):
-        chunk = deserialize_chunk(part)
+        chunk = deserialize_chunk(part)  # advances `part` past this chunk
         downloaded_chunks[(xorb_hash, i)] = chunk
+      # at this point `part` should be fully consumed
 ```
 
 #### Step 3: Extract Term Data and Reconstruct
 
-Process the `terms` array in order, using the downloaded chunk data:
+Process the `terms` array in order, using the downloaded chunk data. For each term, the combined decompressed length of its chunks MUST match the term's `unpacked_length`; reject the reconstruction otherwise (it indicates truncated or corrupt xorb data).
 
 ```python
 file_chunks = []
 for term in terms:
   xorb_hash = term["hash"]
-  for i in range(term["range"]["start"], term["range"]["end"]):
-    chunk = downloaded_chunks[(xorb_hash, i)]
+  term_chunks = [downloaded_chunks[(xorb_hash, i)]
+                 for i in range(term["range"]["start"], term["range"]["end"])]
 
+  # Validate: decompressed length MUST match unpacked_length from the term
+  assert sum(len(chunk) for chunk in term_chunks) == term["unpacked_length"]
+
+  for chunk in term_chunks:
     # skip offset_into_first_range bytes from the beginning
     if offset_into_first_range > len(chunk):
       offset_into_first_range -= len(chunk)

--- a/docs/xet/download-protocol.md
+++ b/docs/xet/download-protocol.md
@@ -37,13 +37,12 @@ The reconstruction API returns a `QueryReconstructionResponse` object with three
         "start": 0,
         "end": 4
       }
-    },
-    ...
+    }
   ],
   "xorbs": {
     "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456": [
       {
-        "url": "https://transfer.xethub.hf.co/xorb/default/a1b2c3d4...?<signed-params>",
+        "url": "https://transfer.xethub.hf.co/xorb/default/a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456?X-Xet-Signed-Range=bytes%3D0-131071&Expires=1735689600&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoidHJhbnNmZXIueGV0aHViLmhmLmNvL3hvcmIvZGVmYXVsdC9hMWIyYzNkNCoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3MzU2ODk2MDB9fX1dfQ__&Signature=Kx8n2rJ5pYqWc3vLdBhTfZ9mAeRsUgN1oiXwEbCa0kqLm4t7yHpV6dZ~woIsPuGj&Key-Pair-Id=K2EXAMPLECDNKEY01",
         "ranges": [
           {
             "chunks": { "start": 0, "end": 4 },
@@ -51,11 +50,12 @@ The reconstruction API returns a `QueryReconstructionResponse` object with three
           }
         ]
       }
-    ],
-    ...
+    ]
   }
 }
 ```
+
+This example describes a small file made of a single term: chunks `[0, 4)` from xorb `a1b2c3d4...`, whose 131072 bytes are downloaded from a single signed URL.
 
 ### Fields
 
@@ -81,7 +81,7 @@ The reconstruction API returns a `QueryReconstructionResponse` object with three
 - Maps xorb hashes to a list of multi-range fetch entries.
 - Typically 1 entry per xorb. Multiple entries only when the URL would exceed the URL length limit.
 - Each `XorbMultiRangeFetch` contains:
-  - `url`: Signed URL with all byte ranges encoded. The client MUST send exactly the signed range value as the `Range` header.
+  - `url`: Signed URL with all byte ranges encoded. The client MUST send exactly the signed range value as the `Range` header. The query string carries the signed byte ranges in `X-Xet-Signed-Range` (URL-encoded, e.g. `bytes%3D0-131071`) plus the CDN signature parameters (`Expires`, `Policy`, `Signature`, `Key-Pair-Id`). These are short-lived; do not cache or rewrite them.
   - `ranges`: Array of `XorbRangeDescriptor`, sorted by chunk start. Each descriptor contains:
     - `chunks`: Chunk index range `{ start: number, end: number }`; end-exclusive `[start, end)`
     - `bytes`: Physical byte range `{ start: number, end: number }` for the HTTP Range header; end-inclusive `[start, end]`
@@ -261,7 +261,7 @@ Here's an example of a `QueryReconstructionResponse` that shows how file reconst
   "xorbs": {
     "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456": [
       {
-        "url": "https://transfer.xethub.hf.co/xorb/default/a1b2c3d4...?<signed-params>",
+        "url": "https://transfer.xethub.hf.co/xorb/default/a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456?X-Xet-Signed-Range=bytes%3D57980-1433008&Expires=1735689600&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoidHJhbnNmZXIueGV0aHViLmhmLmNvL3hvcmIvZGVmYXVsdC9hMWIyYzNkNCoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3MzU2ODk2MDB9fX1dfQ__&Signature=Qz3mWpLf9xKvR2sHnDbTgY7uAeJcUiO1kXwEbCa5rqPm8t4yHpV6dZ~woIsPuGjN&Key-Pair-Id=K2EXAMPLECDNKEY01",
         "ranges": [
           {
             "chunks": { "start": 1, "end": 43 },
@@ -272,7 +272,7 @@ Here's an example of a `QueryReconstructionResponse` that shows how file reconst
     ],
     "fedcba0987654321098765432109876543210fedcba098765432109876543": [
       {
-        "url": "https://transfer.xethub.hf.co/xorb/default/fedcba09...?<signed-params>",
+        "url": "https://transfer.xethub.hf.co/xorb/default/fedcba0987654321098765432109876543210fedcba098765432109876543?X-Xet-Signed-Range=bytes%3D0-65670&Expires=1735689600&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoidHJhbnNmZXIueGV0aHViLmhmLmNvL3hvcmIvZGVmYXVsdC9mZWRjYmEwOSoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3MzU2ODk2MDB9fX1dfQ__&Signature=Ht6bYnQd4wKfM9xRcS2vLpDgT8uAeJiO1kXwEbCa7rqZm5t3yHpV6dZ~woIsPuFa&Key-Pair-Id=K2EXAMPLECDNKEY01",
         "ranges": [
           {
             "chunks": { "start": 0, "end": 3 },

--- a/docs/xet/download-protocol.md
+++ b/docs/xet/download-protocol.md
@@ -81,7 +81,7 @@ This example describes a small file made of a single term: chunks `[0, 4)` from 
 - Maps xorb hashes to a list of multi-range fetch entries.
 - Typically 1 entry per xorb. Multiple entries only when the URL would exceed the URL length limit.
 - Each `XorbMultiRangeFetch` contains:
-  - `url`: Signed URL with all byte ranges encoded. The client MUST send exactly the signed range value as the `Range` header. The query string carries the signed byte ranges in `X-Xet-Signed-Range` (URL-encoded, e.g. `bytes%3D0-131071`) plus the CDN signature parameters (`Expires`, `Policy`, `Signature`, `Key-Pair-Id`). These are short-lived; do not cache or rewrite them.
+  - `url`: Signed URL with all byte ranges encoded in the query string: `X-Xet-Signed-Range` (URL-encoded, e.g. `bytes%3D0-131071`) plus the CDN signature parameters (`Expires`, `Policy`, `Signature`, `Key-Pair-Id`). These are short-lived; do not cache or rewrite them.
   - `ranges`: Array of `XorbRangeDescriptor`, sorted by chunk start. Each descriptor contains:
     - `chunks`: Chunk index range `{ start: number, end: number }`; end-exclusive `[start, end)`
     - `bytes`: Physical byte range `{ start: number, end: number }` for the HTTP Range header; end-inclusive `[start, end]`

--- a/docs/xet/download-protocol.md
+++ b/docs/xet/download-protocol.md
@@ -87,7 +87,7 @@ This example describes a small file made of a single term: chunks `[0, 4)` from 
     - `bytes`: Physical byte range `{ start: number, end: number }` for the HTTP Range header; end-inclusive `[start, end]`
 
 > [!IMPORTANT]
-> The URL encodes the exact set of byte ranges that MUST be requested. Requesting individual sub-ranges separately will result in an authorization failure. The client MUST send all ranges from a single `XorbMultiRangeFetch` entry in a single request.
+> The signed `url` authorizes exactly the byte ranges in its `X-Xet-Signed-Range` set; a `Range` header requesting bytes outside that set returns an authorization failure. Clients SHOULD request all ranges of a `XorbMultiRangeFetch` entry in a single request, which returns a `multipart/byteranges` response when the entry has more than one range.
 
 ## Stage 3: Downloading and Reconstructing the File
 

--- a/docs/xet/index.md
+++ b/docs/xet/index.md
@@ -1,7 +1,7 @@
 # Xet Protocol Specification
 
 > [!NOTE]
-> Version 1.0.0
+> Version 1.1.0
 > The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119](https://www.ietf.org/rfc/rfc2119.txt) [RFC8174](https://www.ietf.org/rfc/rfc8174.txt)
 when, and only when, they appear in all capitals, as shown here.
 

--- a/docs/xet/upload-protocol.md
+++ b/docs/xet/upload-protocol.md
@@ -116,6 +116,9 @@ For this to succeed, all xorbs referenced by the shard MUST have already complet
 
 This API registers files as uploaded.
 
+> [!TIP]
+> A [streaming variant](./api#5-streaming-shard-upload) (`POST /v2/shards`) runs the same validation and registration but streams finalization progress back as newline-delimited JSON, so clients can show real progress while the server verifies a large shard. Clients SHOULD fall back to `/v1/shards` on a `404`.
+
 > [!NOTE]
 > For a large batch of files or a batch of large files if the serialized shard will be greater than 64 MiB you MUST break up the content into multiple shards.
 


### PR DESCRIPTION
Closes huggingface-internal/xetcas#985.

The public CAS API spec in `docs/xet/api.md` only documented 4 of the endpoints actually exposed on the public read/write router (`cas_server/src/serve.rs`). This PR converts the reconstruction endpoint to its V2 shape and documents the remaining public endpoints, so the spec matches the server.

### Changes

- **Get File Reconstruction**: updated to `GET /v2/reconstructions/{file_id}` (multi-range optimized response, `Range` + `Accept-Encoding` headers).
- **New: `POST /v1/reconstructions`** (batch reconstruction, `batch_get_reconstruction`), JWT read.
- **New: `HEAD /v1/xorbs/{prefix}/{hash}`** (`head_xorb`, existence check via `Content-Length`), JWT read.
- **New: `HEAD /v1/files/{file_id}`** (`head_file`, existence check via `Content-Length`), JWT read.
- **New: `GET /v2/file-chunk-hashes/{file_id}`** (`get_file_chunk_hashes`, delta-upload chunk windows, requires `X-Range-Dirty` header), JWT read.

### Verification

All paths, methods, auth scopes, header names, and JSON field names were cross-checked against `xetcas` main and `xet-client` rev `b1374f5`:
- All 5 endpoints live in the public router (port 80), gated by `auth_builder(AccessLevel::Read, ...)`, not the internal control-plane router.
- `FileChunkHashesResponse` / `ChunkWindow` use `#[serde(rename_all = "camelCase")]`, so the documented `totalChunks` / `fileSize` / `windows` / `dirtyByteRange` / `hashRanges` / `gapVerification` field names are correct.
- The `X-Range-Dirty` header name matches `handler::X_RANGE_DIRTY`.

Note: per discussion on the issue, the `file-chunk-hashes` endpoint may evolve (ChunkHashRange RFC). Documenting current behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the Xet spec; no runtime code, auth, or data-path behavior is modified in this PR.
> 
> **Overview**
> Bumps the Xet protocol spec to **1.1.0** and brings `docs/xet` in line with the public CAS surface.
> 
> **Reconstruction (download path):** Primary docs now use **`GET /v2/reconstructions/{file_id}`** with a **`xorbs`** map (multi-range signed URLs) instead of v1 **`fetch_info`**. **`download-protocol.md`** is rewritten for multi-range `Range` requests, `multipart/byteranges`, and term assembly from a chunk cache; v1 is documented separately as deprecated with fallback on `404`/`501`.
> 
> **New/expanded CAS API sections in `api.md`:** **`POST /v2/shards`** (NDJSON progress for shard finalize), **`POST /v1/reconstructions`** (batch, v1 shape), **`HEAD`** on xorbs and files, and **`GET /v2/file-chunk-hashes/{file_id}`** with required **`X-Range-Dirty`** for delta uploads. **`upload-protocol.md`** points clients at streaming shard upload with v1 fallback.
> 
> **Batch note:** Batch reconstruction still documents **`fetch_info`**; per-file v2 remains the multi-range format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66874f42946a364c852176382c5a656d4aa0e44d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->