### PR TITLE
Add info about buckets free tier, and rewrite outdated comment

### DIFF
--- a/docs/hub/storage-buckets-access.md
+++ b/docs/hub/storage-buckets-access.md
@@ -11,7 +11,7 @@ Beyond the [CLI and Python SDK](./storage-buckets#managing-files), there are sev
 | **hf:// paths** (fsspec) | Python data tools (pandas, DuckDB) | [See below](#python-data-tools) |
 | **CLI sync** | Batch transfers, backups | [Sync docs](./storage-buckets#syncing-directories) |
 
-Access through `s3://` paths is on the roadmap, but not available yet.
+Access through the S3 API is not currently supported, but is on the roadmap.
 
 ## Mount as a Local Filesystem
 

--- a/docs/hub/storage-buckets-access.md
+++ b/docs/hub/storage-buckets-access.md
@@ -11,6 +11,8 @@ Beyond the [CLI and Python SDK](./storage-buckets#managing-files), there are sev
 | **hf:// paths** (fsspec) | Python data tools (pandas, DuckDB) | [See below](#python-data-tools) |
 | **CLI sync** | Batch transfers, backups | [Sync docs](./storage-buckets#syncing-directories) |
 
+Access through `s3://` paths is on the roadmap, but not available yet.
+
 ## Mount as a Local Filesystem
 
 [hf-mount](https://github.com/huggingface/hf-mount) lets you mount buckets (and repos) as local filesystems via NFS (recommended) or FUSE. Files are fetched lazily — only the bytes your code reads hit the network.

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -330,7 +330,7 @@ Because buckets are built on [Xet](./xet/index), successive checkpoints where la
 
 Buckets serve as staging areas for data processing workflows. Process raw data, write intermediate outputs to a bucket, then promote the final artifact to a versioned [Dataset](./datasets) repository when the pipeline completes. This keeps your versioned repo clean while giving your pipeline fast mutable storage.
 
-Bonus point: transferring data from a bucket to a repository is efficient because both use Xet under the hood. When you [promote a bucket artifact to a dataset repo](#copying-files-between-repos-and-buckets), only the Xet content hashes are copied server-side — no need to re-upload large files.
+Note that transferring data from a Bucket to a repository without reuploading is not yet available, but is on the roadmap.
 
 ### Agentic storage
 

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -330,7 +330,7 @@ Because buckets are built on [Xet](./xet/index), successive checkpoints where la
 
 Buckets serve as staging areas for data processing workflows. Process raw data, write intermediate outputs to a bucket, then promote the final artifact to a versioned [Dataset](./datasets) repository when the pipeline completes. This keeps your versioned repo clean while giving your pipeline fast mutable storage.
 
-Note that transferring data from a Bucket to a repository without reuploading is not yet available, but is on the roadmap.
+Bonus point: transferring data from a bucket to a repository is efficient because both use Xet under the hood. When you [promote a bucket artifact to a dataset repo](#copying-files-between-repos-and-buckets), only the Xet content hashes are copied server-side — no need to re-upload large files.
 
 ### Agentic storage
 

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -361,4 +361,6 @@ See [Specifying a bucket](./model-cards#specifying-a-bucket) in the model cards 
 
 Storage Buckets are billed based on the amount of data stored, with simple per-TB pricing. Enterprise plans benefit from dedup-based billing, where shared chunks across files directly reduce the billed footprint.
 
+As for other repositories, buckets are free to create and have a free storage allowance. You only pay if you exceed the [free tier](https://huggingface.co/docs/hub/storage-limits), and you can delete files to reduce your usage at any time.
+
 For current pricing tiers and volume discounts, see [hf.co/storage](https://huggingface.co/storage). For general billing information, see the [Billing](./billing) documentation.

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -363,6 +363,4 @@ See [Specifying a bucket](./model-cards#specifying-a-bucket) in the model cards 
 
 Storage Buckets are billed based on the amount of data stored, with simple per-TB pricing. Enterprise plans benefit from dedup-based billing, where shared chunks across files directly reduce the billed footprint.
 
-As for other repositories, buckets are free to create and have a free storage allowance. You only pay if you exceed the [free tier](https://huggingface.co/docs/hub/storage-limits), and you can delete files to reduce your usage at any time.
-
-For current pricing tiers and volume discounts, see [hf.co/storage](https://huggingface.co/storage). For general billing information, see the [Billing](./billing) documentation.
+As for other repositories, buckets are free to create and have a free storage allowance. For usage above the [free tier](https://huggingface.co/docs/hub/storage-limits), see [hf.co/storage](https://huggingface.co/storage). For general billing information, see the [Billing](./billing) documentation.

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -301,6 +301,8 @@ api.copy_files(
 
 You need read access to the source repository or bucket and write access to the destination bucket.
 
+Note that transferring data the other way from a bucket to a repository (model, dataset, Space) without reuploading is not yet available, but is on the roadmap.
+
 ## Pre-warming and CDN
 
 Buckets live on the Hub's global storage by default. For workloads where storage location directly affects throughput you can **pre-warm** bucket data to bring it closer to your compute.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only wording and link updates; no product logic or APIs are changed.
> 
> **Overview**
> Clarifies current Storage Bucket limitations by explicitly noting that **S3 API access isn’t supported yet** and that **server-side copy from a bucket back into a repo** (model/dataset/Space) is not available yet.
> 
> Updates the **Pricing** section to state that buckets are free to create and include a free storage allowance, linking to `storage-limits` for the free tier and keeping `hf.co/storage` for paid tiers/billing details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd549d8f8e0e95ecf8e57cf26f03f52a477d4904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->