### PR TITLE
chore: bump doc-builder SHA for PR upload workflow

### DIFF
--- a/.github/workflows/api_inference_upload_pr_documentation.yml
+++ b/.github/workflows/api_inference_upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@9ad2de8582b56c017cb530c1165116d40433f1c6  # main
     with:
       package_name: inference-providers
     secrets:


### PR DESCRIPTION
Switch the PR doc upload flow from the legacy dataset push to the new HF bucket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that updates the referenced `huggingface/doc-builder` reusable workflow commit; impact is limited to PR documentation upload behavior.
> 
> **Overview**
> Updates the `Upload Inference Providers PR Documentation` GitHub Actions workflow to pin `huggingface/doc-builder`’s `upload_pr_documentation.yml` reusable workflow to a newer commit SHA, changing which upstream doc-upload implementation runs for inference-providers PR docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73ffdd0b25dc72b8569cff1047646ecd15b8c2a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->