### PR TITLE
docs: fix typo in datasets ingesting guide

### DIFF
--- a/docs/hub/datasets-ingesting.md
+++ b/docs/hub/datasets-ingesting.md
@@ -93,7 +93,7 @@ The main reason is that you don’t want to version every update of your data be
 
 Three options are available:
 
-* **Use a Storage Bucket instead of a Dataset repository:** [Storage Buckets](/docs/hub/storage-buckets) offer an S3-like experience that allows upadating files very frequently, since they are not based on git. Storage Buckets are especially useful for data that are not ready to be published as a dataset, e.g. data that are still evolving or that need more curation.
+* **Use a Storage Bucket instead of a Dataset repository:** [Storage Buckets](/docs/hub/storage-buckets) offer an S3-like experience that allows updating files very frequently, since they are not based on git. Storage Buckets are especially useful for data that are not ready to be published as a dataset, e.g. data that are still evolving or that need more curation.
 * **Use a CommitScheduler**: The `CommitScheduler` in `huggingface_hub` offers near real-time ingestion to keep the git history of a Dataset repository manageable. It can be configured to do git commits at intervals defined in minutes.
 * **Use Hugging Face Jobs to schedule ingestion scripts**: Hugging Face Jobs provides a way to run and schedule python scripts on Hugging Face infrastructure. Schedule ingestion scripts to run at intervals defined using the Cron syntax.
 


### PR DESCRIPTION
## Summary
- fix a typo in the datasets ingesting guide

## Related issue
- N/A (trivial docs typo)

## Validation
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only typo fix with no behavioral or runtime impact.
> 
> **Overview**
> Fixes a typo in `docs/hub/datasets-ingesting.md`, correcting “upadating” to “updating” in the Storage Buckets option under **Scheduled ingestion**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5bf821d6e4d2df25103a440daa3b5e4c473333c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->