### PR TITLE
docs: document data_dir in YAML dataset configuration

### DIFF
--- a/docs/hub/datasets-manual-configuration.md
+++ b/docs/hub/datasets-manual-configuration.md
@@ -116,31 +116,9 @@ Note that the order of subsets shown in the viewer is the default one first, the
 
 ## Data Directory
 
-Instead of listing individual files with `data_files`, you can use `data_dir` to point to a directory. Files inside that directory are resolved automatically based on the builder's default patterns. This is especially useful when your data is organized in subdirectories:
+Instead of listing individual files with `data_files`, you can use `data_dir` to point to a directory. Files inside that directory are resolved automatically based on file extensions. This is especially useful when your data is organized in subdirectories:
 
-```
-my_dataset_repository/
-├── README.md
-├── train/
-│   ├── 001.parquet
-│   └── 002.parquet
-└── test/
-    └── 001.parquet
-```
-
-```yaml
----
-configs:
-- config_name: default
-  data_files:
-  - split: train
-    path: "train/*.parquet"
-  - split: test
-    path: "test/*.parquet"
----
-```
-
-You can simplify this with `data_dir` when each subset's data lives in its own directory:
+For example in a case like this, you can simply use `data_dir` since each subset's data lives in its own directory:
 
 ```
 my_dataset_repository/

--- a/docs/hub/datasets-manual-configuration.md
+++ b/docs/hub/datasets-manual-configuration.md
@@ -114,6 +114,74 @@ Note that the order of subsets shown in the viewer is the default one first, the
 > This is useful to set which subset the Dataset Viewer shows first, and which subset data libraries load by default.
 
 
+## Data Directory
+
+Instead of listing individual files with `data_files`, you can use `data_dir` to point to a directory. Files inside that directory are resolved automatically based on the builder's default patterns. This is especially useful when your data is organized in subdirectories:
+
+```
+my_dataset_repository/
+├── README.md
+├── train/
+│   ├── 001.parquet
+│   └── 002.parquet
+└── test/
+    └── 001.parquet
+```
+
+```yaml
+---
+configs:
+- config_name: default
+  data_files:
+  - split: train
+    path: "train/*.parquet"
+  - split: test
+    path: "test/*.parquet"
+---
+```
+
+You can simplify this with `data_dir` when each subset's data lives in its own directory:
+
+```
+my_dataset_repository/
+├── README.md
+├── main/
+│   ├── train.csv
+│   └── test.csv
+└── extra/
+    ├── train.csv
+    └── test.csv
+```
+
+```yaml
+---
+configs:
+- config_name: main
+  data_dir: "main"
+- config_name: extra
+  data_dir: "extra"
+---
+```
+
+When `data_dir` is set, the builder resolves files relative to that directory. If the directory contains files matching the default split naming pattern (e.g. `train.csv`, `test.csv`), splits are assigned automatically without needing explicit `data_files`.
+
+You can also combine `data_dir` with `data_files` for more control:
+
+```yaml
+---
+configs:
+- config_name: default
+  data_dir: "data"
+  data_files:
+  - split: train
+    path: "training_*.csv"
+  - split: test
+    path: "eval_*.csv"
+---
+```
+
+In this case, the `path` patterns in `data_files` are resolved relative to the `data_dir`.
+
 ## Builder parameters
 
 Not only `data_files`, but other builder-specific parameters can be passed via YAML, allowing for more flexibility on how to load the data while not requiring any custom code. For example, define which separator to use in which subset to load your `csv` files:


### PR DESCRIPTION
## Summary

The `data_dir` field is a supported YAML metadata option for dataset configs, but it is not documented in the manual configuration guide. This PR adds a new "Data Directory" section covering:

- Using `data_dir` to point subsets at different directories
- Automatic split detection from default naming patterns (e.g. `train.csv`, `test.csv`)
- Combining `data_dir` with `data_files` for more control over path resolution

The section is placed between "Multiple Subsets" and "Builder parameters" to follow the natural progression from simple to advanced configuration.

Fixes huggingface/datasets#6561

## Test plan
- [x] Verified `data_dir` behavior matches source code in `datasets/load.py` (`create_builder_configs_from_metadata_configs`)
- [x] Examples are consistent with existing doc style and YAML format
- [x] No changes to existing content

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; main risk is potential user confusion if examples or semantics are inaccurate.
> 
> **Overview**
> Adds a new **Data Directory** section to `docs/hub/datasets-manual-configuration.md` documenting the `data_dir` YAML field as an alternative to listing `data_files`.
> 
> Includes examples for per-subset directory layouts, notes on automatic split detection from default filenames (e.g. `train.csv`/`test.csv`), and shows how `data_dir` can be combined with `data_files` so `path` patterns resolve relative to the directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1062640b0594fb1b7b0fb09946dace2dce91d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->