### PR TITLE
docs: add Storage Buckets examples to pandas and DuckDB pages

### DIFF
--- a/docs/hub/datasets-duckdb.md
+++ b/docs/hub/datasets-duckdb.md
@@ -78,3 +78,4 @@ In the following sections, we will cover more complex operations you can perform
 > duckdb.register_filesystem(HfFileSystem())
 > duckdb.sql("SELECT * FROM 'hf://buckets/username/my-bucket/data.parquet' LIMIT 10")
 > ```
+Native `hf://buckets/` support in DuckDB is expected in a future release.

--- a/docs/hub/datasets-duckdb.md
+++ b/docs/hub/datasets-duckdb.md
@@ -69,3 +69,12 @@ Or using traditional SQL syntax:
 SELECT * FROM 'hf://datasets/ibm/duorc/ParaphraseRC/*.parquet' LIMIT 3;
 ```
 In the following sections, we will cover more complex operations you can perform with DuckDB on Hugging Face datasets.
+
+> [!TIP]
+> **Querying Storage Buckets**: When using the DuckDB Python client, you can query data stored in [Storage Buckets](./storage-buckets) by registering the Hugging Face filesystem:
+> ```python
+> import duckdb
+> from huggingface_hub import HfFileSystem
+> duckdb.register_filesystem(HfFileSystem())
+> duckdb.sql("SELECT * FROM 'hf://buckets/username/my-bucket/data.parquet' LIMIT 10")
+> ```

--- a/docs/hub/datasets-pandas.md
+++ b/docs/hub/datasets-pandas.md
@@ -34,6 +34,13 @@ To load a file from Hugging Face, the path needs to start with `hf://`. For exam
 
 For more information on the Hugging Face paths and how they are implemented, please refer to the [the client library's documentation on the HfFileSystem](/docs/huggingface_hub/guides/hf_file_system).
 
+> [!TIP]
+> The same `hf://` paths also work with [Storage Buckets](./storage-buckets):
+> ```python
+> >>> df = pd.read_parquet("hf://buckets/username/my-bucket/data.parquet")
+> >>> df.to_parquet("hf://buckets/username/my-bucket/output.parquet")
+> ```
+
 ## Save a DataFrame
 
 You can save a pandas DataFrame using `to_csv/to_json/to_parquet` to a local file or to Hugging Face directly.


### PR DESCRIPTION
## Summary
- Add tip box to `datasets-pandas.md` showing `hf://buckets/` read/write (works via fsspec)
- Add tip box to `datasets-duckdb.md` showing `register_filesystem(HfFileSystem())` pattern for querying bucket data

Both examples smoke-tested locally against a real public bucket (`davanstrien/atlas-data`).

## What's not included (follow-up PR)
- **Polars**: native `hf://` handler doesn't support `buckets` yet (`ComputeError: hugging face uri bucket must be one of ["datasets", "spaces"]`)
- **DuckDB CLI**: native handler only supports `hf://datasets/` and `hf://spaces/`
- A dedicated "Access Buckets from Code" page covering hf-mount, volume mounts, etc.

## Test plan
- [x] `pd.read_parquet("hf://buckets/davanstrien/atlas-data/model-cards-prepped.parquet")` — 428k rows returned
- [x] `duckdb.register_filesystem(HfFileSystem())` + SQL query on same file — 428k rows returned
- [x] Confirmed Polars native and DuckDB CLI do NOT support `hf://buckets/` (excluded from this PR)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes adding example snippets; no runtime behavior or APIs are modified.
> 
> **Overview**
> Updates the Hub dataset integration docs to include **Storage Buckets (`hf://buckets/...`) usage examples**.
> 
> The Pandas page adds a tip demonstrating reading and writing Parquet directly with `pd.read_parquet`/`to_parquet` against bucket paths, and the DuckDB page adds a tip showing how to query bucket data from the DuckDB Python client by registering `HfFileSystem`, with a note that native DuckDB bucket support is not yet available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a68aac705c834424a161c8b06fa37940879ee219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->