### PR TITLE
Update storage bucket path in documentation

### DIFF
--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -284,7 +284,7 @@ You can copy [Xet](./xet/index)-tracked files from any repository (model, datase
 ```bash
 hf buckets cp \
   hf://datasets/HuggingFaceFW/fineweb/data \
-  hf://buckets/username/my-bucket
+  hf://buckets/username/fineweb-data
 ```
 
 **Python:**

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -295,7 +295,7 @@ api = HfApi()
 
 api.copy_files(
     "hf://datasets/HuggingFaceFW/fineweb/data",
-    "hf://buckets/username/fineweb-data",
+    "hf://buckets/username/my-bucket",
 )
 ```
 

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -295,7 +295,7 @@ api = HfApi()
 
 api.copy_files(
     "hf://datasets/HuggingFaceFW/fineweb/data",
-    "hf://buckets/username/my-bucket",
+    "hf://buckets/username/fineweb-data",
 )
 ```
 


### PR DESCRIPTION
Making it consistent to use `username/my-bucket` in examples 

follow up to https://github.com/huggingface/hub-docs/pull/2375#discussion_r3072681160

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating a CLI example path; no runtime or API behavior is affected.
> 
> **Overview**
> Updates `storage-buckets.md` to change the `hf buckets cp` example destination from `hf://buckets/username/my-bucket` to `hf://buckets/username/fineweb-data`, aligning the example with the surrounding `fineweb` dataset copy scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbb400dd0fb294dce9b929fa233c8a67fbb85538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->