### PR TITLE
buckets: document CopyFile operation for storage buckets

### DIFF
--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -270,6 +270,35 @@ batch_bucket_files("username/my-bucket", delete=["old-model.bin", "logs/debug.lo
 
 For more deletion options (pattern-based filtering, recursive removal, etc.), see the [`huggingface_hub` delete guide](https://huggingface.co/docs/huggingface_hub/guides/buckets#delete-files).
 
+### Copying files between repos and buckets
+
+You can copy [Xet](./xet/index)-tracked files from any repository (model, dataset, Space) or bucket into a destination bucket without re-uploading the data. The copy is server-side: only the Xet content hashes are migrated, so even very large files are copied instantly.
+
+> [!NOTE]
+> Only Xet-tracked files can be copied this way. For small non-Xet files (e.g. config files, READMEs), download and re-upload them instead — they are lightweight.
+
+**CLI:**
+```bash
+hf buckets cp \
+  hf://datasets/HuggingFaceFW/fineweb/data \
+  hf://buckets/{your_username}/fineweb-data
+```
+
+**Python:**
+```python
+from huggingface_hub import HfApi
+
+api = HfApi()
+
+api.copy_files(
+    "hf://datasets/HuggingFaceFW/fineweb/data",
+    "hf://buckets/{your_username}/fineweb-data",
+)
+```
+
+
+The caller must have read access to the source repository/bucket and write access to the destination bucket.
+
 ## Pre-warming and CDN
 
 Buckets live on the Hub's global storage by default. For workloads where storage location directly affects throughput you can **pre-warm** bucket data to bring it closer to your compute.
@@ -299,7 +328,7 @@ Because buckets are built on [Xet](./xet/index), successive checkpoints where la
 
 Buckets serve as staging areas for data processing workflows. Process raw data, write intermediate outputs to a bucket, then promote the final artifact to a versioned [Dataset](./datasets) repository when the pipeline completes. This keeps your versioned repo clean while giving your pipeline fast mutable storage.
 
-Note that transferring data from a Bucket to a repository without reuploading is not yet available, but is on the roadmap.
+You can [copy Xet-tracked files](#copying-files-between-repos-and-buckets) between repositories and buckets server-side, without re-uploading.
 
 ### Agentic storage
 

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -328,7 +328,7 @@ Because buckets are built on [Xet](./xet/index), successive checkpoints where la
 
 Buckets serve as staging areas for data processing workflows. Process raw data, write intermediate outputs to a bucket, then promote the final artifact to a versioned [Dataset](./datasets) repository when the pipeline completes. This keeps your versioned repo clean while giving your pipeline fast mutable storage.
 
-You can [copy Xet-tracked files](#copying-files-between-repos-and-buckets) between repositories and buckets server-side, without re-uploading.
+Note that transferring data from a Bucket to a repository without reuploading is not yet available, but is on the roadmap.
 
 ### Agentic storage
 

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -275,7 +275,7 @@ For more deletion options (pattern-based filtering, recursive removal, etc.), se
 You can copy [Xet](./xet/index)-tracked files from any repository (model, dataset, Space) or bucket into a destination bucket without re-uploading the data. The copy is server-side: only the Xet content hashes are migrated, so even very large files are copied instantly.
 
 > [!NOTE]
-> Only Xet-tracked files are copied server-to-server. Small non-Xet files (e.g. config files, READMEs), are automatically downloaded and re-uploaded.
+> Only Xet-tracked files are copied server-to-server. Small non-Xet files (e.g., config files and READMEs) are automatically downloaded and re-uploaded.
 
 **CLI:**
 ```bash
@@ -292,12 +292,12 @@ api = HfApi()
 
 api.copy_files(
     "hf://datasets/HuggingFaceFW/fineweb/data",
-    "hf://buckets/{your_username}/fineweb-data",
+    "hf://buckets/username/fineweb-data",
 )
 ```
 
 
-The caller must have read access to the source repository/bucket and write access to the destination bucket.
+You need read access to the source repository or bucket and write access to the destination bucket.
 
 ## Pre-warming and CDN
 

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -281,7 +281,7 @@ You can copy [Xet](./xet/index)-tracked files from any repository (model, datase
 ```bash
 hf buckets cp \
   hf://datasets/HuggingFaceFW/fineweb/data \
-  hf://buckets/{your_username}/fineweb-data
+  hf://buckets/username/my-bucket
 ```
 
 **Python:**

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -275,7 +275,7 @@ For more deletion options (pattern-based filtering, recursive removal, etc.), se
 You can copy [Xet](./xet/index)-tracked files from any repository (model, dataset, Space) or bucket into a destination bucket without re-uploading the data. The copy is server-side: only the Xet content hashes are migrated, so even very large files are copied instantly.
 
 > [!NOTE]
-> Only Xet-tracked files can be copied this way. For small non-Xet files (e.g. config files, READMEs), download and re-upload them instead — they are lightweight.
+> Only Xet-tracked files are copied server-to-server. Small non-Xet files (e.g. config files, READMEs), are automatically downloaded and re-uploaded.
 
 **CLI:**
 ```bash


### PR DESCRIPTION
## Summary
- Document the copy files operation for storage buckets
- Show CLI (`hf buckets cp`) and Python (`api.copy_files`) usage
- Note that only Xet-tracked files can be copied server-side
- Update the "Data processing pipelines" use case to reference the new copy capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds guidance for `hf buckets cp`/`HfApi.copy_files`; no runtime or API behavior is modified.
> 
> **Overview**
> Adds a new **“Copying files between repos and buckets”** section to the storage buckets docs, describing server-side copying of Xet-tracked content from Hub repos or other buckets into a destination bucket.
> 
> Includes CLI (`hf buckets cp`) and Python (`HfApi.copy_files`) examples, plus a note that only Xet-tracked files copy server-to-server (non-Xet files are downloaded and re-uploaded) and that source read + destination write access is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a40880761264959e99339fa6e25c3bb4f00e780. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->