### PR TITLE
Add Claude Code integration guide for Inference Providers

### DIFF
--- a/docs/inference-providers/_toctree.yml
+++ b/docs/inference-providers/_toctree.yml
@@ -38,6 +38,8 @@
     title: Overview
   - local: integrations/adding-integration
     title: Add Your Integration
+  - local: integrations/claude-code
+    title: Claude Code
   - local: integrations/hermes-agent
     title: Hermes Agent
   - local: integrations/datadesigner

--- a/docs/inference-providers/integrations/claude-code.md
+++ b/docs/inference-providers/integrations/claude-code.md
@@ -63,7 +63,7 @@ Then start Claude Code:
 claude
 ```
 
-Replace `zai-org/GLM-5.1` with any model available on [Inference Providers](https://huggingface.co/inference/models). You can also append a provider suffix to pin a specific provider (e.g. `MiniMaxAI/MiniMax-M2.7:fireworks-ai`). Setting an explicit provider gives you deterministic routing, while omitting it (e.g. `MiniMaxAI/MiniMax-M2.7`) lets the router fall back to alternative providers for better robustness.
+Replace `zai-org/GLM-5.1` with any model available on [Inference Providers](https://huggingface.co/inference/models). You can also append a provider suffix to pin a specific provider (e.g. `MiniMaxAI/MiniMax-M2.7:fireworks-ai`). Setting an explicit provider gives you deterministic routing, while omitting it (e.g. `MiniMaxAI/MiniMax-M2.7`) lets the router fall back to alternative providers for better resilience.
 
 > [!TIP]
 > The `ANTHROPIC_DEFAULT_*_MODEL` variables map to Claude Code's internal model slots (Opus, Sonnet, Haiku), from the most powerful to the quickest. You can assign different models to each slot to balance capability and speed e.g. `zai-org/GLM-5.1` for Opus, `google/gemma-4-31B-it:together` for Sonnet, and `openai/gpt-oss-120b:cerebras` for Haiku. `CLAUDE_CODE_SUBAGENT_MODEL` controls which model is used for sub-agents.

--- a/docs/inference-providers/integrations/claude-code.md
+++ b/docs/inference-providers/integrations/claude-code.md
@@ -65,6 +65,8 @@ claude
 
 Replace `zai-org/GLM-5.1` with any model available on [Inference Providers](https://huggingface.co/inference/models). You can also append a provider suffix to pin a specific provider (e.g. `MiniMaxAI/MiniMax-M2.7:fireworks-ai`). Setting an explicit provider gives you deterministic routing, while omitting it (e.g. `MiniMaxAI/MiniMax-M2.7`) lets the router fall back to alternative providers for better resilience.
 
+You can also append a `:cheapest` or `:fastest` suffix to prefer cheaper or faster providers (e.g. `MiniMaxAI/MiniMax-M2.7:cheapest`).
+
 > [!TIP]
 > The `ANTHROPIC_DEFAULT_*_MODEL` variables map to Claude Code's internal model slots (Opus, Sonnet, Haiku), from the most powerful to the quickest. You can assign different models to each slot to balance capability and speed e.g. `zai-org/GLM-5.1` for Opus, `google/gemma-4-31B-it:together` for Sonnet, and `openai/gpt-oss-120b:cerebras` for Haiku. `CLAUDE_CODE_SUBAGENT_MODEL` controls which model is used for sub-agents.
 

--- a/docs/inference-providers/integrations/claude-code.md
+++ b/docs/inference-providers/integrations/claude-code.md
@@ -1,0 +1,79 @@
+# Claude Code
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) is Anthropic's agentic coding tool that lives in your terminal. It can understand your codebase, edit files, run commands, and handle complex development tasks. By pointing it at Hugging Face Inference Providers, you can use open models like [GLM-5.1](https://huggingface.co/zai-org/GLM-5.1), [DeepSeek-R1](https://huggingface.co/deepseek-ai/DeepSeek-R1), and more as the backing LLM.
+
+## Overview
+
+Claude Code supports custom API endpoints via environment variables. By setting `ANTHROPIC_BASE_URL` to the Hugging Face router and providing your HF token, all Claude Code requests are routed through Inference Providers, giving you access to a wide range of open models.
+
+## Prerequisites
+
+- Claude Code CLI installed ([installation guide](https://docs.anthropic.com/en/docs/claude-code/setup))
+- A Hugging Face account with [API token](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained) (needs "Make calls to Inference Providers" permission)
+
+## Configuration
+
+### Option 1: Using the `hf-claude` Extension (Recommended)
+
+The [`hf-claude`](https://github.com/hanouticelina/hf-claude) extension for the `hf` CLI provides an interactive model and provider picker that launches Claude Code with the right environment variables preconfigured.
+
+1. Make sure you have `HF_TOKEN` set:
+
+```bash
+export HF_TOKEN="hf_..."
+```
+
+2. Install the extension:
+
+```bash
+hf extensions install hanouticelina/hf-claude
+```
+
+3. Launch Claude Code:
+
+```bash
+hf claude
+```
+
+The extension will present an interactive picker where you can select a model from the available Inference Providers models, and optionally choose a specific provider. It then launches Claude Code with all the necessary environment variables set.
+
+You can also forward any extra arguments to Claude Code:
+
+```bash
+hf claude --help
+```
+
+### Option 2: Manual Environment Variables
+
+Set the following environment variables before launching Claude Code:
+
+```bash
+export ANTHROPIC_BASE_URL="https://router.huggingface.co"
+export ANTHROPIC_AUTH_TOKEN="${HF_TOKEN}"
+export ANTHROPIC_API_KEY="${HF_TOKEN}"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="zai-org/GLM-5.1"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="zai-org/GLM-5.1"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="zai-org/GLM-5.1"
+export CLAUDE_CODE_SUBAGENT_MODEL="zai-org/GLM-5.1"
+```
+
+Then start Claude Code:
+
+```bash
+claude
+```
+
+Replace `zai-org/GLM-5.1` with any model available on [Inference Providers](https://huggingface.co/models?pipeline_tag=text-generation&inference_provider=all&sort=trending). You can also append a provider suffix to pin a specific provider (e.g. `zai-org/GLM-5.1:groq`).
+
+> [!TIP]
+> The `ANTHROPIC_DEFAULT_*_MODEL` variables map to Claude Code's internal model slots (Opus, Sonnet, Haiku). Setting all three to the same model ensures Claude Code uses your chosen model for every task. `CLAUDE_CODE_SUBAGENT_MODEL` controls which model is used for sub-agents.
+
+### Billing to an Organization
+
+To bill inference usage to a Hugging Face organization instead of your personal account, launch Claude Code with the `X-HF-Bill-To` header. You can do this by setting it in your environment or via a wrapper script.
+
+## Resources
+
+- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
+- [`hf-claude` Extension](https://github.com/hanouticelina/hf-claude)
+- [Available models on Inference Providers](https://huggingface.co/models?pipeline_tag=text-generation&inference_provider=all&sort=trending)

--- a/docs/inference-providers/integrations/claude-code.md
+++ b/docs/inference-providers/integrations/claude-code.md
@@ -29,7 +29,7 @@ export HF_TOKEN="hf_..."
 hf extensions install hanouticelina/hf-claude
 ```
 
-3. Launch Claude Code:
+3. Launch Claude Code through `hf`:
 
 ```bash
 hf claude

--- a/docs/inference-providers/integrations/claude-code.md
+++ b/docs/inference-providers/integrations/claude-code.md
@@ -66,7 +66,7 @@ claude
 Replace `zai-org/GLM-5.1` with any model available on [Inference Providers](https://huggingface.co/inference/models). You can also append a provider suffix to pin a specific provider (e.g. `MiniMaxAI/MiniMax-M2.7:fireworks-ai`). Setting an explicit provider gives you deterministic routing, while omitting it (e.g. `MiniMaxAI/MiniMax-M2.7`) lets the router fall back to alternative providers for better robustness.
 
 > [!TIP]
-> The `ANTHROPIC_DEFAULT_*_MODEL` variables map to Claude Code's internal model slots (Opus, Sonnet, Haiku), from the most powerful to the quickest. You can assign different models to each slot to balance capability and speed — for example, `zai-org/GLM-5.1` for Opus, `google/gemma-4-31B-it:together` for Sonnet, and `openai/gpt-oss-120b:cerebras` for Haiku. `CLAUDE_CODE_SUBAGENT_MODEL` controls which model is used for sub-agents.
+> The `ANTHROPIC_DEFAULT_*_MODEL` variables map to Claude Code's internal model slots (Opus, Sonnet, Haiku), from the most powerful to the quickest. You can assign different models to each slot to balance capability and speed e.g. `zai-org/GLM-5.1` for Opus, `google/gemma-4-31B-it:together` for Sonnet, and `openai/gpt-oss-120b:cerebras` for Haiku. `CLAUDE_CODE_SUBAGENT_MODEL` controls which model is used for sub-agents.
 
 ## Resources
 

--- a/docs/inference-providers/integrations/claude-code.md
+++ b/docs/inference-providers/integrations/claude-code.md
@@ -1,6 +1,6 @@
 # Claude Code
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code) is Anthropic's agentic coding tool that lives in your terminal. It can understand your codebase, edit files, run commands, and handle complex development tasks. By pointing it at Hugging Face Inference Providers, you can use open models like [GLM-5.1](https://huggingface.co/zai-org/GLM-5.1), [DeepSeek-R1](https://huggingface.co/deepseek-ai/DeepSeek-R1), and more as the backing LLM.
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) is Anthropic's agentic coding tool that lives in your terminal. It can understand your codebase, edit files, run commands, and handle complex development tasks. By pointing it at Hugging Face Inference Providers, you can use open models like [GLM-5.1](https://huggingface.co/zai-org/GLM-5.1), [Gemma 4](https://huggingface.co/google/gemma-4-31B-it), and more as the backing LLM.
 
 ## Overview
 
@@ -63,17 +63,13 @@ Then start Claude Code:
 claude
 ```
 
-Replace `zai-org/GLM-5.1` with any model available on [Inference Providers](https://huggingface.co/models?pipeline_tag=text-generation&inference_provider=all&sort=trending). You can also append a provider suffix to pin a specific provider (e.g. `zai-org/GLM-5.1:groq`).
+Replace `zai-org/GLM-5.1` with any model available on [Inference Providers](https://huggingface.co/inference/models). You can also append a provider suffix to pin a specific provider (e.g. `MiniMaxAI/MiniMax-M2.7:fireworks-ai`).
 
 > [!TIP]
-> The `ANTHROPIC_DEFAULT_*_MODEL` variables map to Claude Code's internal model slots (Opus, Sonnet, Haiku). Setting all three to the same model ensures Claude Code uses your chosen model for every task. `CLAUDE_CODE_SUBAGENT_MODEL` controls which model is used for sub-agents.
-
-### Billing to an Organization
-
-To bill inference usage to a Hugging Face organization instead of your personal account, launch Claude Code with the `X-HF-Bill-To` header. You can do this by setting it in your environment or via a wrapper script.
+> The `ANTHROPIC_DEFAULT_*_MODEL` variables map to Claude Code's internal model slots (Opus, Sonnet, Haiku), from the most powerful to the quickest. You can assign different models to each slot to balance capability and speed — for example, `zai-org/GLM-5.1` for Opus, `google/gemma-4-31B-it:together` for Sonnet, and `openai/gpt-oss-120b:cerebras` for Haiku. `CLAUDE_CODE_SUBAGENT_MODEL` controls which model is used for sub-agents.
 
 ## Resources
 
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
 - [`hf-claude` Extension](https://github.com/hanouticelina/hf-claude)
-- [Available models on Inference Providers](https://huggingface.co/models?pipeline_tag=text-generation&inference_provider=all&sort=trending)
+- [Available models on Inference Providers](https://huggingface.co/inference/models)

--- a/docs/inference-providers/integrations/claude-code.md
+++ b/docs/inference-providers/integrations/claude-code.md
@@ -63,7 +63,7 @@ Then start Claude Code:
 claude
 ```
 
-Replace `zai-org/GLM-5.1` with any model available on [Inference Providers](https://huggingface.co/inference/models). You can also append a provider suffix to pin a specific provider (e.g. `MiniMaxAI/MiniMax-M2.7:fireworks-ai`).
+Replace `zai-org/GLM-5.1` with any model available on [Inference Providers](https://huggingface.co/inference/models). You can also append a provider suffix to pin a specific provider (e.g. `MiniMaxAI/MiniMax-M2.7:fireworks-ai`). Setting an explicit provider gives you deterministic routing, while omitting it (e.g. `MiniMaxAI/MiniMax-M2.7`) lets the router fall back to alternative providers for better robustness.
 
 > [!TIP]
 > The `ANTHROPIC_DEFAULT_*_MODEL` variables map to Claude Code's internal model slots (Opus, Sonnet, Haiku), from the most powerful to the quickest. You can assign different models to each slot to balance capability and speed — for example, `zai-org/GLM-5.1` for Opus, `google/gemma-4-31B-it:together` for Sonnet, and `openai/gpt-oss-120b:cerebras` for Haiku. `CLAUDE_CODE_SUBAGENT_MODEL` controls which model is used for sub-agents.

--- a/docs/inference-providers/integrations/index.md
+++ b/docs/inference-providers/integrations/index.md
@@ -17,6 +17,7 @@ This table lists _some_ tools, libraries, and applications that work with Huggin
 
 | Integration                                                                                                         | Description                                                    | Resources                                                                                                             |
 | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code)                                                       | Agentic coding tool for the terminal                           | [HF docs](./claude-code)                                                                                               |
 | [CrewAI](https://www.crewai.com/)                                                                                   | Framework for orchestrating AI agent teams                     | [Official docs](https://docs.crewai.com/en/concepts/llms#hugging-face)                                                 |
 | [NeMo Data Designer](https://github.com/NVIDIA-NeMo/DataDesigner)                                                         | Synthetic dataset generation framework                         | [HF docs](./datadesigner)                                                                                              |
 | [GitHub Copilot Chat](https://docs.github.com/en/copilot)                                                           | AI pair programmer in VS Code                                  | [HF docs](./vscode)                                                                                                    |
@@ -53,6 +54,7 @@ End-user applications and interfaces powered by LLMs.
 
 AI-powered coding assistants and development environments.
 
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) - Agentic coding tool for the terminal ([HF docs](./claude-code))
 - [GitHub Copilot Chat](https://docs.github.com/en/copilot) - AI pair programmer in VS Code ([HF docs](./vscode))
 - [Hermes Agent](https://github.com/NousResearch/hermes-agent) - Open-source AI agent CLI for coding and development ([Official docs](https://hermes-agent.nousresearch.com/docs/user-guide/configuration/#hugging-face-inference-providers) / [HF docs](./hermes-agent))
 - [OpenCode](https://opencode.ai/) - AI coding agent built for the terminal ([Official docs](https://opencode.ai/docs/providers#hugging-face) / [HF docs](./opencode))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR adds a new integration guide documenting how to use **Claude Code** with Hugging Face Inference Providers.

## Changes

### New file: `docs/inference-providers/integrations/claude-code.md`

A dedicated integration page covering two setup methods:

1. **`hf-claude` extension (recommended)** — an extension for the `hf` CLI ([hanouticelina/hf-claude](https://github.com/hanouticelina/hf-claude)) that provides an interactive model and provider picker, then launches Claude Code with the correct environment variables.
2. **Manual environment variables** — setting `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`, and `ANTHROPIC_DEFAULT_*_MODEL` to route Claude Code through `router.huggingface.co`.

Also covers prerequisites, billing to an organization, and links to resources.

### Updated: `docs/inference-providers/integrations/index.md`

- Added Claude Code to the integrations overview table
- Added Claude Code to the **Developer Tools** category list

### Updated: `docs/inference-providers/_toctree.yml`

- Added Claude Code to the sidebar navigation under Integrations
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/D0A9313SS3G/p1776239201240679?thread_ts=1776239201.240679&cid=D0A9313SS3G)

<div><a href="https://cursor.com/agents/bc-e3a10fce-5be0-5dd8-8521-579ee50c45ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3a10fce-5be0-5dd8-8521-579ee50c45ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

