### PR TITLE
docs: add "Access Buckets from Code" page

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -421,6 +421,8 @@
   new: true
   isExpanded: true
   sections:
+  - local: storage-buckets-access
+    title: Access from Code
   - local: storage-buckets-security
     title: Bucket Security
 

--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -422,7 +422,7 @@
   isExpanded: true
   sections:
   - local: storage-buckets-access
-    title: Access from Code
+    title: Access Patterns
   - local: storage-buckets-security
     title: Bucket Security
 

--- a/docs/hub/storage-buckets-access.md
+++ b/docs/hub/storage-buckets-access.md
@@ -1,4 +1,4 @@
-# Access Buckets from Code
+# Access Patterns
 
 Beyond the [CLI and Python SDK](./storage-buckets#managing-files), there are several ways to access bucket data from your existing tools and workflows.
 

--- a/docs/hub/storage-buckets-access.md
+++ b/docs/hub/storage-buckets-access.md
@@ -1,0 +1,68 @@
+# Access Buckets from Code
+
+Beyond the [CLI and Python SDK](./storage-buckets#managing-files), there are several ways to access bucket data from your existing tools and workflows.
+
+## Choosing an Access Method
+
+| Method | Best for | Details |
+|--------|----------|---------|
+| **hf-mount** | Mount as local filesystem — any tool works | [See below](#mount-as-a-local-filesystem) |
+| **hf:// paths** (fsspec) | Python data tools (pandas, DuckDB) | [See below](#python-data-tools) |
+| **Volume mounts** | HF Jobs & Spaces | [See below](#volume-mounts-in-jobs-and-spaces) |
+| **CLI sync** | Batch transfers, backups | [Sync docs](./storage-buckets#syncing-directories) |
+
+## Mount as a Local Filesystem
+
+[hf-mount](https://github.com/huggingface/hf-mount) lets you mount buckets (and repos) as local filesystems via NFS (recommended) or FUSE. Files are fetched lazily — only the bytes your code reads hit the network.
+
+Install:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
+```
+
+Mount a bucket:
+
+```bash
+hf-mount start bucket username/my-bucket /mnt/data
+```
+
+Once mounted, any tool that reads or writes files works with your bucket — pandas, DuckDB, vLLM, training scripts, shell commands, etc.
+
+> [!TIP]
+> Buckets are mounted read-write; repos are read-only. See the [hf-mount repository](https://github.com/huggingface/hf-mount) for full documentation including backend options, caching, and write modes.
+
+## Python Data Tools
+
+The [`HfFileSystem`](/docs/huggingface_hub/guides/hf_file_system) provides [fsspec](https://filesystem-spec.readthedocs.io)-compatible access to buckets using `hf://buckets/` paths. Any Python library that supports fsspec can read and write bucket data directly.
+
+**pandas:**
+
+```python
+import pandas as pd
+
+df = pd.read_parquet("hf://buckets/username/my-bucket/data.parquet")
+df.to_parquet("hf://buckets/username/my-bucket/output.parquet")
+```
+
+**DuckDB** (Python client):
+
+```python
+import duckdb
+from huggingface_hub import HfFileSystem
+
+duckdb.register_filesystem(HfFileSystem())
+duckdb.sql("SELECT * FROM 'hf://buckets/username/my-bucket/data.parquet' LIMIT 10")
+```
+
+For more on `hf://` paths and supported operations, see the [`HfFileSystem` guide](/docs/huggingface_hub/guides/hf_file_system) and the [Buckets Python guide](/docs/huggingface_hub/guides/buckets).
+
+## Volume Mounts in Jobs and Spaces
+
+When running [Jobs](./jobs) or [Spaces](./spaces), you can mount buckets directly as volumes — no extra setup needed. Buckets are mounted read-write by default.
+
+```bash
+hf jobs run -v hf://buckets/username/my-bucket:/data python:3.12 python script.py
+```
+
+For the full volume mount syntax and Python API, see the [Jobs configuration docs](./jobs-configuration#volumes).

--- a/docs/hub/storage-buckets-access.md
+++ b/docs/hub/storage-buckets-access.md
@@ -65,4 +65,4 @@ When running [Jobs](./jobs) or [Spaces](./spaces), you can mount buckets directl
 hf jobs run -v hf://buckets/username/my-bucket:/data python:3.12 python script.py
 ```
 
-For the full volume mount syntax and Python API, see the [Jobs configuration docs](./jobs-configuration#volumes).
+For the full volume mount syntax and Python API, see the [Jobs configuration docs](./jobs-configuration#volumes) and the [Spaces volume mount guide](/docs/huggingface_hub/guides/manage-spaces#mount-volumes-in-your-space).

--- a/docs/hub/storage-buckets-access.md
+++ b/docs/hub/storage-buckets-access.md
@@ -7,8 +7,8 @@ Beyond the [CLI and Python SDK](./storage-buckets#managing-files), there are sev
 | Method | Best for | Details |
 |--------|----------|---------|
 | **hf-mount** | Mount as local filesystem — any tool works | [See below](#mount-as-a-local-filesystem) |
+| **Volume mounts** | HF Jobs & Spaces (same idea, managed for you) | [See below](#volume-mounts-in-jobs-and-spaces) |
 | **hf:// paths** (fsspec) | Python data tools (pandas, DuckDB) | [See below](#python-data-tools) |
-| **Volume mounts** | HF Jobs & Spaces | [See below](#volume-mounts-in-jobs-and-spaces) |
 | **CLI sync** | Batch transfers, backups | [Sync docs](./storage-buckets#syncing-directories) |
 
 ## Mount as a Local Filesystem
@@ -31,6 +31,16 @@ Once mounted, any tool that reads or writes files works with your bucket — pan
 
 > [!TIP]
 > Buckets are mounted read-write; repos are read-only. See the [hf-mount repository](https://github.com/huggingface/hf-mount) for full documentation including backend options, caching, and write modes.
+
+## Volume Mounts in Jobs and Spaces
+
+Volume mounts in [Jobs](./jobs) and [Spaces](./spaces) are the same idea as `hf-mount`, managed for you by the platform — no extra setup needed. Buckets are mounted read-write by default.
+
+```bash
+hf jobs run -v hf://buckets/username/my-bucket:/data python:3.12 python script.py
+```
+
+For the full volume mount syntax and Python API, see the [Jobs configuration docs](./jobs-configuration#volumes) and the [Spaces volume mount guide](/docs/huggingface_hub/guides/manage-spaces#mount-volumes-in-your-space).
 
 ## Python Data Tools
 
@@ -56,13 +66,3 @@ duckdb.sql("SELECT * FROM 'hf://buckets/username/my-bucket/data.parquet' LIMIT 1
 ```
 
 For more on `hf://` paths and supported operations, see the [`HfFileSystem` guide](/docs/huggingface_hub/guides/hf_file_system) and the [Buckets Python guide](/docs/huggingface_hub/guides/buckets).
-
-## Volume Mounts in Jobs and Spaces
-
-When running [Jobs](./jobs) or [Spaces](./spaces), you can mount buckets directly as volumes — no extra setup needed. Buckets are mounted read-write by default.
-
-```bash
-hf jobs run -v hf://buckets/username/my-bucket:/data python:3.12 python script.py
-```
-
-For the full volume mount syntax and Python API, see the [Jobs configuration docs](./jobs-configuration#volumes) and the [Spaces volume mount guide](/docs/huggingface_hub/guides/manage-spaces#mount-volumes-in-your-space).

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -8,7 +8,7 @@ You can interact with buckets using the Hub web interface, the [`hf` CLI](https:
 > Buckets are available to all users and organizations. See [hf.co/storage](https://huggingface.co/storage) for pricing details.
 
 > [!TIP]
-> Want to use bucket data with pandas, DuckDB, or mount buckets as a local filesystem? See [Access Buckets from Code](./storage-buckets-access).
+> Want to use bucket data with pandas, DuckDB, or mount buckets as a local filesystem? See [Access Patterns](./storage-buckets-access).
 
 ## Buckets vs Repositories
 

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -7,6 +7,9 @@ You can interact with buckets using the Hub web interface, the [`hf` CLI](https:
 > [!TIP]
 > Buckets are available to all users and organizations. See [hf.co/storage](https://huggingface.co/storage) for pricing details.
 
+> [!TIP]
+> Want to use bucket data with pandas, DuckDB, or mount buckets as a local filesystem? See [Access Buckets from Code](./storage-buckets-access).
+
 ## Buckets vs Repositories
 
 The Hub offers two types of storage: Git-based **repositories** for versioned, collaborative work and **buckets** for fast, mutable object storage.


### PR DESCRIPTION
## Summary
New subpage under Storage Buckets covering the main access patterns for using bucket data from code:

- **hf-mount**: mount buckets as local filesystem (NFS/FUSE)
- **HfFileSystem (fsspec)**: `hf://buckets/` paths with pandas, DuckDB Python client
- **Volume mounts**: cross-link to Jobs/Spaces volume docs
- **CLI sync**: cross-link to existing sync docs

Also adds a tip callout on the main `storage-buckets.md` page linking to the new page.

## Notes
The page is intentionally high-level for now — buckets is evolving fast, so it links out
to detailed docs (hf-mount repo, huggingface_hub guides) rather than duplicating content.
Happy to flesh out with more detailed examples and additional tool integrations in future PRs.

Related: #2362 (adds bucket tip boxes to pandas/DuckDB pages)

## Test plan
- [x] Page renders in sidebar under Storage Buckets → Access from Code
- [x] Cross-links resolve (storage-buckets, jobs-configuration, HfFileSystem guide, buckets guide)
- [x] pandas and DuckDB Python examples verified working against a real bucket

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes (new page, sidebar entry, and cross-links) with no runtime or API impact; main risk is broken or outdated links/examples.
> 
> **Overview**
> Adds a new `Storage Buckets → Access Patterns` doc page describing how to use bucket data via `hf-mount`, Jobs/Spaces volume mounts, `hf://buckets/` fsspec (`HfFileSystem`) integrations (pandas/DuckDB examples), and existing CLI `sync` workflows.
> 
> Updates the hub sidebar (`_toctree.yml`) to include the new subpage and adds a tip callout in `storage-buckets.md` pointing readers to it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e59e8db29efa898d5ea16e034ad2dde6c520608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->