### PR TITLE
docs(buckets): split integrations into dedicated sub-page

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -425,6 +425,8 @@
   sections:
   - local: storage-buckets-access
     title: Access Patterns
+  - local: storage-buckets-integrations
+    title: Bucket Integrations
   - local: storage-buckets-security
     title: Bucket Security
 

--- a/docs/hub/storage-buckets-integrations.md
+++ b/docs/hub/storage-buckets-integrations.md
@@ -1,0 +1,76 @@
+# Bucket Integrations
+
+Storage Buckets can be read and written from many Python data libraries using `hf://buckets/` paths, backed by the [`huggingface_hub` filesystem interface](/docs/huggingface_hub/guides/hf_file_system).
+
+For the underlying access mechanisms — mounts, volume mounts, and fsspec — see [Access Patterns](./storage-buckets-access).
+
+## pandas
+
+```python
+import pandas as pd
+
+df = pd.read_parquet("hf://buckets/username/my-bucket/data.parquet")
+df.to_parquet("hf://buckets/username/my-bucket/output.parquet")
+```
+
+## Dask
+
+```python
+import dask.dataframe as dd
+
+df = dd.read_parquet("hf://buckets/username/my-bucket/data.parquet")
+```
+
+## PyArrow
+
+```python
+import pyarrow.parquet as pq
+
+table = pq.read_table("hf://buckets/username/my-bucket/data.parquet")
+```
+
+## PySpark
+
+With [`pyspark_huggingface`](https://github.com/huggingface/pyspark_huggingface) installed:
+
+```python
+df = (
+    spark.read.format("huggingface")
+    .option("data_files", '["data.parquet"]')
+    .load("buckets/username/my-bucket")
+)
+```
+
+See [PySpark on the Hub](./datasets-pyspark) for more.
+
+## 🤗 Datasets
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("buckets/username/my-bucket", data_files=["data.parquet"])
+```
+
+## Filesystem operations
+
+For direct file operations, `huggingface_hub` exposes a pre-instantiated [filesystem object](/docs/huggingface_hub/guides/hf_file_system), `hffs`:
+
+```python
+from huggingface_hub import hffs
+
+with hffs.open("buckets/username/my-bucket/hello.txt", "w") as f:
+    f.write("Hello world!")
+
+hffs.cp("buckets/username/my-bucket/hello.txt", "buckets/username/my-bucket/hello2.txt")
+hffs.rm("buckets/username/my-bucket/hello2.txt")
+files = hffs.ls("buckets/username/my-bucket")
+text_files = hffs.glob("buckets/username/my-bucket/*.txt")
+```
+
+## Other languages
+
+[OpenDAL](https://opendal.apache.org/) provides a similar filesystem interface for Rust, Java, Go, JavaScript, and more.
+
+## Coming soon
+
+Support for more libraries is on the way — including Polars, DuckDB (native `hf://` URL support), Daft, and webdataset.

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -8,7 +8,7 @@ You can interact with buckets using the Hub web interface, the [`hf` CLI](https:
 > Buckets are available to all users and organizations. See [hf.co/storage](https://huggingface.co/storage) for pricing details.
 
 > [!TIP]
-> Want to use bucket data with pandas, DuckDB, or mount buckets as a local filesystem? See [Access Patterns](./storage-buckets-access).
+> See [Access Patterns](./storage-buckets-access) for how to reach bucket data from your tools (mount as a filesystem, `hf://` paths, volume mounts in Jobs/Spaces), and [Bucket Integrations](./storage-buckets-integrations) for ready-to-use snippets in popular data libraries like pandas, Dask, and Spark.
 
 ## Buckets vs Repositories
 
@@ -300,54 +300,6 @@ api.copy_files(
 ```
 
 You need read access to the source repository or bucket and write access to the destination bucket.
-
-## Integrations
-
-### Mount
-
-Use [hf-mount](https://github.com/huggingface/hf-mount) to mount buckets and repos as local filesystems:
-
-```bash
-hf-mount start bucket username/my-bucket /tmp/data
-```
-
-### FileSystems
-
-While `huggingface_hub` provides the main functions to handle files in buckets, you can also use its [filesystem interface](https://huggingface.co/docs/huggingface_hub/guides/hf_file_system) in Python for convenience:
-
-```python
-from huggingface_hub import hffs
-
-with hffs.open("buckets/username/my-bucket/hello.txt", "w") as f:
-    f.write("Hello world !")
-
-hffs.cp("buckets/username/my-bucket/hello.txt", "buckets/username/my-bucket/hello2.txt")
-hffs.rm("buckets/username/my-bucket/hello2.txt")
-files = hffs.ls("buckets/username/my-bucket")
-text_files = hffs.glob("buckets/username/my-bucket/*.txt")
-```
-
-Check out [OpenDAL](https://opendal.apache.org/) to access buckets with a similar interface in Rust/Java/Go/Javascript/etc.
-
-### Data processing
-
-Use your favorite data library with buckets:
-
-```python
-# pandas
-df = pd.read_parquet("hf://buckets/username/my-bucket/data.parquet")
-# dask
-df = dd.read_parquet("hf://buckets/username/my-bucket/data.parquet")
-# pyarrow
-df = pq.read_table("hf://buckets/username/my-bucket/data.parquet")
-# daft
-df = daft.read_parquet("hf://buckets/username/my-bucket/data.parquet")
-# pyspark + pyspark_huggingface
-df = spark.format("huggingface").option("data_files", '["data.parquet"]').load("buckets/username/my-bucket")
-# datasets
-ds = load_dataset("buckets/username/my-bucket", data_files=["data.parquet"])
-# more to come: polars, duckdb, webdataset...
-```
 
 ## Pre-warming and CDN
 


### PR DESCRIPTION
Stacked on top of #2383 — one concrete take on Julien's "maybe split this into a new page" suggestion. Feel free to merge, cherry-pick, or discard.

**What this changes**
- Moves the Integrations content into a new `storage-buckets-integrations.md` sub-page (sibling of Access Patterns, under Storage Buckets in the toctree)
- Keeps `storage-buckets.md` focused on concepts + management
- Reframes the top-of-page TIP so readers know which sub-page is for what: Access Patterns = mechanisms (mount, fsspec, volume mounts), Bucket Integrations = per-library snippets

**Why a separate page**
Integrations naturally grow as more libraries add bucket support, and a dedicated page gives library authors an obvious place to PR their own recipe. The split also avoids overlap with Access Patterns (which already covers `hf-mount` and `HfFileSystem` mechanics).

**One thing to double-check: Daft**
I moved Daft to the "Coming soon" list because `daft.read_parquet("hf://buckets/...")` didn't work in my tests against a real bucket — it returned `FileNotFoundError`, which suggests daft's `hf://` handler may not recognize the `buckets/` prefix yet. Totally happy to move it back to the working examples if you can confirm it works on your end (maybe I'm holding it wrong) — just thought it'd be good to verify before shipping the snippet in docs.

**Verified working** (against a real bucket): pandas, Dask, PyArrow, 🤗 Datasets (both forms), `hffs` filesystem operations. PySpark not tested locally but matches the form already documented in #2382.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that reorganizes content and links without affecting product behavior.
> 
> **Overview**
> **Reorganizes Storage Buckets docs** by moving the former “Integrations” section out of `storage-buckets.md` into a new `storage-buckets-integrations.md` page with ready-to-use snippets (pandas, Dask, PyArrow, PySpark, 🤗 Datasets, and `hffs` filesystem ops).
> 
> Updates `docs/hub/_toctree.yml` to add the new “Bucket Integrations” subpage under Storage Buckets, and adjusts the top-of-page TIP in `storage-buckets.md` to direct readers to *Access Patterns* vs *Bucket Integrations*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b5687599f7ea76cceff3785fe0fa25100ac5389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->