### PR TITLE
docs(resource-groups): document role-based resource group creation setting

### DIFF
--- a/docs/hub/enterprise-resource-groups.md
+++ b/docs/hub/enterprise-resource-groups.md
@@ -25,6 +25,7 @@ This feature allows organization administrators to:
 - Assign different permission roles (read, contributor, write, admin) to team members
 - Keep private repositories visible only to authorized group members
 - Enable multiple teams to work independently within the same organization
+- Configure which member roles are allowed to create new resource groups
 
 This Team & Enterprise feature helps organizations manage complex team structures and maintain proper access control over their repositories.
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -33,7 +33,7 @@ Head to your Organization's settings, then navigate to the "Resource Group" tab 
     <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-page-dark.png"/>
 </div>
 
-If you are an admin of the organization, you can create and manage Resource Groups from that page.
+Organization admins can create and manage Resource Groups from that page. Depending on the organization's settings, members with lower roles may also be allowed to create resource groups (see [Who can create resource groups](#who-can-create-resource-groups) below).
 
 After creating a resource group and giving it a meaningful name, you can start adding repositories and users to it.
 
@@ -74,6 +74,18 @@ Auto-join and SCIM management are **mutually exclusive** on the same Resource Gr
 - You cannot link a SCIM group to a Resource Group that has auto-join enabled.
 
 To switch a Resource Group from auto-join to SCIM-managed (or vice versa), disable the current setting first.
+
+## Who can create resource groups
+
+By default, only organization admins can create new resource groups. Org admins can change this by setting the **minimum member role required to create resource groups** on the resource groups settings page.
+
+The available options are:
+- **Admins only** (default) — only org admins can create resource groups.
+- **Write** — members with Write or Admin role can create resource groups.
+- **Contributor** — members with Contributor, Write, or Admin role can create resource groups.
+- **All members** — any org member can create resource groups.
+
+When a non-admin member creates a resource group, they are automatically added as an **admin** of that newly created group. When creating a resource group via the API, non-admin creators must include at least one admin in the group's initial user list.
 
 ## Resource Groups API
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -33,7 +33,7 @@ Head to your Organization's settings, then navigate to the "Resource Group" tab 
     <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-page-dark.png"/>
 </div>
 
-Organization admins can create and manage Resource Groups from that page. Depending on the organization's settings, members with lower roles may also be allowed to create Resource Groups (see [Who can create resource groups](#who-can-create-resource-groups) below).
+Organization admins can create and manage Resource Groups from that page. Depending on the organization's settings, members with lower roles may also be allowed to create Resource Groups (see [Who can create Resource Groups](#who-can-create-resource-groups) below).
 
 After creating a Resource Group and giving it a meaningful name, you can start adding repositories and users to it.
 
@@ -75,17 +75,17 @@ Auto-join and SCIM management are **mutually exclusive** on the same Resource Gr
 
 To switch a Resource Group from auto-join to SCIM-managed (or vice versa), disable the current setting first.
 
-## Who can create resource groups
+## Who can create Resource Groups
 
-By default, only organization admins can create new resource groups. Org admins can change this by setting the **minimum member role required to create resource groups** on the resource groups settings page.
+By default, only organization admins can create new Resource Groups. Org admins can change this by setting the **minimum member role required to create Resource Groups** on the Resource Groups settings page.
 
 The available options are:
-- **Admins only** (default) — only org admins can create resource groups.
-- **Write** — members with Write or Admin role can create resource groups.
-- **Contributor** — members with Contributor, Write, or Admin role can create resource groups.
-- **All members** — any org member can create resource groups.
+- **Admins only** (default) — only org admins can create Resource Groups.
+- **Write** — members with Write or Admin role can create Resource Groups.
+- **Contributor** — members with Contributor, Write, or Admin role can create Resource Groups.
+- **All members** — any org member can create Resource Groups.
 
-When a non-admin member creates a resource group, they are automatically added as an **admin** of that newly created group. When creating a resource group via the API, non-admin creators must include at least one admin in the group's initial user list.
+When a non-admin member creates a Resource Group through the UI, they are automatically added as an **admin** of that newly created group. Through the API, this does not happen automatically, since API callers may be creating groups on behalf of others. Non-admin API callers must include at least one user with the admin role in the group's initial member list.
 
 ## Resource Groups API
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -33,9 +33,9 @@ Head to your Organization's settings, then navigate to the "Resource Group" tab 
     <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-page-dark.png"/>
 </div>
 
-Organization admins can create and manage Resource Groups from that page. Depending on the organization's settings, members with lower roles may also be allowed to create resource groups (see [Who can create resource groups](#who-can-create-resource-groups) below).
+Organization admins can create and manage Resource Groups from that page. Depending on the organization's settings, members with lower roles may also be allowed to create Resource Groups (see [Who can create resource groups](#who-can-create-resource-groups) below).
 
-After creating a resource group and giving it a meaningful name, you can start adding repositories and users to it.
+After creating a Resource Group and giving it a meaningful name, you can start adding repositories and users to it.
 
 <div class="flex justify-center">
     <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-manage-empty-page.png"/>


### PR DESCRIPTION
## Summary

- Added bullet to `enterprise-resource-groups.md` noting that admins can configure which member roles are allowed to create resource groups
- Updated `security-resource-groups.md` to clarify that non-admin members may also create resource groups depending on org settings
- Added new "Who can create resource groups" section documenting the available options and behavior for non-admin creators


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates clarifying who can create Resource Groups; no product or API behavior changes.
> 
> **Overview**
> Updates Resource Groups documentation to mention that org admins can configure the minimum org role required to create new Resource Groups.
> 
> Adds a new **Who can create Resource Groups** section describing the available role thresholds (Admins only/Write/Contributor/All members) and clarifies UI vs API behavior when non-admins create a group (UI auto-adds creator as group `admin`, API requires specifying at least one `admin` member).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f69dd0f3e1c5e359aca7bfbc823685f82879631c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->