### PR TITLE
[Spaces]: add Spaces attached volumes documentation

### DIFF
--- a/docs/hub/spaces-storage.md
+++ b/docs/hub/spaces-storage.md
@@ -13,3 +13,19 @@ If you need to persist data with a longer lifetime than the Space itself, you ca
 </div>
 
 See the [Storage Buckets documentation](./storage-buckets) for full details on creating and using buckets.
+
+## Attached Volumes
+
+Spaces can mount Hugging Face repositories (models, datasets, other Spaces) and [Storage Buckets](./storage-buckets) as volumes. These volumes are mounted into the Space container at the paths specified during configuration, making repository or bucket contents available as local files at runtime.
+
+You can configure volumes from the Space settings under the **Storage** section, or using the [`huggingface_hub` Python client](https://huggingface.co/docs/huggingface_hub).
+
+### Viewing attached volumes
+
+The Space page displays attached volumes in the actions dropdown. Each volume shows its source repository or bucket, its mount path inside the container, and whether it is mounted as read-only or read-write.
+
+[screenshot]
+
+### Access-aware filtering
+
+When a volume references a private repository, the source is only visible to users who have read access to that repository. Users without access will still see that a volume is attached (along with its mount path and access mode), but the source will be masked as `****/******` with a "(private)" label. This prevents private repository names from being leaked to unauthorized viewers.

--- a/docs/hub/spaces-storage.md
+++ b/docs/hub/spaces-storage.md
@@ -20,7 +20,7 @@ See the [Storage Buckets documentation](./storage-buckets) for full details on c
 
 The Space page displays attached volumes in the actions dropdown. Each volume shows its source repository or bucket, its mount path inside the container, and whether it is mounted as read-only or read-write.
 
-<div class="flex justify-center" style="max-width: 300px">
+<div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-light.png"/>
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-dark.png"/>
 </div>

--- a/docs/hub/spaces-storage.md
+++ b/docs/hub/spaces-storage.md
@@ -20,7 +20,7 @@ See the [Storage Buckets documentation](./storage-buckets) for full details on c
 
 The Space page displays attached volumes in the actions dropdown. Each volume shows its source repository or bucket, its mount path inside the container, and whether it is mounted as read-only or read-write.
 
-<div class="flex justify-center" style="max-width: 350px">
+<div class="flex justify-center" style="max-width: 350px; margin: 0 auto">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-light.png"/>
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-dark.png"/>
 </div>

--- a/docs/hub/spaces-storage.md
+++ b/docs/hub/spaces-storage.md
@@ -3,9 +3,11 @@
 Every Space comes with a small amount of disk storage. This disk space is ephemeral, meaning its content will be lost if your Space restarts or is stopped.
 If you need to persist data with a longer lifetime than the Space itself, you can attach one (or more) Storage Buckets.
 
-## Storage Buckets
+## Attached Volumes
 
-[Storage Buckets](./storage-buckets) are the recommended way to persist data in your Space. You can attach a bucket when creating a Space or from the Space settings later. The bucket is mounted into your Space and can be used to store files that persist across restarts.
+Spaces can mount [Storage Buckets](./storage-buckets) and Hugging Face repositories (models, datasets, other Spaces) as volumes. These volumes are mounted into the Space container at the paths specified during configuration, making their contents available as local files at runtime.
+
+Storage Buckets are the recommended way to persist data. You can attach a bucket when creating a Space or from the Space settings later.
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attach-bucket.png"/>
@@ -13,12 +15,6 @@ If you need to persist data with a longer lifetime than the Space itself, you ca
 </div>
 
 See the [Storage Buckets documentation](./storage-buckets) for full details on creating and using buckets.
-
-## Attached Volumes
-
-Spaces can mount Hugging Face repositories (models, datasets, other Spaces) and [Storage Buckets](./storage-buckets) as volumes. These volumes are mounted into the Space container at the paths specified during configuration, making repository or bucket contents available as local files at runtime.
-
-You can configure volumes from the Space settings under the **Storage** section, or using the [`huggingface_hub` Python client](https://huggingface.co/docs/huggingface_hub).
 
 ### Viewing attached volumes
 
@@ -29,6 +25,4 @@ The Space page displays attached volumes in the actions dropdown. Each volume sh
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-dark.png"/>
 </div>
 
-### Access-aware filtering
-
-When a volume references a private repository, the source is only visible to users who have read access to that repository. Users without access will still see that a volume is attached (along with its mount path and access mode), but the source will be masked as `****/******` with a "(private)" label. This prevents private repository names from being leaked to unauthorized viewers.
+When a volume references a private repository, users without access will still see the volume listed (with its mount path and access mode), but the source will be masked as `****/******` with a "(private)" label.

--- a/docs/hub/spaces-storage.md
+++ b/docs/hub/spaces-storage.md
@@ -24,7 +24,10 @@ You can configure volumes from the Space settings under the **Storage** section,
 
 The Space page displays attached volumes in the actions dropdown. Each volume shows its source repository or bucket, its mount path inside the container, and whether it is mounted as read-only or read-write.
 
-[screenshot]
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-light.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-dark.png"/>
+</div>
 
 ### Access-aware filtering
 

--- a/docs/hub/spaces-storage.md
+++ b/docs/hub/spaces-storage.md
@@ -1,13 +1,18 @@
 # Disk usage on Spaces
 
 Every Space comes with a small amount of disk storage. This disk space is ephemeral, meaning its content will be lost if your Space restarts or is stopped.
-If you need to persist data with a longer lifetime than the Space itself, you can attach one (or more) Storage Buckets.
+If you need to persist data with a longer lifetime than the Space itself, you can attach one or more volumes (Storage Buckets or Hugging Face repositories).
 
 ## Attached Volumes
 
 Spaces can mount [Storage Buckets](./storage-buckets) and Hugging Face repositories (models, datasets, other Spaces) as volumes. These volumes are mounted into the Space container at the paths specified during configuration, making their contents available as local files at runtime.
 
-Storage Buckets are the recommended way to persist data. You can attach a bucket when creating a Space or from the Space settings later.
+Storage Buckets are the recommended way to persist data. How you attach a volume depends on the type:
+
+- **Storage Buckets** can be attached when creating a Space, from the Space settings UI, or programmatically via the [`huggingface_hub`](/docs/huggingface_hub/guides/manage-spaces#mount-volumes-in-your-space) Python API.
+- **Models, datasets, and other Spaces** can currently be attached as volumes through the [`huggingface_hub`](/docs/huggingface_hub/guides/manage-spaces#mount-volumes-in-your-space) Python API. Once attached, they appear in the Space settings alongside buckets, where you can view or unmount them.
+
+Models, datasets, and Spaces are always mounted as read-only. Storage Buckets can be mounted read-write (the default) or read-only.
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attach-bucket.png"/>

--- a/docs/hub/spaces-storage.md
+++ b/docs/hub/spaces-storage.md
@@ -1,18 +1,13 @@
 # Disk usage on Spaces
 
 Every Space comes with a small amount of disk storage. This disk space is ephemeral, meaning its content will be lost if your Space restarts or is stopped.
-If you need to persist data with a longer lifetime than the Space itself, you can attach one or more volumes (Storage Buckets or Hugging Face repositories).
+If you need to persist data with a longer lifetime than the Space itself, you can attach one or more [Storage Buckets](./storage-buckets) as volumes.
 
 ## Attached Volumes
 
-Spaces can mount [Storage Buckets](./storage-buckets) and Hugging Face repositories (models, datasets, other Spaces) as volumes. These volumes are mounted into the Space container at the paths specified during configuration, making their contents available as local files at runtime.
+[Storage Buckets](./storage-buckets) are the recommended way to persist data in your Space. Attached buckets are mounted into the Space container at the path you specify, making their contents available as local files at runtime.
 
-Storage Buckets are the recommended way to persist data. How you attach a volume depends on the type:
-
-- **Storage Buckets** can be attached when creating a Space, from the Space settings UI, or programmatically via the [`huggingface_hub`](/docs/huggingface_hub/guides/manage-spaces#mount-volumes-in-your-space) Python API.
-- **Models, datasets, and other Spaces** can currently be attached as volumes through the [`huggingface_hub`](/docs/huggingface_hub/guides/manage-spaces#mount-volumes-in-your-space) Python API. Once attached, they appear in the Space settings alongside buckets, where you can view or unmount them.
-
-Models, datasets, and Spaces are always mounted as read-only. Storage Buckets can be mounted read-write (the default) or read-only.
+Buckets can be attached when creating a Space, from the Space settings UI, or programmatically via the [`huggingface_hub`](/docs/huggingface_hub/guides/manage-spaces#mount-volumes-in-your-space) Python API. They can be mounted read-write (the default) or read-only.
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attach-bucket.png"/>
@@ -23,11 +18,17 @@ See the [Storage Buckets documentation](./storage-buckets) for full details on c
 
 ### Viewing attached volumes
 
-The Space page displays attached volumes in the actions dropdown. Each volume shows its source repository or bucket, its mount path inside the container, and whether it is mounted as read-only or read-write.
+The Space page displays attached volumes in the actions dropdown. Each volume shows its source bucket, its mount path inside the container, and whether it is mounted as read-only or read-write.
 
 <div class="flex justify-center" style="max-width: 350px; margin: 0 auto">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-light.png"/>
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-dark.png"/>
 </div>
+
+## Mounting models, datasets, and other Spaces
+
+Models, datasets, and other Spaces can be attached as volumes through the [`huggingface_hub`](/docs/huggingface_hub/guides/manage-spaces#mount-volumes-in-your-space) Python API. They are always mounted as read-only.
+
+Once attached, repo volumes appear in the Space actions dropdown alongside buckets and can be viewed or unmounted from the UI.
 
 When a volume references a private repository, users without access will still see the volume listed (with its mount path and access mode), but the source will be masked as `****/******` with a "(private)" label.

--- a/docs/hub/spaces-storage.md
+++ b/docs/hub/spaces-storage.md
@@ -20,7 +20,7 @@ See the [Storage Buckets documentation](./storage-buckets) for full details on c
 
 The Space page displays attached volumes in the actions dropdown. Each volume shows its source repository or bucket, its mount path inside the container, and whether it is mounted as read-only or read-write.
 
-<div class="flex justify-center">
+<div class="flex justify-center" style="max-width: 350px">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-light.png"/>
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-dark.png"/>
 </div>

--- a/docs/hub/spaces-storage.md
+++ b/docs/hub/spaces-storage.md
@@ -25,8 +25,8 @@ You can configure volumes from the Space settings under the **Storage** section,
 The Space page displays attached volumes in the actions dropdown. Each volume shows its source repository or bucket, its mount path inside the container, and whether it is mounted as read-only or read-write.
 
 <div class="flex justify-center">
-<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-light.png"/>
-<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-dark.png"/>
+<img class="block dark:hidden" width="300" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-light.png"/>
+<img class="hidden dark:block" width="300" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-dark.png"/>
 </div>
 
 ### Access-aware filtering

--- a/docs/hub/spaces-storage.md
+++ b/docs/hub/spaces-storage.md
@@ -24,9 +24,9 @@ You can configure volumes from the Space settings under the **Storage** section,
 
 The Space page displays attached volumes in the actions dropdown. Each volume shows its source repository or bucket, its mount path inside the container, and whether it is mounted as read-only or read-write.
 
-<div class="flex justify-center">
-<img class="block dark:hidden" width="300" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-light.png"/>
-<img class="hidden dark:block" width="300" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-dark.png"/>
+<div class="flex justify-center" style="max-width: 300px">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-light.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-attached-volumes-dark.png"/>
 </div>
 
 ### Access-aware filtering


### PR DESCRIPTION
## Summary
- Add an "Attached Volumes" section to the Spaces storage docs (`docs/hub/spaces-storage.md`)
- Document that Spaces can mount HF repos (models, datasets, Spaces) and Storage Buckets as volumes
- Describe how attached volumes appear in the Space page actions dropdown
- Document access-aware filtering: private repo sources are masked for unauthorized viewers

https://moon-ci-docs.huggingface.co/docs/hub/pr_2377/en/spaces-storage

<img width="756" height="591" alt="image" src="https://github.com/user-attachments/assets/947ac761-0b16-4294-a1b5-6fee82aba02f" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes describing how to attach and view volumes; no product code or behavior is modified.
> 
> **Overview**
> Updates `docs/hub/spaces-storage.md` to reframe persistent storage as **attached volumes**, detailing how Storage Buckets mount into the Space container (RW/RO) and how volumes are shown in the Space actions dropdown.
> 
> Adds documentation for mounting **models/datasets/other Spaces** as read-only volumes via the `huggingface_hub` API, including UI behavior for private repo sources being masked for unauthorized viewers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13282a24ccb897ccb53581e56f54584ffdbe878b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->