### PR TITLE
docs: add read-collections and write-collections OAuth scopes

### DIFF
--- a/docs/hub/oauth.md
+++ b/docs/hub/oauth.md
@@ -106,6 +106,8 @@ The currently supported scopes are:
 - `contribute-repos`: Can create repositories and access those created by this app. Cannot access any other repositories unless additional permissions are granted.
 - `write-repos`: Get write/read access to the user's personal repos.
 - `manage-repos`: Get full access to the user's personal repos. Also grants repo creation and deletion.
+- `read-collections`: Get read access to the user's personal collections.
+- `write-collections`: Get write/read access to the user's personal collections. Also grants collection creation and deletion.
 - `inference-api`: Get access to the [Inference Providers](https://huggingface.co/docs/inference-providers/index), you will be able to make inference requests on behalf of the user.
 - `jobs`: Run [jobs](https://huggingface.co/docs/huggingface_hub/main/en/guides/jobs) 
 - `webhooks`: Manage [webhooks](https://huggingface.co/docs/huggingface_hub/main/en/guides/webhooks)

--- a/docs/hub/spaces-oauth.md
+++ b/docs/hub/spaces-oauth.md
@@ -78,6 +78,8 @@ Those scopes are optional and can be added by setting `hf_oauth_scopes` in your 
 - `contribute-repos`: Can create repositories and access those created by this app. Cannot access any other repositories unless additional permissions are granted.
 - `write-repos`: Get write/read access to the user's personal repos.
 - `manage-repos`: Get full access to the user's personal repos. Also grants repo creation and deletion.
+- `read-collections`: Get read access to the user's personal collections.
+- `write-collections`: Get write/read access to the user's personal collections. Also grants collection creation and deletion.
 - `inference-api`: Get access to the [Inference Providers](https://huggingface.co/docs/inference-providers/index), you will be able to make inference requests on behalf of the user.
 - `jobs`: Run [jobs](https://huggingface.co/docs/huggingface_hub/main/en/guides/jobs) 
 - `webhooks`: Manage [webhooks](https://huggingface.co/docs/huggingface_hub/main/en/guides/webhooks)


### PR DESCRIPTION
Add two new OAuth scopes: `read-collections` and `write-collections`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that just exposes two additional OAuth scope names in the supported-scope lists.
> 
> **Overview**
> **Documents two new OAuth scopes for collections access.** Updates the supported scope lists in `docs/hub/oauth.md` and `docs/hub/spaces-oauth.md` to include `read-collections` and `write-collections`, describing their read vs. write/create/delete permissions for user collections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b76921c2baf45d8c236464a425ca72c8ef65498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->