### PR TITLE
Add buckets integrations docs: mount, filesystems, data processing

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -425,6 +425,8 @@
   sections:
   - local: storage-buckets-access
     title: Access Patterns
+  - local: storage-buckets-integrations
+    title: Bucket Integrations
   - local: storage-buckets-security
     title: Bucket Security
 

--- a/docs/hub/storage-buckets-integrations.md
+++ b/docs/hub/storage-buckets-integrations.md
@@ -1,0 +1,76 @@
+# Bucket Integrations
+
+Storage Buckets can be read and written from many Python data libraries using `hf://buckets/` paths, backed by the [`huggingface_hub` filesystem interface](/docs/huggingface_hub/guides/hf_file_system).
+
+For the underlying access mechanisms — mounts, volume mounts, and fsspec — see [Access Patterns](./storage-buckets-access).
+
+## pandas
+
+```python
+import pandas as pd
+
+df = pd.read_parquet("hf://buckets/username/my-bucket/data.parquet")
+df.to_parquet("hf://buckets/username/my-bucket/output.parquet")
+```
+
+## Dask
+
+```python
+import dask.dataframe as dd
+
+df = dd.read_parquet("hf://buckets/username/my-bucket/data.parquet")
+```
+
+## PyArrow
+
+```python
+import pyarrow.parquet as pq
+
+table = pq.read_table("hf://buckets/username/my-bucket/data.parquet")
+```
+
+## PySpark
+
+With [`pyspark_huggingface`](https://github.com/huggingface/pyspark_huggingface) installed:
+
+```python
+df = (
+    spark.read.format("huggingface")
+    .option("data_files", '["data.parquet"]')
+    .load("buckets/username/my-bucket")
+)
+```
+
+See [PySpark on the Hub](./datasets-pyspark) for more.
+
+## 🤗 Datasets
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("buckets/username/my-bucket", data_files=["data.parquet"])
+```
+
+## Filesystem operations
+
+For direct file operations, `huggingface_hub` exposes a pre-instantiated [filesystem object](/docs/huggingface_hub/guides/hf_file_system), `hffs`:
+
+```python
+from huggingface_hub import hffs
+
+with hffs.open("buckets/username/my-bucket/hello.txt", "w") as f:
+    f.write("Hello world!")
+
+hffs.cp("buckets/username/my-bucket/hello.txt", "buckets/username/my-bucket/hello2.txt")
+hffs.rm("buckets/username/my-bucket/hello2.txt")
+files = hffs.ls("buckets/username/my-bucket")
+text_files = hffs.glob("buckets/username/my-bucket/*.txt")
+```
+
+## Other languages
+
+[OpenDAL](https://opendal.apache.org/) provides a similar filesystem interface for Rust, Java, Go, JavaScript, and more.
+
+## Coming soon
+
+Support for more libraries is on the way — including Polars, DuckDB (native `hf://` URL support), Daft, and webdataset.

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -8,7 +8,7 @@ You can interact with buckets using the Hub web interface, the [`hf` CLI](https:
 > Buckets are available to all users and organizations. See [hf.co/storage](https://huggingface.co/storage) for pricing details.
 
 > [!TIP]
-> Want to use bucket data with pandas, DuckDB, or mount buckets as a local filesystem? See [Access Patterns](./storage-buckets-access).
+> See [Access Patterns](./storage-buckets-access) for how to reach bucket data from your tools (mount as a filesystem, `hf://` paths, volume mounts in Jobs/Spaces), and [Bucket Integrations](./storage-buckets-integrations) for ready-to-use snippets in popular data libraries like pandas, Dask, and Spark.
 
 ## Buckets vs Repositories
 
@@ -300,54 +300,6 @@ api.copy_files(
 ```
 
 You need read access to the source repository or bucket and write access to the destination bucket.
-
-## Integrations
-
-### Mount
-
-Use [hf-mount](https://github.com/huggingface/hf-mount) to mount buckets and repos as local filesystems:
-
-```bash
-hf-mount start bucket username/my-bucket /tmp/data
-```
-
-### FileSystems
-
-While `huggingface_hub` provides the main functions to handle files in buckets, you can also use its [filesystem interface](https://huggingface.co/docs/huggingface_hub/guides/hf_file_system) in Python for convenience:
-
-```python
-from huggingface_hub import hffs
-
-with hffs.open("buckets/username/my-bucket/hello.txt", "w") as f:
-    f.write("Hello world !")
-
-hffs.cp("buckets/username/my-bucket/hello.txt", "buckets/username/my-bucket/hello2.txt")
-hffs.rm("buckets/username/my-bucket/hello2.txt")
-files = hffs.ls("buckets/username/my-bucket")
-text_files = hffs.glob("buckets/username/my-bucket/*.txt")
-```
-
-Check out [OpenDAL](https://opendal.apache.org/) to access buckets with a similar interface in Rust/Java/Go/Javascript/etc.
-
-### Data processing
-
-Use your favorite data library with buckets:
-
-```python
-# pandas
-df = pd.read_parquet("hf://buckets/username/my-bucket/data.parquet")
-# dask
-df = dd.read_parquet("hf://buckets/username/my-bucket/data.parquet")
-# pyarrow
-df = pq.read_table("hf://buckets/username/my-bucket/data.parquet")
-# daft
-df = daft.read_parquet("hf://buckets/username/my-bucket/data.parquet")
-# pyspark + pyspark_huggingface
-df = spark.format("huggingface").option("data_files", '["data.parquet"]').load("buckets/username/my-bucket")
-# datasets
-ds = load_dataset("buckets/username/my-bucket", data_files=["data.parquet"])
-# more to come: polars, duckdb, webdataset...
-```
 
 ## Pre-warming and CDN
 

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -299,8 +299,55 @@ api.copy_files(
 )
 ```
 
-
 You need read access to the source repository or bucket and write access to the destination bucket.
+
+## Integrations
+
+### Mount
+
+Use [hf-mount](https://github.com/huggingface/hf-mount) to mount buckets and repos as local filesystems:
+
+```bash
+hf-mount start bucket username/my-bucket /tmp/data
+```
+
+### FileSystems
+
+While `huggingface_hub` provides the main functions to handle files in buckets, you can also use its [filesystem interface](https://huggingface.co/docs/huggingface_hub/guides/hf_file_system) in Python for convenience:
+
+```python
+from huggingface_hub import hffs
+
+with hffs.open("buckets/username/my-bucket/hello.txt", "w") as f:
+    f.write("Hello world !")
+
+hffs.cp("buckets/username/my-bucket/hello.txt", "buckets/username/my-bucket/hello2.txt")
+hffs.rm("buckets/username/my-bucket/hello2.txt")
+files = hffs.ls("buckets/username/my-bucket")
+text_files = hffs.glob("buckets/username/my-bucket/*.txt")
+```
+
+Check out [OpenDAL](https://opendal.apache.org/) to access buckets with a similar interface in Rust/Java/Go/Javascript/etc.
+
+### Data processing
+
+Use your favorite data library with buckets:
+
+```python
+# pandas
+df = pd.read_parquet("hf://buckets/username/my-bucket/data.parquet")
+# dask
+df = dd.read_parquet("hf://buckets/username/my-bucket/data.parquet")
+# pyarrow
+df = pq.read_table("hf://buckets/username/my-bucket/data.parquet")
+# daft
+df = daft.read_parquet("hf://buckets/username/my-bucket/data.parquet")
+# pyspark + pyspark_huggingface
+df = spark.format("huggingface").option("data_files", '["data.parquet"]').load("buckets/username/my-bucket")
+# datasets
+ds = load_dataset("buckets/username/my-bucket", data_files=["data.parquet"])
+# more to come: polars, duckdb, webdataset...
+```
 
 ## Pre-warming and CDN
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only changes that add a new page and update navigation links; no runtime or API behavior is affected.
> 
> **Overview**
> Adds a new `Bucket Integrations` doc under Storage Buckets with copy/paste examples for accessing `hf://buckets/...` data via pandas, Dask, PyArrow, PySpark (via `pyspark_huggingface`), 🤗 Datasets, and `huggingface_hub` filesystem operations.
> 
> Updates the Hub docs toctree and `storage-buckets.md` to link to this new integrations page alongside the existing Access Patterns guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f06bd0a3080647ed859540077fa402e26b7de20f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->