### PR TITLE
add huggingface-papers skill to agents-skills.md

### DIFF
--- a/docs/hub/agents-skills.md
+++ b/docs/hub/agents-skills.md
@@ -62,6 +62,7 @@ Install via the Cursor plugin flow using the [repository URL](https://github.com
 | [`huggingface-tool-builder`](https://github.com/huggingface/skills/tree/main/skills/huggingface-tool-builder) | Build reusable scripts for HF API operations |
 | [`gradio`](https://github.com/huggingface/skills/tree/main/skills/huggingface-gradio) | Build Gradio web UIs and demos |
 | [`transformers-js`](https://github.com/huggingface/skills/tree/main/skills/transformers-js) | Run ML models in JavaScript/TypeScript with WebGPU/WASM |
+| [`huggingface-papers`](https://github.com/huggingface/skills/tree/main/skills/huggingface-papers) | Look up and read Hugging Face paper pages in markdown |
 
 ## Using Skills
 

--- a/docs/hub/agents-skills.md
+++ b/docs/hub/agents-skills.md
@@ -58,11 +58,11 @@ Install via the Cursor plugin flow using the [repository URL](https://github.com
 | [`huggingface-community-evals`](https://github.com/huggingface/skills/tree/main/skills/huggingface-community-evals) | Run evaluations against models on the Hugging Face Hub on local hardware |
 | [`huggingface-jobs`](https://github.com/huggingface/skills/tree/main/skills/huggingface-jobs) | Run compute jobs on Hugging Face infrastructure |
 | [`huggingface-trackio`](https://github.com/huggingface/skills/tree/main/skills/huggingface-trackio) | Track and visualize ML training experiments with Trackio |
+| [`huggingface-papers`](https://github.com/huggingface/skills/tree/main/skills/huggingface-papers) | Look up and read Hugging Face paper pages in markdown |
 | [`huggingface-paper-publisher`](https://github.com/huggingface/skills/tree/main/skills/huggingface-paper-publisher) | Publish and manage research papers on the Hub |
 | [`huggingface-tool-builder`](https://github.com/huggingface/skills/tree/main/skills/huggingface-tool-builder) | Build reusable scripts for HF API operations |
 | [`gradio`](https://github.com/huggingface/skills/tree/main/skills/huggingface-gradio) | Build Gradio web UIs and demos |
 | [`transformers-js`](https://github.com/huggingface/skills/tree/main/skills/transformers-js) | Run ML models in JavaScript/TypeScript with WebGPU/WASM |
-| [`huggingface-papers`](https://github.com/huggingface/skills/tree/main/skills/huggingface-papers) | Look up and read Hugging Face paper pages in markdown |
 
 ## Using Skills
 


### PR DESCRIPTION
Following up on #2345 - the `huggingface-papers` skill exists in `huggingface/skills` repo but was missed when #2329 was merged. This adds it to the Available Skills table.

Link verified live.

cc @pcuenca


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a single new entry to the Skills table with no code or behavior impact.
> 
> **Overview**
> Adds the missing `huggingface-papers` entry (with link and short description) to the **Available Skills** table in `docs/hub/agents-skills.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e8f3e4d5a25f3d54f12cee6e746c7eff8937166. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->