### PR TITLE
docs: add no_access organization member role

### DIFF
--- a/docs/hub/enterprise-resource-groups.md
+++ b/docs/hub/enterprise-resource-groups.md
@@ -22,7 +22,7 @@ This feature allows organization administrators to:
 
 - Group related repositories together for better organization
 - Control member access at a group level rather than individual repository level
-- Assign different permission roles (read, contributor, write, admin) to team members
+- Assign different permission roles (no_access, read, contributor, write, admin) to team members
 - Keep private repositories visible only to authorized group members
 - Enable multiple teams to work independently within the same organization
 - Configure which member roles are allowed to create new resource groups

--- a/docs/hub/organizations-security.md
+++ b/docs/hub/organizations-security.md
@@ -8,7 +8,9 @@
 >
 > The Resource Group feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 
-Members of organizations can have four different roles: `read`, `contributor`, `write`, or `admin`:
+Members of organizations can have five different roles: `no_access`, `read`, `contributor`, `write`, or `admin`:
+
+- `no_access`: the member belongs to the Organization but has no access to its repositories or settings. Use with [Resource Groups](./security-resource-groups) to grant access to specific repos only.
 
 - `read`: read-only access to the Organization's repos and metadata/settings (eg, the Organization's profile, members list, API token, etc).
 

--- a/docs/hub/programmatic-user-access-control.md
+++ b/docs/hub/programmatic-user-access-control.md
@@ -53,7 +53,7 @@ Content-Type: application/json
   - `role` (required): The member's **organization-level** role. One of: `"no_access"`, `"read"`, `"contributor"`, `"write"`, or `"admin"`.
   - `resourceGroups` (optional): Array of resource group assignments for this user. Each item:
     - `id`: Resource group ID (24-character hex string; get IDs from the [resource groups list API](#list-resource-groups)).
-    - `role`: Role in that resource group: `"no_access"`, `"read"`, `"contributor"`, `"write"`, or `"admin"`.
+    - `role`: Role in that resource group: `"read"`, `"contributor"`, `"write"`, or `"admin"`.
   - If you omit `resourceGroups` or pass `[]`, the user is removed from all resource groups. To only change org role and leave resource groups unchanged, pass their current resource group memberships (the body always sets both org role and resource group list).
 
 **Example (curl) – set org role to "read", no resource groups (removes any the user was previously in)**

--- a/docs/hub/programmatic-user-access-control.md
+++ b/docs/hub/programmatic-user-access-control.md
@@ -12,7 +12,7 @@ This guide describes how to manage organization member roles and resource group 
 
 ## Change member role via API
 
-You can change a member's **organization role** (Read / Contributor / Write / Admin) and, optionally, their roles in **resource groups** using the Hub API. The API updates **one member per request**. To change roles for multiple members, call the API in a loop (examples below).
+You can change a member's **organization role** (No Access / Read / Contributor / Write / Admin) and, optionally, their roles in **resource groups** using the Hub API. The API updates **one member per request**. To change roles for multiple members, call the API in a loop (examples below).
 
 **OpenAPI reference:** <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/PUT/api/organizations/&#123;name&#125;/members/&#123;username&#125;/role" rel="nofollow">PUT /api/organizations/&#123;name&#125;/members/&#123;username&#125;/role</a>
 
@@ -50,10 +50,10 @@ Content-Type: application/json
   - `org_name`: Organization slug (e.g. `my-org`).
   - `username`: Hugging Face **username** of the member whose role you are changing.
 - **Body**
-  - `role` (required): The member's **organization-level** role. One of: `"read"`, `"contributor"`, `"write"`, or `"admin"`.
+  - `role` (required): The member's **organization-level** role. One of: `"no_access"`, `"read"`, `"contributor"`, `"write"`, or `"admin"`.
   - `resourceGroups` (optional): Array of resource group assignments for this user. Each item:
     - `id`: Resource group ID (24-character hex string; get IDs from the [resource groups list API](#list-resource-groups)).
-    - `role`: Role in that resource group: `"read"`, `"contributor"`, `"write"`, or `"admin"`.
+    - `role`: Role in that resource group: `"no_access"`, `"read"`, `"contributor"`, `"write"`, or `"admin"`.
   - If you omit `resourceGroups` or pass `[]`, the user is removed from all resource groups. To only change org role and leave resource groups unchanged, pass their current resource group memberships (the body always sets both org role and resource group list).
 
 **Example (curl) – set org role to "read", no resource groups (removes any the user was previously in)**


### PR DESCRIPTION
Document the new `no_access` role for organization members across the relevant pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that expand role/value lists and add explanatory text; no runtime behavior or API implementation is modified.
> 
> **Overview**
> Documents a new organization-level role, `no_access`, across the Hub docs, updating role lists from 4 to 5 roles and adding a brief description of when to use it (notably alongside Resource Groups for repo-only access).
> 
> Updates the programmatic member-role management guide to include `no_access` in the described org roles and in the allowed `role` values for the `PUT /api/organizations/{name}/members/{username}/role` payload, and aligns Resource Groups docs to mention the expanded role set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7296d4fb0a2c7e2c928c94d14b732523e347c57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->