### PR TITLE
docs: update from huggingface-internal/moon-landing#17752

### DIFF
--- a/docs/hub/oauth.md
+++ b/docs/hub/oauth.md
@@ -252,8 +252,8 @@ curl -X POST "https://huggingface.co/oauth/token" \
 
 Tokens issued via Token Exchange have built-in security restrictions:
 
-- **Organization-scoped**: Tokens can only access resources within your organization (models, datasets, Spaces owned by the org).
-- **No personal access**: Tokens cannot access the user's personal private repositories or resources from other organizations.
+- **Organization-scoped**: Tokens can only access resources within your organization (models, datasets, Spaces owned by the org), plus any public gated repos outside the org that the user has been individually granted access to (read-only).
+- **No personal access**: Tokens cannot access the user's personal private repositories or private repos from other organizations.
 - **Short-lived**: Tokens expire after 8 hours by default. Organization administrators can configure the token duration (up to 30 days) in the OAuth app settings. No refresh tokens are provided.
 - **Auditable**: All token exchanges are logged and visible in your organization's [audit logs](./audit-logs).
 


### PR DESCRIPTION
Automatically generated documentation update based on huggingface-internal/moon-landing#17752.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that уточifies Token Exchange token access boundaries; no runtime or security logic is modified.
> 
> **Overview**
> Updates `docs/hub/oauth.md` security considerations for Token Exchange tokens, clarifying that *org-scoped* tokens may also read public gated repos outside the org when the user has explicit access, and tightening the *no personal access* wording to explicitly exclude personal private repos and private repos in other orgs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2fe25deee7328d2c1137647c287c657438532c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->