### PR TITLE
docs: update from huggingface-internal/moon-landing#17503

### DIFF
--- a/docs/inference-providers/pricing.md
+++ b/docs/inference-providers/pricing.md
@@ -6,11 +6,11 @@ Access 200+ models from leading AI inference providers with centralized, transpa
 
 Every Hugging Face user receives monthly credits to experiment with Inference Providers:
 
-| Account Type                     | Monthly Credits          | Extra usage (pay-as-you-go)     |
-| -------------------------------- | ------------------------ | ------------------------------- |
-| Free Users                       | $0.10, subject to change | yes (credits purchase required) |
-| PRO Users                        | $2.00                    | yes                             |
-| Team or Enterprise Organizations | $2.00 per seat           | yes                             |
+| Account Type                     | Monthly Credits              | Extra usage (pay-as-you-go)     |
+| -------------------------------- | ---------------------------- | ------------------------------- |
+| Free Users                       | $0.10, subject to change     | yes (credits purchase required) |
+| PRO Users                        | up to $31 (max $1/day)       | yes                             |
+| Team or Enterprise Organizations | $2.00 per seat               | yes                             |
 
 > [!TIP]
 > Your monthly credits automatically apply when you route requests through Hugging Face. For Team or Enterprise organizations, credits are shared among all members.


### PR DESCRIPTION
Automatically generated documentation update based on huggingface-internal/moon-landing#17503.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adjusting stated PRO monthly credits; no code, behavior, or billing logic is modified.
> 
> **Overview**
> Updates `docs/inference-providers/pricing.md` to revise the *Free Credits* table, changing the PRO plan monthly credits from a fixed `$2.00` to **up to `$31` (max `$1/day`)**, while keeping Free and Team/Enterprise rows the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a840be2cbb96a7aa7ad04275125737d9d16268a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->