### PR TITLE
docs: align publisher analytics export schema

### DIFF
--- a/docs/hub/publisher-analytics.md
+++ b/docs/hub/publisher-analytics.md
@@ -62,7 +62,7 @@ Records are ordered chronologically and provide a daily granular view of downloa
 > [!WARNING]
 > This feature is an add-on for the <a href="https://huggingface.co/contact/sales?from=enterprise" target="_blank">Enterprise Plus</a> plan.
 
-As an advanced feature, Hugging Face can export anonymized, request-level access logs for all of the models and datasets published by your organization. Each line represents a single download-related request, giving you full granularity over your organization's download data.
+As an advanced feature, Hugging Face can export anonymized, request-level access logs for all of the models and datasets published by your organization. Each line represents a single download-related request, giving you full granularity over your models and datasets' download data.
 
 Your team is responsible for ingesting these logs and running computations on them. The export intentionally includes raw HTTP status codes and methods so you can classify `HEAD`, partial-content, redirect, and other request patterns based on your own analytics needs.
 

--- a/docs/hub/publisher-analytics.md
+++ b/docs/hub/publisher-analytics.md
@@ -62,20 +62,20 @@ Records are ordered chronologically and provide a daily granular view of downloa
 > [!WARNING]
 > This feature is an add-on for the <a href="https://huggingface.co/contact/sales?from=enterprise" target="_blank">Enterprise Plus</a> plan.
 
-As an advanced feature, Hugging Face can export anonymized, request-level access logs for all of the models and datasets published by your organization. Each line represents a single download request (including HEAD and partial requests), giving you full granularity over your models and datasets' download data.
+As an advanced feature, Hugging Face can export anonymized, request-level access logs for all of the models and datasets published by your organization. Each line represents a single download-related request, giving you full granularity over your organization's download data.
 
-Your team is responsible for ingesting these logs and running computations on them — for example, to deduplicate downloads to get unique downloader counts.
+Your team is responsible for ingesting these logs and running computations on them. The export intentionally includes raw HTTP status codes and methods so you can classify `HEAD`, partial-content, redirect, and other request patterns based on your own analytics needs.
 
 | Column         | Description                                             |
 | -------------- | ------------------------------------------------------- |
 | `timestamp`    | Request timestamp                                       |
-| `requestType`  | Type of download request (`GET`, `HEAD`, partial/range) |
+| `status`       | HTTP status code (for example `200`, `206`, `302`, `307`, `304`) |
+| `method`       | HTTP method (for example `GET`, `HEAD`)                 |
 | `repoName`     | Full repo name (e.g. `nvidia/segformer-b0`)             |
-| `repoType`     | `model` or `dataset`                                    |
+| `repoType`     | Repository type: `model`, `dataset`, or `space`         |
 | `hashedUserId` | Non-reversible hash of user ID (if authenticated)       |
 | `hashedIp`     | Non-reversible hash of IP address (if unauthenticated)  |
 | `country`      | Country ISO code                                        |
-| `region`       | Region name                                             |
-| `isInternal`   | Whether the request comes from an HF internal service   |
+| `region`       | Region or city name                                     |
 
 As it requires setting up a custom data export pipeline on our side (custom Elastic index, etc), this is only available as an add-on to Enterprise Plus.


### PR DESCRIPTION
Updates the publisher analytics page to match the current Enterprise Plus export schema. Replaces `requestType` and `isInternal` with `status` and `method`, clarifies the remaining field descriptions, and keeps the feature scope text limited to models and datasets so the page does not imply bucket support.

Internal PR: https://github.com/huggingface-internal/elastic-cloud-stats/pull/28

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5.4](https://img.shields.io/badge/GPT_5.4-000000)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates field names and descriptions to match the current Enterprise Plus log export schema.
> 
> **Overview**
> Updates `publisher-analytics.md` to match the current request-level export schema for Enterprise Plus.
> 
> Replaces `requestType`/`isInternal` with explicit `status` and `method` columns, clarifies that logs include raw HTTP codes/methods for custom classification, and updates field descriptions (including expanding `repoType` to include `space` and refining `region`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9da74a9cb00b07ce2b75e6cb5ebdcf326f71c094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->