### PR TITLE
[Inference Providers] Add DeepInfra inference provider documentation

### DIFF
--- a/docs/inference-providers/_toctree.yml
+++ b/docs/inference-providers/_toctree.yml
@@ -106,6 +106,8 @@
     title: Cerebras
   - local: providers/cohere
     title: Cohere
+  - local: providers/deepinfra
+    title: DeepInfra
   - local: providers/fal-ai
     title: Fal AI
   - local: providers/featherless-ai

--- a/docs/inference-providers/index.md
+++ b/docs/inference-providers/index.md
@@ -15,6 +15,7 @@ Our platform integrates with leading AI infrastructure providers, giving you acc
 | -------------------------------------------- | :-------------------: | :-------------------: | :----------------: | :-----------: | :-----------: | :------------: |
 | [Cerebras](./providers/cerebras)             |          ✅           |                       |                    |               |               |                |
 | [Cohere](./providers/cohere)                 |          ✅           |          ✅           |                    |               |               |                |
+| [DeepInfra](./providers/deepinfra)           |          ✅           |          ✅           |                    |               |               |                |
 | [Fal AI](./providers/fal-ai)                 |                       |                       |                    |      ✅       |      ✅       |       ✅       |
 | [Featherless AI](./providers/featherless-ai) |          ✅           |          ✅           |                    |               |               |                |
 | [Fireworks](./providers/fireworks-ai)        |          ✅           |          ✅           |                    |               |               |                |

--- a/docs/inference-providers/providers/deepinfra.md
+++ b/docs/inference-providers/providers/deepinfra.md
@@ -1,0 +1,47 @@
+<!---
+WARNING
+
+This markdown file has been generated from a script. Please do not edit it directly.
+
+### Template
+
+If you want to update the content related to deepinfra's description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/deepinfra.handlebars`.
+
+### Logos
+
+If you want to update deepinfra's logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `deepinfra-light.png` and `deepinfra-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
+
+For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.
+--->
+
+# DeepInfra
+
+> [!TIP]
+> All supported DeepInfra models can be found [here](https://huggingface.co/models?inference_provider=deepinfra&sort=trending)
+
+<div class="flex justify-center">
+    <a href="https://deepinfra.com/" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/deepinfra-light.png"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/deepinfra-dark.png"/>
+    </a>
+</div>
+
+<div class="flex">
+    <a href="https://huggingface.co/deepinfra" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
+    </a>
+</div>
+
+DeepInfra is a serverless AI inference platform that enables developers to run machine learning models through a simple API, without managing infrastructure. The platform handles GPUs, scaling, and monitoring, offering cost-efficient pay-per-token pricing with OpenAI-compatible endpoints.
+
+## Resources
+- **Website**: https://deepinfra.com/
+- **Documentation**: https://deepinfra.com/docs
+
+## Supported tasks
+
+

--- a/scripts/inference-providers/scripts/generate.ts
+++ b/scripts/inference-providers/scripts/generate.ts
@@ -37,6 +37,7 @@ const HEADERS: Record<string, string> = process.env.HF_TOKEN
 const PROVIDERS_URLS: Record<string, string> = {
   cerebras: "https://www.cerebras.ai/",
   cohere: "https://cohere.com/",
+  deepinfra: "https://deepinfra.com/",
   "fal-ai": "https://fal.ai/",
   "featherless-ai": "https://featherless.ai/",
   "fireworks-ai": "https://fireworks.ai/",

--- a/scripts/inference-providers/templates/providers/deepinfra.handlebars
+++ b/scripts/inference-providers/templates/providers/deepinfra.handlebars
@@ -1,0 +1,16 @@
+# DeepInfra
+
+> [!TIP]
+> All supported DeepInfra models can be found [here](https://huggingface.co/models?inference_provider=deepinfra&sort=trending)
+
+{{{logoSection}}}
+
+{{{followUsSection}}}
+
+DeepInfra is a serverless AI inference platform that enables developers to run machine learning models through a simple API, without managing infrastructure. The platform handles GPUs, scaling, and monitoring, offering cost-efficient pay-per-token pricing with OpenAI-compatible endpoints.
+
+## Resources
+- **Website**: https://deepinfra.com/
+- **Documentation**: https://deepinfra.com/docs
+
+{{{tasksSection}}}

--- a/scripts/inference-providers/templates/providers/deepinfra.handlebars
+++ b/scripts/inference-providers/templates/providers/deepinfra.handlebars
@@ -7,10 +7,10 @@
 
 {{{followUsSection}}}
 
-DeepInfra is a serverless AI inference platform that enables developers to run machine learning models through a simple API, without managing infrastructure. The platform handles GPUs, scaling, and monitoring, offering cost-efficient pay-per-token pricing with OpenAI-compatible endpoints.
+DeepInfra is a serverless AI inference platform offering one of the most cost-effective pricing per token in the industry. With a catalog of over 100 models spanning LLMs, text-to-image, text-to-speech, speech-to-text, video generation, OCR, and more, DeepInfra makes it easy for developers to integrate a wide range of AI capabilities into their applications with minimal setup.
 
 ## Resources
 - **Website**: https://deepinfra.com/
-- **Documentation**: https://deepinfra.com/docs
+- **Documentation**: https://docs.deepinfra.com
 
 {{{tasksSection}}}


### PR DESCRIPTION
> ⚠️ Do not merge until the DeepInfra integration is live

Part of the DeepInfra provider integration ([huggingface/huggingface.js#1804](https://github.com/huggingface/huggingface.js/issues/1804)).

Logos uploaded to `huggingface/documentation-images`: [deepinfra-light.png](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/deepinfra-light.png), [deepinfra-dark.png](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/deepinfra-dark.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static-site generation updates only; no runtime product logic or security-sensitive code paths are changed.
> 
> **Overview**
> Adds **DeepInfra** as a listed Inference Provider by updating the docs navigation (`_toctree.yml`) and partners table (`index.md`).
> 
> Introduces a generated provider page `providers/deepinfra.md` and its source template `deepinfra.handlebars`, and updates the docs generation script (`generate.ts`) to include DeepInfra in `PROVIDERS_URLS` so it is rendered alongside other providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f28dd5d597c9cdb3ac9e50189bed97f8c153198. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->