### PR TITLE
docs: fix typo in datasets spark guide

### DIFF
--- a/docs/hub/datasets-spark.md
+++ b/docs/hub/datasets-spark.md
@@ -165,7 +165,7 @@ To filter the dataset and only keep dialogues in Chinese:
 ```
 
 It is also possible to apply filters or remove columns on the loaded DataFrame, but it is more efficient to do it while loading, especially on Parquet datasets.
-Indeed, Parquet contains metadata at the file and row group level, which allows to skip entire parts of the dataset that don't contain samples that satisfy the criteria. Columns in Parquet can also be loaded independently, whch allows to skip the excluded columns and avoid loading unnecessary data.
+Indeed, Parquet contains metadata at the file and row group level, which allows to skip entire parts of the dataset that don't contain samples that satisfy the criteria. Columns in Parquet can also be loaded independently, which allows to skip the excluded columns and avoid loading unnecessary data.
 
 ### Options
 


### PR DESCRIPTION
## Summary
- fix a typo in the datasets Spark guide

## Related issue
- N/A (trivial docs typo)

## Validation
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on runtime behavior.
> 
> **Overview**
> Fixes a typo in the Spark datasets guide by correcting "whch" to "which" in the Parquet metadata/predicate pushdown explanation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79447f05ecdc2c0aafcf7edb72fc06affbb87ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->