### PR TITLE
inference providers: update auto routing to always select fastest provider

### DIFF
--- a/docs/inference-providers/index.md
+++ b/docs/inference-providers/index.md
@@ -457,7 +457,7 @@ result = client.chat_completion(
 
 **Provider Selection Policy:**
 
-- `provider: "auto"` (default): Selects the first available provider for the model, sorted by your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers).
+- `provider: "auto"` (default): Selects the fastest available provider for the model (highest throughput in tokens per second), equivalent to the `:fastest` policy.
 - `provider: "specific-provider"`: Forces use of a specific provider (e.g., "together", "replicate", "fal-ai", ...).
 
 ### Alternative: OpenAI-Compatible Chat Completions Endpoint (Chat Only)


### PR DESCRIPTION
## Summary

- Updates the `provider: "auto"` description in the Inference Providers documentation to reflect that `auto` now always selects the fastest available provider (highest throughput in tokens/s), equivalent to the `:fastest` policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it updates wording for `provider: "auto"` behavior with no runtime or API changes.
> 
> **Overview**
> Updates the Inference Providers docs to clarify that `provider: "auto"` now **always selects the fastest available provider** (highest tokens/sec), aligning it with the `:fastest` routing policy rather than preference-order selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e7638f056d60cfbe4b3ca72816f21f13b0b5059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->