### PR TITLE
docs: fix broken skill links and names in agents-skills.md

### DIFF
--- a/docs/hub/agents-skills.md
+++ b/docs/hub/agents-skills.md
@@ -52,18 +52,16 @@ Install via the Cursor plugin flow using the [repository URL](https://github.com
 | Skill | What it does |
 | ----- | ------------ |
 | [`hf-cli`](https://github.com/huggingface/skills/tree/main/skills/hf-cli) | Hub operations via the `hf` CLI: download, upload, manage repos, run jobs |
-| [`hugging-face-datasets`](https://github.com/huggingface/skills/tree/main/skills/hugging-face-datasets) | Create and manage datasets on the Hub |
-| [`hugging-face-dataset-viewer`](https://github.com/huggingface/skills/tree/main/skills/hugging-face-dataset-viewer) | Explore and query any dataset via the Dataset Viewer API |
-| [`hugging-face-model-trainer`](https://github.com/huggingface/skills/tree/main/skills/hugging-face-model-trainer) | Train or fine-tune LLMs with TRL (SFT, DPO, GRPO) on HF Jobs |
-| [`hugging-face-vision-trainer`](https://github.com/huggingface/skills/tree/main/skills/hugging-face-vision-trainer) | Train object detection and image classification models |
-| [`hugging-face-object-detection-trainer`](https://github.com/huggingface/skills/tree/main/skills/hugging-face-object-detection-trainer) | Fine-tune object detection models (RTDETRv2, YOLOS, DETR) |
-| [`hugging-face-evaluation`](https://github.com/huggingface/skills/tree/main/skills/hugging-face-evaluation) | Add and manage evaluation results in model cards |
-| [`hugging-face-jobs`](https://github.com/huggingface/skills/tree/main/skills/hugging-face-jobs) | Run compute jobs on Hugging Face infrastructure |
-| [`hugging-face-trackio`](https://github.com/huggingface/skills/tree/main/skills/hugging-face-trackio) | Track and visualize ML training experiments |
-| [`hugging-face-paper-publisher`](https://github.com/huggingface/skills/tree/main/skills/hugging-face-paper-publisher) | Publish and manage research papers on the Hub |
-| [`hugging-face-tool-builder`](https://github.com/huggingface/skills/tree/main/skills/hugging-face-tool-builder) | Build reusable scripts for HF API operations |
+| [`huggingface-datasets`](https://github.com/huggingface/skills/tree/main/skills/huggingface-datasets) | Create and upload datasets, and explore them via the Dataset Viewer API |
+| [`huggingface-llm-trainer`](https://github.com/huggingface/skills/tree/main/skills/huggingface-llm-trainer) | Train or fine-tune LLMs with TRL (SFT, DPO, GRPO) on HF Jobs |
+| [`huggingface-vision-trainer`](https://github.com/huggingface/skills/tree/main/skills/huggingface-vision-trainer) | Train and fine-tune object detection, image classification and segmentation models on HF Jobs |
+| [`huggingface-community-evals`](https://github.com/huggingface/skills/tree/main/skills/huggingface-community-evals) | Add and manage evaluation results in model cards |
+| [`huggingface-jobs`](https://github.com/huggingface/skills/tree/main/skills/huggingface-jobs) | Run compute jobs on Hugging Face infrastructure |
+| [`huggingface-trackio`](https://github.com/huggingface/skills/tree/main/skills/huggingface-trackio) | Track and visualize ML training experiments |
+| [`huggingface-paper-publisher`](https://github.com/huggingface/skills/tree/main/skills/huggingface-paper-publisher) | Publish and manage research papers on the Hub |
 | [`gradio`](https://github.com/huggingface/skills/tree/main/skills/huggingface-gradio) | Build Gradio web UIs and demos |
-| [`transformers-js`](https://github.com/huggingface/skills/tree/main/skills/transformers.js) | Run ML models in JavaScript/TypeScript with WebGPU/WASM |
+| [`transformers-js`](https://github.com/huggingface/skills/tree/main/skills/transformers-js) | Run ML models in JavaScript/TypeScript with WebGPU/WASM |
+| [`huggingface-papers`](https://github.com/huggingface/skills/tree/main/skills/huggingface-papers) | Look up and read Hugging Face paper pages in markdown |
 
 ## Using Skills
 


### PR DESCRIPTION
Several skills in the huggingface/skills repo were renamed (hyphens removed from the `hugging-face-` prefix), which broke all the links in the Available Skills table.

A few skills were also removed or merged.

## Changes
- Updated all skill names and URLs to match current huggingface/skills repo
- Removed hugging-face-dataset-viewer (merged into huggingface-datasets)
- Removed hugging-face-object-detection-trainer (merged into huggingface-vision-trainer)
- Removed hugging-face-tool-builder (deleted upstream)
- Added huggingface-papers skill
- Fixed transformers.js -> transformers-js URL

All new links verified as live, all old links confirmed 404.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update that retargets links and renames entries; low risk beyond potentially introducing new broken URLs or mismatched skill descriptions.
> 
> **Overview**
> Updates `docs/hub/agents-skills.md` to reflect upstream skill renames and consolidation: fixes broken `hugging-face-*` links by switching to `huggingface-*` skill names/paths, merges the dataset viewer and object detection entries into their successor skills, and removes entries that no longer exist upstream.
> 
> Also corrects the `transformers-js` URL and adds the new `huggingface-papers` skill to the Available Skills table.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b89d4f7c2d7345c668577a1e7447fe79898330a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->