### PR TITLE
[ZeroGPU] CUDA placement note

### DIFF
--- a/docs/hub/spaces-zerogpu.md
+++ b/docs/hub/spaces-zerogpu.md
@@ -95,14 +95,14 @@ gr.Interface(
 ).launch()
 ```
 
-### Note on (PyTorch) CUDA device
+### Model loading
 
 Even though a real GPU is only available inside `@spaces.GPU` functions, models must be placed on `cuda` at the root module level (as shown in the example above).
 
 Lazy-loading or moving models to CUDA inside `@spaces.GPU` is discouraged, as it is significantly less efficient (CUDA transfers are optimized for placements done during startup).
 
 > [!NOTE]
-> This works because a PyTorch CUDA emulation mode is enabled outside `@spaces.GPU` functions, allowing CUDA operations without a real GPU. Inside `@spaces.GPU`, real CUDA is used.
+> Loading models on `cuda` at module level works because a PyTorch CUDA emulation mode is enabled outside `@spaces.GPU` functions, allowing CUDA operations without a real GPU. Inside `@spaces.GPU`, real CUDA is used.
 
 ## GPU size selection
 

--- a/docs/hub/spaces-zerogpu.md
+++ b/docs/hub/spaces-zerogpu.md
@@ -72,6 +72,9 @@ To utilize ZeroGPU in your Space, follow these steps:
 
 This decoration process allows the Space to request a GPU when the function is called and release it upon completion.
 
+> [!NOTE]
+> The `@spaces.GPU` decorator is designed to be effect-free in non-ZeroGPU environments, ensuring compatibility across different setups.
+
 ### Example Usage
 
 ```python
@@ -92,7 +95,14 @@ gr.Interface(
 ).launch()
 ```
 
-Note: The `@spaces.GPU` decorator is designed to be effect-free in non-ZeroGPU environments, ensuring compatibility across different setups.
+### Note on (PyTorch) CUDA device
+
+Even though a real GPU is only available inside `@spaces.GPU` functions, models must be placed on `cuda` at the root module level (as shown in the example above).
+
+Lazy-loading or moving models to CUDA inside `@spaces.GPU` is discouraged, as it is significantly less efficient (CUDA transfers are optimized for placements done during startup).
+
+> [!NOTE]
+> This works because a PyTorch CUDA emulation mode is enabled outside `@spaces.GPU` functions, allowing CUDA operations without a real GPU. Inside `@spaces.GPU`, real CUDA is used.
 
 ## GPU size selection
 


### PR DESCRIPTION
Agents (also some human devs) reading https://huggingface.co/docs/hub/spaces-zerogpu tend to lazy-load models inside `@spaces.GPU` (despite the example code snippet), probably out of caution. Let's make it more explicit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies where models should be moved to CUDA and why lazy-loading inside `@spaces.GPU` is inefficient.
> 
> **Overview**
> Clarifies ZeroGPU guidance around `@spaces.GPU` by adding a prominent note that the decorator is effect-free outside ZeroGPU environments.
> 
> Adds a new **Model loading** section explicitly instructing users to move models to `cuda` at module import time (not inside `@spaces.GPU`) and explains that this works via CUDA emulation outside the decorated function, with real CUDA used inside it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d98ed6b22f8830856b3746472d0e0264a80d4c04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->