### PR TITLE
Update billing support faq with changes

### DIFF
--- a/docs/hub/billing.md
+++ b/docs/hub/billing.md
@@ -118,35 +118,43 @@ Hugging Face compute service usage will then be included in your AWS bill. Read 
 
 ## Support FAQ 
 
-**Q. Why did I get charged $10 when I added my credit card? When will I get this back?**
+**Q. Why do I need to add credits? What can I use them for?**
 
-A. This amount is not charged and the hold should clear within a few business days. If you have more questions about the status of the clear, you can contact your bank for more information. 
+A. Credits let you use HF pay-as-you-go services:
 
-**Q. My card was declined after adding to my account. What’s up?**
+- Jobs: run any workload on GPUs
+- Inference Providers: call 250k+ models via API
+- Inference Endpoints: dedicated deployments
+- GPU Spaces: host on custom hardware
+- ZeroGPU: extra quota beyond daily allowance
+- Private Storage: extra storage for private repos
+
+**Q. What happens if I run out of credits?**
+
+A. We recommend enabling automatic recharge to avoid service disruptions after credits are exhausted.
+
+**Q. I'm having issues adding my card. What’s up?**
 
 A. Please ensure the card supports 3D-secure authentication and is properly configured for recurring online payments. We do not yet support credit cards issued in India as we’re working on adding system compliance with the latest RBI directives. Until we add support for Indian credit cards, you can:
 * Link an organization account to an AWS account in order to access pay-as-you-go features (Endpoints, Spaces, AutoTrain): [Hugging Face Platform on the AWS Marketplace: Pay with your AWS Account](https://huggingface.co/blog/aws-marketplace)
 * Use a credit card issued in another country
 
-**Q. When am I going to get my invoice for pay as you go services?**
+**Q. How can I add my tax ID or update the billing details?**
 
-A. We bill in arrears and issue invoices for the prior month’s usage - typically the first of the month. So if you incurred billing usage in January, you’ll see the final payment process and invoiced February 1st.
+A. Email billing@huggingface.co and we can help!
 
-**Q. Why did you charge me multiple times during the month?**
+**Q. I was just billed for the PRO/Team subscription a few days ago. Why did you charge me again?**
 
-A. If you’re a new HF account using our premium pay as you go services, we’ll process a few billing threshold payments. Don’t worry, you’ll get an invoice for the total usage incurred for the month at the end of the billing period that will include these processed thresholds payments. For more information see https://huggingface.co/docs/hub/billing#billing-thresholds--invoicing.
+A. All subscriptions renew on the 1st of each month. We prorate the subscription charge if you sign up mid-month for your first month of Team or PRO.
 
 **Q. I need copies of my past invoices, where can I find these?**
 
-A. You can access up to the previous 3 months from the current month in your billing settings: https://huggingface.co/settings/billing. Click on the “End-of-period Invoice” link under that month’s “Payments & Invoices” and you’ll be able to download the invoice and the receipt. As an example:, if it’s currently January, you’ll be able to access the previous months’ invoices: December, November, and October. You can also check your email as we’ll send a copy of the invoice / receipt to the email address on the account. 
+A. View and download all invoices here: https://huggingface.co/settings/billing/invoices. Invoices are also emailed.
 
 **Q. I need to update my credit card in my account. What to do?**
 
 A. Head to https://huggingface.co/settings/billing/payment and update your payment method at anytime. 
 
-**Q. Oh no! My payment failed, what do I do to avoid a service interruption?**
-
-A. You can pay your bill with another payment method by clicking on the “pay online” link in the unpaid invoice. Click on the “End-of-period Invoice” link under that month’s “Payments & Invoices” and you’ll be able to pay online. You can also update your credit card at https://huggingface.co/settings/billing/payment.
 
 **Subscriptions**
 


### PR DESCRIPTION
Updates to the billing support FAQ documentation to include billing changes, with commonly asked questions received in support

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update; no product logic changes, but it may affect user expectations around credits and subscription billing if wording is inaccurate.
> 
> **Overview**
> Updates `docs/hub/billing.md` Support FAQ to align with the **credits-based pay-as-you-go** flow, including what credits are used for and guidance on avoiding disruptions when credits run out.
> 
> Refreshes billing guidance by adding a tax ID/billing-details contact, clarifying **PRO/Team proration and 1st-of-month renewals**, and updating invoice retrieval to the new `/settings/billing/invoices` link; removes older FAQ items about card authorization holds/threshold billing and failed-payment instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aff38f6d6b90fff8fc57d38758388cd1ff6ad013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->