### PR TITLE
Refresh hub index page card styling

### DIFF
--- a/docs/hub/index.md
+++ b/docs/hub/index.md
@@ -4,8 +4,8 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 
 <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 md:mt-10 not-prose">
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-purple-100 bg-linear-to-br from-purple-50/50 dark:from-purple-500/5 px-6 py-4 dark:border-gray-850">
-<div class="flex items-center py-0.5 text-lg font-semibold text-purple-600 dark:text-white mb-2">
+<div class="group flex flex-col space-y-1 rounded-xl border border-purple-100 bg-linear-to-br from-purple-50/50 dark:from-purple-500/10 px-6 py-4 dark:border-gray-850">
+<div class="flex items-center py-0.5 text-lg font-semibold text-black dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-gray-900 dark:text-white" height="1em" viewBox="0 0 27 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="img"><path fill-rule="evenodd" clip-rule="evenodd" d="M16.555 8.061a4.447 4.447 0 0 0-3.94 2.913l-2.435 7.261c-.52 1.59.465 2.913 2.097 2.913h7.655a4.504 4.504 0 0 0 3.997-2.913l2.35-7.26c.506-1.591-.422-2.914-2.055-2.914H16.555Zm.563 2.913-2.435 7.107h5.024l.507-1.576h-2.955l.393-1.281h2.463l.563-1.548h-2.477l.422-1.168h2.815l.507-1.548h-4.87.057l-.014.014Z" fill="currentColor"/><path d="M15.201 1c1.633 0 2.562 1.337 2.055 2.913l-.738 2.273h-.013l-.05.002a6.326 6.326 0 0 0-5.602 4.142l-.009.024-.009.024-1.248 3.724H3.241c-1.647 0-2.604-1.338-2.112-2.914l2.463-7.275A4.447 4.447 0 0 1 7.532 1h7.67Zm-.309 10.188a4.503 4.503 0 0 1-3.296 2.823l1.019-3.036a4.448 4.448 0 0 1 3.264-2.826l-.987 3.04ZM5.593 5.545h2.928l-1.83 5.488h2.068l.247-.795.246-.795.422-1.266.564-1.548.393-1.084h2.815l.52-1.632h-7.81l-.563 1.632Z" fill="currentColor"/></svg> Subscriptions &  Plans</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./pro">PRO subscription</a>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./enterprise">Team & Enterprise Plans</a>
@@ -20,7 +20,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./rate-limits">Rate Limits</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-orange-100 bg-linear-to-br from-orange-50/50 dark:from-orange-500/5 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-orange-100 bg-linear-to-br from-orange-50/50 dark:from-orange-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-orange-600 dark:text-white mb-2">
  <svg class="shrink-0 mr-1.5 text-orange-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><path fill="currentColor" d="M2.6 10.59L8.38 4.8l1.69 1.7c-.24.85.15 1.78.93 2.23v5.54c-.6.34-1 .99-1 1.73a2 2 0 0 0 2 2a2 2 0 0 0 2-2c0-.74-.4-1.39-1-1.73V9.41l2.07 2.09c-.07.15-.07.32-.07.5a2 2 0 0 0 2 2a2 2 0 0 0 2-2a2 2 0 0 0-2-2c-.18 0-.35 0-.5.07L13.93 7.5a1.98 1.98 0 0 0-1.15-2.34c-.43-.16-.88-.2-1.28-.09L9.8 3.38l.79-.78c.78-.79 2.04-.79 2.82 0l7.99 7.99c.79.78.79 2.04 0 2.82l-7.99 7.99c-.78.79-2.04.79-2.82 0L2.6 13.41c-.79-.78-.79-2.04 0-2.82Z"></path></svg>Repositories</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./repositories-getting-started">Getting Started</a>
@@ -36,7 +36,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./repositories-licenses">Licenses</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-indigo-100 bg-linear-to-br from-indigo-50/50 dark:from-indigo-500/5 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-indigo-100 bg-linear-to-br from-indigo-50/50 dark:from-indigo-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-indigo-600 dark:text-white mb-2">
     <svg class="shrink-0 mr-1.5 text-indigo-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><path class="uim-quaternary" d="M20.23 7.24L12 12L3.77 7.24a1.98 1.98 0 0 1 .7-.71L11 2.76c.62-.35 1.38-.35 2 0l6.53 3.77c.29.173.531.418.7.71z" opacity=".25" fill="currentColor"></path><path class="uim-tertiary" d="M12 12v9.5a2.09 2.09 0 0 1-.91-.21L4.5 17.48a2.003 2.003 0 0 1-1-1.73v-7.5a2.06 2.06 0 0 1 .27-1.01L12 12z" opacity=".5" fill="currentColor"></path><path class="uim-primary" d="M20.5 8.25v7.5a2.003 2.003 0 0 1-1 1.73l-6.62 3.82c-.275.13-.576.198-.88.2V12l8.23-4.76c.175.308.268.656.27 1.01z" fill="currentColor"></path></svg> Models</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./models-the-hub">The Model Hub</a>
@@ -52,7 +52,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./models-download-stats">Download Stats</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-red-100 bg-linear-to-br from-red-50/50 dark:from-red-500/5 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-red-100 bg-linear-to-br from-red-50/50 dark:from-red-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-red-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-red-400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 25 25"><ellipse cx="12.5" cy="5" fill="currentColor" fill-opacity="0.25" rx="7.5" ry="2"></ellipse><path d="M12.5 15C16.6421 15 20 14.1046 20 13V20C20 21.1046 16.6421 22 12.5 22C8.35786 22 5 21.1046 5 20V13C5 14.1046 8.35786 15 12.5 15Z" fill="currentColor" opacity="0.5"></path><path d="M12.5 7C16.6421 7 20 6.10457 20 5V11.5C20 12.6046 16.6421 13.5 12.5 13.5C8.35786 13.5 5 12.6046 5 11.5V5C5 6.10457 8.35786 7 12.5 7Z" fill="currentColor" opacity="0.5"></path><path d="M5.23628 12C5.08204 12.1598 5 12.8273 5 13C5 14.1046 8.35786 15 12.5 15C16.6421 15 20 14.1046 20 13C20 12.8273 19.918 12.1598 19.7637 12C18.9311 12.8626 15.9947 13.5 12.5 13.5C9.0053 13.5 6.06886 12.8626 5.23628 12Z" fill="currentColor"></path></svg> Datasets</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets">Introduction</a>
@@ -70,7 +70,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets-data-files-configuration">Data files Configuration</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-blue-100 bg-linear-to-br from-blue-50/50 dark:from-blue-500/5 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-blue-100 bg-linear-to-br from-blue-50/50 dark:from-blue-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-blue-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-blue-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" viewBox="0 0 25 25"><path opacity=".5" d="M6.016 14.674v4.31h4.31v-4.31h-4.31ZM14.674 14.674v4.31h4.31v-4.31h-4.31ZM6.016 6.016v4.31h4.31v-4.31h-4.31Z" fill="currentColor"></path><path opacity=".75" fill-rule="evenodd" clip-rule="evenodd" d="M3 4.914C3 3.857 3.857 3 4.914 3h6.514c.884 0 1.628.6 1.848 1.414a5.171 5.171 0 0 1 7.31 7.31c.815.22 1.414.964 1.414 1.848v6.514A1.914 1.914 0 0 1 20.086 22H4.914A1.914 1.914 0 0 1 3 20.086V4.914Zm3.016 1.102v4.31h4.31v-4.31h-4.31Zm0 12.968v-4.31h4.31v4.31h-4.31Zm8.658 0v-4.31h4.31v4.31h-4.31Zm0-10.813a2.155 2.155 0 1 1 4.31 0 2.155 2.155 0 0 1-4.31 0Z" fill="currentColor"></path><path opacity=".25" d="M16.829 6.016a2.155 2.155 0 1 0 0 4.31 2.155 2.155 0 0 0 0-4.31Z" fill="currentColor"></path></svg> Spaces</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces">Introduction</a>
@@ -86,7 +86,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces-oauth">Sign in with HF</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-blue-100 bg-linear-to-br from-blue-50/50 dark:from-blue-500/5 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-blue-100 bg-linear-to-br from-blue-50/50 dark:from-blue-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-blue-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-blue-500" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 48 48" fill="none"><path opacity="0.25" d="M36 4H12C7.58172 4 4 7.58172 4 12V36C4 40.4183 7.58172 44 12 44H36C40.4183 44 44 40.4183 44 36V12C44 7.58172 40.4183 4 36 4Z" fill="currentColor"/><path opacity="0.5" d="M31 11H17C13.6863 11 11 13.6863 11 17V31C11 34.3137 13.6863 37 17 37H31C34.3137 37 37 34.3137 37 31V17C37 13.6863 34.3137 11 31 11Z" fill="currentColor"/><path d="M27 18H21C19.3431 18 18 19.3431 18 21V27C18 28.6569 19.3431 30 21 30H27C28.6569 30 30 28.6569 30 27V21C30 19.3431 28.6569 18 27 18Z" fill="currentColor"/></svg> Storage Buckets <span class="ml-1 rounded-sm bg-blue-500/10 px-1 text-xs leading-tight text-blue-700 dark:text-blue-200">new</span></div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./storage-buckets">Introduction</a>
@@ -97,7 +97,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./storage-buckets-security">Security & Compliance</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-teal-100 bg-linear-to-br from-teal-50/50 dark:from-teal-500/5 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-teal-100 bg-linear-to-br from-teal-50/50 dark:from-teal-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-teal-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-teal-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 18 18" fill="currentColor"><path d="M6.66667 12.4352V4.93521L11.6667 8.68521L6.66667 12.4352ZM8.33333 0.351877C7.23898 0.351877 6.15535 0.567425 5.1443 0.986215C4.13326 1.405 3.2146 2.01883 2.44078 2.79265C0.877974 4.35546 0 6.47507 0 8.68521C0 10.8953 0.877974 13.015 2.44078 14.5778C3.2146 15.3516 4.13326 15.9654 5.1443 16.3842C6.15535 16.803 7.23898 17.0185 8.33333 17.0185C10.5435 17.0185 12.6631 16.1406 14.2259 14.5778C15.7887 13.015 16.6667 10.8953 16.6667 8.68521C16.6667 7.59086 16.4511 6.50723 16.0323 5.49618C15.6135 4.48514 14.9997 3.56648 14.2259 2.79265C13.4521 2.01883 12.5334 1.405 11.5224 0.986215C10.5113 0.567425 9.42768 0.351877 8.33333 0.351877Z"></path></svg> Jobs</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./jobs">Introduction</a>
@@ -112,7 +112,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./jobs-reference">Reference</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-cyan-100 bg-linear-to-br from-cyan-50/50 dark:from-cyan-500/5 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-cyan-100 bg-linear-to-br from-cyan-50/50 dark:from-cyan-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-cyan-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-cyan-500" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" viewBox="0 0 12 12" fill="currentColor"><rect width="9.491" height="2.438" x="1.254" y="8.845" fill="currentColor" opacity=".5" rx="1.219"/><path fill="currentColor" d="M8.068 3.07a2.678 2.678 0 0 1 0 5.355H3.932a2.678 2.678 0 0 1 0-5.355h1.652v.412a.343.343 0 0 0 .684 0V3.07zM4.412 4.85a.898.898 0 1 0 0 1.796.898.898 0 0 0 0-1.795m3.177 0a.898.898 0 1 0 0 1.796.898.898 0 0 0 0-1.795"/><path fill="currentColor" d="M6.269 3.48a.342.342 0 0 1-.684 0V2.353a.9.9 0 0 0 .684 0z" opacity=".25"/><circle cx="5.927" cy="1.526" r=".894" fill="currentColor"/></svg> Agents</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./agents">Introduction</a>
@@ -125,7 +125,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./agents-libraries">Agent Libraries</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-green-100 bg-linear-to-br from-green-50/50 dark:from-green-500/5 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-green-100 bg-linear-to-br from-green-50/50 dark:from-green-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-green-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-green-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" viewBox="0 0 24 24"><path fill="currentColor" stroke="currentColor" d="M8.892 21.854a6.25 6.25 0 0 1-4.42-10.67l7.955-7.955a4.5 4.5 0 0 1 6.364 6.364l-6.895 6.894a2.816 2.816 0 0 1-3.89 0a2.75 2.75 0 0 1 .002-3.888l5.126-5.127a1 1 0 1 1 1.414 1.414l-5.126 5.127a.75.75 0 0 0 0 1.06a.768.768 0 0 0 1.06 0l6.895-6.894a2.503 2.503 0 0 0 0-3.535a2.56 2.56 0 0 0-3.536 0l-7.955 7.955a4.25 4.25 0 1 0 6.01 6.01l6.188-6.187a1 1 0 1 1 1.414 1.414l-6.187 6.186a6.206 6.206 0 0 1-4.42 1.832z"></path></svg> Other</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./organizations">Organizations</a>

--- a/docs/hub/index.md
+++ b/docs/hub/index.md
@@ -2,143 +2,143 @@
 
 The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M demo apps (Spaces), all open source and publicly available, in an online platform where people can easily collaborate and build ML together. The Hub works as a central place where anyone can explore, experiment, collaborate, and build technology with Machine Learning. Are you ready to join the path towards open source Machine Learning? 🤗
 
-<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 md:mt-10">
+<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 md:mt-10 not-prose">
 
-<div class="group flex flex-col space-y-2 rounded-xl border border-purple-100 bg-linear-to-br from-purple-50 dark:bg-none px-6 py-4 transition-colors hover:shadow-sm dark:border-purple-700">
-<div class="flex items-center py-0.5 text-lg font-semibold text-purple-600 dark:text-gray-400 mb-1">
-<svg class="shrink-0 mr-1.5 text-purple-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" viewBox="0 0 32 32"><path fill="currentColor" d="M11.61 29.92a1 1 0 0 1-.6-1.07L12.83 17H8a1 1 0 0 1-1-1.23l3-13A1 1 0 0 1 11 2h10a1 1 0 0 1 .78.37a1 1 0 0 1 .2.85L20.25 11H25a1 1 0 0 1 .9.56a1 1 0 0 1-.11 1l-13 17A1 1 0 0 1 12 30a1.1 1.1 0 0 1-.39-.08M17.75 13l2-9H11.8L9.26 15h5.91l-1.59 10.28L23 13Z"/></svg> Subscriptions &  Plans</div>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./pro">PRO subscription</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./enterprise">Team & Enterprise Plans</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./enterprise-sso">Single Sign-On (SSO)</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./audit-logs">Audit Logs</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./storage-regions">Storage Regions</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./enterprise-datasets">Data Studio for Private datasets</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./security-resource-groups">Resource Groups</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./enterprise-advanced-security">Advanced Security</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./enterprise-tokens-management">Tokens Management</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./enterprise-network-security">Network Security</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./rate-limits">Rate Limits</a>
+<div class="group flex flex-col space-y-1 rounded-xl border border-purple-100 bg-linear-to-br from-purple-50/50 dark:from-purple-500/5 px-6 py-4 dark:border-gray-850">
+<div class="flex items-center py-0.5 text-lg font-semibold text-purple-600 dark:text-white mb-2">
+<svg class="shrink-0 mr-1.5 text-gray-900 dark:text-white" height="1em" viewBox="0 0 27 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="img"><path fill-rule="evenodd" clip-rule="evenodd" d="M16.555 8.061a4.447 4.447 0 0 0-3.94 2.913l-2.435 7.261c-.52 1.59.465 2.913 2.097 2.913h7.655a4.504 4.504 0 0 0 3.997-2.913l2.35-7.26c.506-1.591-.422-2.914-2.055-2.914H16.555Zm.563 2.913-2.435 7.107h5.024l.507-1.576h-2.955l.393-1.281h2.463l.563-1.548h-2.477l.422-1.168h2.815l.507-1.548h-4.87.057l-.014.014Z" fill="currentColor"/><path d="M15.201 1c1.633 0 2.562 1.337 2.055 2.913l-.738 2.273h-.013l-.05.002a6.326 6.326 0 0 0-5.602 4.142l-.009.024-.009.024-1.248 3.724H3.241c-1.647 0-2.604-1.338-2.112-2.914l2.463-7.275A4.447 4.447 0 0 1 7.532 1h7.67Zm-.309 10.188a4.503 4.503 0 0 1-3.296 2.823l1.019-3.036a4.448 4.448 0 0 1 3.264-2.826l-.987 3.04ZM5.593 5.545h2.928l-1.83 5.488h2.068l.247-.795.246-.795.422-1.266.564-1.548.393-1.084h2.815l.52-1.632h-7.81l-.563 1.632Z" fill="currentColor"/></svg> Subscriptions &  Plans</div>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./pro">PRO subscription</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./enterprise">Team & Enterprise Plans</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./enterprise-sso">Single Sign-On (SSO)</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./audit-logs">Audit Logs</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./storage-regions">Storage Regions</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./enterprise-datasets">Data Studio for Private datasets</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./security-resource-groups">Resource Groups</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./enterprise-advanced-security">Advanced Security</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./enterprise-tokens-management">Tokens Management</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./enterprise-network-security">Network Security</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./rate-limits">Rate Limits</a>
 </div>
 
-<div class="group flex flex-col space-y-2 rounded-xl border border-orange-100 bg-linear-to-br from-orange-50 dark:bg-none px-6 py-4 transition-colors hover:shadow-sm dark:border-orange-700">
-<div class="flex items-center py-0.5 text-lg font-semibold text-orange-600 dark:text-gray-400 mb-1">
+<div class="group flex flex-col space-y-1 rounded-xl border border-orange-100 bg-linear-to-br from-orange-50/50 dark:from-orange-500/5 px-6 py-4 dark:border-gray-850">
+<div class="flex items-center py-0.5 text-lg font-semibold text-orange-600 dark:text-white mb-2">
  <svg class="shrink-0 mr-1.5 text-orange-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><path fill="currentColor" d="M2.6 10.59L8.38 4.8l1.69 1.7c-.24.85.15 1.78.93 2.23v5.54c-.6.34-1 .99-1 1.73a2 2 0 0 0 2 2a2 2 0 0 0 2-2c0-.74-.4-1.39-1-1.73V9.41l2.07 2.09c-.07.15-.07.32-.07.5a2 2 0 0 0 2 2a2 2 0 0 0 2-2a2 2 0 0 0-2-2c-.18 0-.35 0-.5.07L13.93 7.5a1.98 1.98 0 0 0-1.15-2.34c-.43-.16-.88-.2-1.28-.09L9.8 3.38l.79-.78c.78-.79 2.04-.79 2.82 0l7.99 7.99c.79.78.79 2.04 0 2.82l-7.99 7.99c-.78.79-2.04.79-2.82 0L2.6 13.41c-.79-.78-.79-2.04 0-2.82Z"></path></svg>Repositories</div>
-<a class="transform no-underline! transition-colors hover:translate-x-px hover:text-gray-700" href="./repositories-getting-started">Getting Started</a>
-<a class="transform no-underline! transition-colors hover:translate-x-px hover:text-gray-700" href="./repositories-settings">Repository Settings</a>
-<a class="transform no-underline! transition-colors hover:translate-x-px hover:text-gray-700" href="./storage-limits">Storage Limits</a>
-<a class="transform no-underline! transition-colors hover:translate-x-px hover:text-gray-700" href="./xet/index">Storage Backend (Xet)</a>
-<a class="transform no-underline! transition-colors hover:translate-x-px hover:text-gray-700" href="./local-cache">Local Cache</a>
-<a class="transform no-underline! transition-colors hover:translate-x-px hover:text-gray-700" href="./repositories-pull-requests-discussions">Pull requests and Discussions</a>
-<a class="transform no-underline! transition-colors hover:translate-x-px hover:text-gray-700" href="./notifications">Notifications</a>
-<a class="transform no-underline! transition-colors hover:translate-x-px hover:text-gray-700" href="./collections">Collections</a>
-<a class="transform no-underline! transition-colors hover:translate-x-px hover:text-gray-700" href="./webhooks">Webhooks</a>
-<a class="transform no-underline! transition-colors hover:translate-x-px hover:text-gray-700" href="./repositories-next-steps">Next Steps</a>
-<a class="transform no-underline! transition-colors hover:translate-x-px hover:text-gray-700" href="./repositories-licenses">Licenses</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./repositories-getting-started">Getting Started</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./repositories-settings">Repository Settings</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./storage-limits">Storage Limits</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./xet/index">Storage Backend (Xet)</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./local-cache">Local Cache</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./repositories-pull-requests-discussions">Pull requests and Discussions</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./notifications">Notifications</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./collections">Collections</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./webhooks">Webhooks</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./repositories-next-steps">Next Steps</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./repositories-licenses">Licenses</a>
 </div>
 
-<div class="group flex flex-col space-y-2 rounded-xl border border-indigo-100 bg-linear-to-br from-indigo-50 dark:bg-none px-6 py-4 transition-colors hover:shadow-sm dark:border-indigo-700">
-<div class="flex items-center py-0.5 text-lg font-semibold text-indigo-600 dark:text-gray-400 mb-1">
+<div class="group flex flex-col space-y-1 rounded-xl border border-indigo-100 bg-linear-to-br from-indigo-50/50 dark:from-indigo-500/5 px-6 py-4 dark:border-gray-850">
+<div class="flex items-center py-0.5 text-lg font-semibold text-indigo-600 dark:text-white mb-2">
     <svg class="shrink-0 mr-1.5 text-indigo-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><path class="uim-quaternary" d="M20.23 7.24L12 12L3.77 7.24a1.98 1.98 0 0 1 .7-.71L11 2.76c.62-.35 1.38-.35 2 0l6.53 3.77c.29.173.531.418.7.71z" opacity=".25" fill="currentColor"></path><path class="uim-tertiary" d="M12 12v9.5a2.09 2.09 0 0 1-.91-.21L4.5 17.48a2.003 2.003 0 0 1-1-1.73v-7.5a2.06 2.06 0 0 1 .27-1.01L12 12z" opacity=".5" fill="currentColor"></path><path class="uim-primary" d="M20.5 8.25v7.5a2.003 2.003 0 0 1-1 1.73l-6.62 3.82c-.275.13-.576.198-.88.2V12l8.23-4.76c.175.308.268.656.27 1.01z" fill="currentColor"></path></svg> Models</div>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./models-the-hub">The Model Hub</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./model-cards">Model Cards</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./eval-results">Eval Results</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./models-gated">Gated Models</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./models-uploading">Uploading Models</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./models-downloading">Downloading Models</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./models-libraries">Libraries</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./models-tasks">Tasks</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./models-widgets">Widgets</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./models-inference">Inference Providers</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./models-download-stats">Download Stats</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./models-the-hub">The Model Hub</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./model-cards">Model Cards</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./eval-results">Eval Results</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./models-gated">Gated Models</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./models-uploading">Uploading Models</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./models-downloading">Downloading Models</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./models-libraries">Libraries</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./models-tasks">Tasks</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./models-widgets">Widgets</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./models-inference">Inference Providers</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./models-download-stats">Download Stats</a>
 </div>
 
-<div class="group flex flex-col space-y-2 rounded-xl border border-red-100 bg-linear-to-br from-red-50 dark:bg-none px-6 py-4 transition-colors hover:shadow-sm dark:border-red-700">
-<div class="flex items-center py-0.5 text-lg font-semibold text-red-600 dark:text-gray-400 mb-1">
+<div class="group flex flex-col space-y-1 rounded-xl border border-red-100 bg-linear-to-br from-red-50/50 dark:from-red-500/5 px-6 py-4 dark:border-gray-850">
+<div class="flex items-center py-0.5 text-lg font-semibold text-red-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-red-400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 25 25"><ellipse cx="12.5" cy="5" fill="currentColor" fill-opacity="0.25" rx="7.5" ry="2"></ellipse><path d="M12.5 15C16.6421 15 20 14.1046 20 13V20C20 21.1046 16.6421 22 12.5 22C8.35786 22 5 21.1046 5 20V13C5 14.1046 8.35786 15 12.5 15Z" fill="currentColor" opacity="0.5"></path><path d="M12.5 7C16.6421 7 20 6.10457 20 5V11.5C20 12.6046 16.6421 13.5 12.5 13.5C8.35786 13.5 5 12.6046 5 11.5V5C5 6.10457 8.35786 7 12.5 7Z" fill="currentColor" opacity="0.5"></path><path d="M5.23628 12C5.08204 12.1598 5 12.8273 5 13C5 14.1046 8.35786 15 12.5 15C16.6421 15 20 14.1046 20 13C20 12.8273 19.918 12.1598 19.7637 12C18.9311 12.8626 15.9947 13.5 12.5 13.5C9.0053 13.5 6.06886 12.8626 5.23628 12Z" fill="currentColor"></path></svg> Datasets</div>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./datasets">Introduction</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./datasets-overview">Datasets Overview</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./datasets-cards">Dataset Cards</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./datasets-gated">Gated Datasets</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./datasets-adding">Uploading Datasets</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./datasets-ingesting">Ingesting Datasets</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./datasets-downloading">Downloading Datasets</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./datasets-streaming">Streaming Datasets</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./datasets-editing">Editing Datasets</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./datasets-libraries">Libraries</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./data-studio">Data Studio</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./datasets-download-stats">Download Stats</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./datasets-data-files-configuration">Data files Configuration</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets">Introduction</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets-overview">Datasets Overview</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets-cards">Dataset Cards</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets-gated">Gated Datasets</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets-adding">Uploading Datasets</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets-ingesting">Ingesting Datasets</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets-downloading">Downloading Datasets</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets-streaming">Streaming Datasets</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets-editing">Editing Datasets</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets-libraries">Libraries</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./data-studio">Data Studio</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets-download-stats">Download Stats</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets-data-files-configuration">Data files Configuration</a>
 </div>
 
-<div class="group flex flex-col space-y-2 rounded-xl border border-blue-100 bg-linear-to-br from-blue-50 dark:bg-none px-6 py-4 transition-colors hover:shadow-sm dark:border-blue-700">
-<div class="flex items-center py-0.5 text-lg font-semibold text-blue-600 dark:text-gray-400 mb-1">
+<div class="group flex flex-col space-y-1 rounded-xl border border-blue-100 bg-linear-to-br from-blue-50/50 dark:from-blue-500/5 px-6 py-4 dark:border-gray-850">
+<div class="flex items-center py-0.5 text-lg font-semibold text-blue-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-blue-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" viewBox="0 0 25 25"><path opacity=".5" d="M6.016 14.674v4.31h4.31v-4.31h-4.31ZM14.674 14.674v4.31h4.31v-4.31h-4.31ZM6.016 6.016v4.31h4.31v-4.31h-4.31Z" fill="currentColor"></path><path opacity=".75" fill-rule="evenodd" clip-rule="evenodd" d="M3 4.914C3 3.857 3.857 3 4.914 3h6.514c.884 0 1.628.6 1.848 1.414a5.171 5.171 0 0 1 7.31 7.31c.815.22 1.414.964 1.414 1.848v6.514A1.914 1.914 0 0 1 20.086 22H4.914A1.914 1.914 0 0 1 3 20.086V4.914Zm3.016 1.102v4.31h4.31v-4.31h-4.31Zm0 12.968v-4.31h4.31v4.31h-4.31Zm8.658 0v-4.31h4.31v4.31h-4.31Zm0-10.813a2.155 2.155 0 1 1 4.31 0 2.155 2.155 0 0 1-4.31 0Z" fill="currentColor"></path><path opacity=".25" d="M16.829 6.016a2.155 2.155 0 1 0 0 4.31 2.155 2.155 0 0 0 0-4.31Z" fill="currentColor"></path></svg> Spaces</div>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces">Introduction</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-overview">Spaces Overview</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-sdks-gradio">Gradio Spaces</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-sdks-static">Static HTML Spaces</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-sdks-docker">Docker Spaces</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-zerogpu">ZeroGPU Spaces</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-embed">Embed your Space</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-run-with-docker">Run with Docker</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-config-reference">Reference</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-advanced">Advanced Topics</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./spaces-oauth">Sign in with HF</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces">Introduction</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces-overview">Spaces Overview</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces-sdks-gradio">Gradio Spaces</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces-sdks-static">Static HTML Spaces</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces-sdks-docker">Docker Spaces</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces-zerogpu">ZeroGPU Spaces</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces-embed">Embed your Space</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces-run-with-docker">Run with Docker</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces-config-reference">Reference</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces-advanced">Advanced Topics</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces-oauth">Sign in with HF</a>
 </div>
 
-<div class="group flex flex-col space-y-2 rounded-xl border border-blue-100 bg-linear-to-br from-blue-50 dark:bg-none px-6 py-4 transition-colors hover:shadow-sm dark:border-blue-700">
-<div class="flex items-center py-0.5 text-lg font-semibold text-blue-600 dark:text-gray-400 mb-1">
+<div class="group flex flex-col space-y-1 rounded-xl border border-blue-100 bg-linear-to-br from-blue-50/50 dark:from-blue-500/5 px-6 py-4 dark:border-gray-850">
+<div class="flex items-center py-0.5 text-lg font-semibold text-blue-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-blue-500" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 48 48" fill="none"><path opacity="0.25" d="M36 4H12C7.58172 4 4 7.58172 4 12V36C4 40.4183 7.58172 44 12 44H36C40.4183 44 44 40.4183 44 36V12C44 7.58172 40.4183 4 36 4Z" fill="currentColor"/><path opacity="0.5" d="M31 11H17C13.6863 11 11 13.6863 11 17V31C11 34.3137 13.6863 37 17 37H31C34.3137 37 37 34.3137 37 31V17C37 13.6863 34.3137 11 31 11Z" fill="currentColor"/><path d="M27 18H21C19.3431 18 18 19.3431 18 21V27C18 28.6569 19.3431 30 21 30H27C28.6569 30 30 28.6569 30 27V21C30 19.3431 28.6569 18 27 18Z" fill="currentColor"/></svg> Storage Buckets <span class="ml-1 rounded-sm bg-blue-500/10 px-1 text-xs leading-tight text-blue-700 dark:text-blue-200">new</span></div>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./storage-buckets">Introduction</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./storage-buckets#buckets-vs-repositories">Buckets vs Git Repositories</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./storage-buckets#creating-a-bucket">Creating a Bucket</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./storage-buckets#managing-files">Managing Files</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./storage-buckets#use-cases">Use Cases</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./storage-buckets-security">Security & Compliance</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./storage-buckets">Introduction</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./storage-buckets#buckets-vs-repositories">Buckets vs Git Repositories</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./storage-buckets#creating-a-bucket">Creating a Bucket</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./storage-buckets#managing-files">Managing Files</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./storage-buckets#use-cases">Use Cases</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./storage-buckets-security">Security & Compliance</a>
 </div>
 
-<div class="group flex flex-col space-y-2 rounded-xl border border-teal-100 bg-linear-to-br from-teal-50 dark:bg-none px-6 py-4 transition-colors hover:shadow-sm dark:border-teal-700">
-<div class="flex items-center py-0.5 text-lg font-semibold text-teal-600 dark:text-gray-400 mb-1">
+<div class="group flex flex-col space-y-1 rounded-xl border border-teal-100 bg-linear-to-br from-teal-50/50 dark:from-teal-500/5 px-6 py-4 dark:border-gray-850">
+<div class="flex items-center py-0.5 text-lg font-semibold text-teal-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-teal-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 18 18" fill="currentColor"><path d="M6.66667 12.4352V4.93521L11.6667 8.68521L6.66667 12.4352ZM8.33333 0.351877C7.23898 0.351877 6.15535 0.567425 5.1443 0.986215C4.13326 1.405 3.2146 2.01883 2.44078 2.79265C0.877974 4.35546 0 6.47507 0 8.68521C0 10.8953 0.877974 13.015 2.44078 14.5778C3.2146 15.3516 4.13326 15.9654 5.1443 16.3842C6.15535 16.803 7.23898 17.0185 8.33333 17.0185C10.5435 17.0185 12.6631 16.1406 14.2259 14.5778C15.7887 13.015 16.6667 10.8953 16.6667 8.68521C16.6667 7.59086 16.4511 6.50723 16.0323 5.49618C15.6135 4.48514 14.9997 3.56648 14.2259 2.79265C13.4521 2.01883 12.5334 1.405 11.5224 0.986215C10.5113 0.567425 9.42768 0.351877 8.33333 0.351877Z"></path></svg> Jobs</div>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./jobs">Introduction</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./jobs-overview">Jobs Overview</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./jobs-quickstart">Quickstart</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./jobs-pricing">Pricing</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./jobs-manage">Manage Jobs</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./jobs-configuration">Jobs Configuration</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./jobs-popular-images">Popular images</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./jobs-schedule">Schedule Jobs</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./jobs-webhooks">Webhooks Automation</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./jobs-reference">Reference</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./jobs">Introduction</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./jobs-overview">Jobs Overview</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./jobs-quickstart">Quickstart</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./jobs-pricing">Pricing</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./jobs-manage">Manage Jobs</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./jobs-configuration">Jobs Configuration</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./jobs-popular-images">Popular images</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./jobs-schedule">Schedule Jobs</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./jobs-webhooks">Webhooks Automation</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./jobs-reference">Reference</a>
 </div>
 
-<div class="group flex flex-col space-y-2 rounded-xl border border-cyan-100 bg-linear-to-br from-cyan-50 dark:bg-none px-6 py-4 transition-colors hover:shadow-sm dark:border-cyan-700">
-<div class="flex items-center py-0.5 text-lg font-semibold text-cyan-600 dark:text-gray-400 mb-1">
-<svg class="shrink-0 mr-1.5 text-cyan-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a2 2 0 0 1 2 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 0 1 7 7h1a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1h-1v1a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1H2a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h1a7 7 0 0 1 7-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 0 1 2-2M7.5 13A2.5 2.5 0 0 0 5 15.5A2.5 2.5 0 0 0 7.5 18a2.5 2.5 0 0 0 2.5-2.5A2.5 2.5 0 0 0 7.5 13m9 0a2.5 2.5 0 0 0-2.5 2.5a2.5 2.5 0 0 0 2.5 2.5a2.5 2.5 0 0 0 2.5-2.5a2.5 2.5 0 0 0-2.5-2.5"/></svg> Agents</div>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./agents">Introduction</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./agents-overview">Agents Overview</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./agents-cli">Hugging Face CLI for AI Agents</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./agents-mcp">Hugging Face MCP Server</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./agents-skills">Hugging Face Agent Skills</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./agents-sdk">Building agents with the HF SDK</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./agents-local">Local Agents</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./agents-libraries">Agent Libraries</a>
+<div class="group flex flex-col space-y-1 rounded-xl border border-cyan-100 bg-linear-to-br from-cyan-50/50 dark:from-cyan-500/5 px-6 py-4 dark:border-gray-850">
+<div class="flex items-center py-0.5 text-lg font-semibold text-cyan-600 dark:text-white mb-2">
+<svg class="shrink-0 mr-1.5 text-cyan-500" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" viewBox="0 0 12 12" fill="currentColor"><rect width="9.491" height="2.438" x="1.254" y="8.845" fill="currentColor" opacity=".5" rx="1.219"/><path fill="currentColor" d="M8.068 3.07a2.678 2.678 0 0 1 0 5.355H3.932a2.678 2.678 0 0 1 0-5.355h1.652v.412a.343.343 0 0 0 .684 0V3.07zM4.412 4.85a.898.898 0 1 0 0 1.796.898.898 0 0 0 0-1.795m3.177 0a.898.898 0 1 0 0 1.796.898.898 0 0 0 0-1.795"/><path fill="currentColor" d="M6.269 3.48a.342.342 0 0 1-.684 0V2.353a.9.9 0 0 0 .684 0z" opacity=".25"/><circle cx="5.927" cy="1.526" r=".894" fill="currentColor"/></svg> Agents</div>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./agents">Introduction</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./agents-overview">Agents Overview</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./agents-cli">Hugging Face CLI for AI Agents</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./agents-mcp">Hugging Face MCP Server</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./agents-skills">Hugging Face Agent Skills</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./agents-sdk">Building agents with the HF SDK</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./agents-local">Local Agents</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./agents-libraries">Agent Libraries</a>
 </div>
 
-<div class="group flex flex-col space-y-2 rounded-xl border border-green-100 bg-linear-to-br from-green-50 dark:bg-none px-6 py-4 transition-colors hover:shadow-sm dark:border-green-700">
-<div class="flex items-center py-0.5 text-lg font-semibold text-green-600 dark:text-gray-400 mb-1">
+<div class="group flex flex-col space-y-1 rounded-xl border border-green-100 bg-linear-to-br from-green-50/50 dark:from-green-500/5 px-6 py-4 dark:border-gray-850">
+<div class="flex items-center py-0.5 text-lg font-semibold text-green-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-green-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" viewBox="0 0 24 24"><path fill="currentColor" stroke="currentColor" d="M8.892 21.854a6.25 6.25 0 0 1-4.42-10.67l7.955-7.955a4.5 4.5 0 0 1 6.364 6.364l-6.895 6.894a2.816 2.816 0 0 1-3.89 0a2.75 2.75 0 0 1 .002-3.888l5.126-5.127a1 1 0 1 1 1.414 1.414l-5.126 5.127a.75.75 0 0 0 0 1.06a.768.768 0 0 0 1.06 0l6.895-6.894a2.503 2.503 0 0 0 0-3.535a2.56 2.56 0 0 0-3.536 0l-7.955 7.955a4.25 4.25 0 1 0 6.01 6.01l6.188-6.187a1 1 0 1 1 1.414 1.414l-6.187 6.186a6.206 6.206 0 0 1-4.42 1.832z"></path></svg> Other</div>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./organizations">Organizations</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./billing">Billing</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./security">Security</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./moderation">Moderation</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./paper-pages">Paper Pages</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./search">Search</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./doi">Digital Object Identifier (DOI)</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./api">Hub API Endpoints</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="./oauth">Sign in with HF</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="https://huggingface.co/code-of-conduct">Contributor Code of Conduct</a>
-<a class="no-underline! hover:opacity-60 transform transition-colors hover:translate-x-px" href="https://huggingface.co/content-guidelines">Content Guidelines</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./organizations">Organizations</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./billing">Billing</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./security">Security</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./moderation">Moderation</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./paper-pages">Paper Pages</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./search">Search</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./doi">Digital Object Identifier (DOI)</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./api">Hub API Endpoints</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./oauth">Sign in with HF</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="https://huggingface.co/code-of-conduct">Contributor Code of Conduct</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="https://huggingface.co/content-guidelines">Content Guidelines</a>
 </div>
 
 </div>

--- a/docs/hub/index.md
+++ b/docs/hub/index.md
@@ -4,7 +4,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 
 <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 md:mt-10 not-prose">
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-purple-100 bg-linear-to-br from-purple-50/50 dark:from-purple-500/10 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-purple-100 bg-linear-to-br from-purple-50 dark:from-purple-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-black dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-gray-900 dark:text-white" height="1em" viewBox="0 0 27 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="img"><path fill-rule="evenodd" clip-rule="evenodd" d="M16.555 8.061a4.447 4.447 0 0 0-3.94 2.913l-2.435 7.261c-.52 1.59.465 2.913 2.097 2.913h7.655a4.504 4.504 0 0 0 3.997-2.913l2.35-7.26c.506-1.591-.422-2.914-2.055-2.914H16.555Zm.563 2.913-2.435 7.107h5.024l.507-1.576h-2.955l.393-1.281h2.463l.563-1.548h-2.477l.422-1.168h2.815l.507-1.548h-4.87.057l-.014.014Z" fill="currentColor"/><path d="M15.201 1c1.633 0 2.562 1.337 2.055 2.913l-.738 2.273h-.013l-.05.002a6.326 6.326 0 0 0-5.602 4.142l-.009.024-.009.024-1.248 3.724H3.241c-1.647 0-2.604-1.338-2.112-2.914l2.463-7.275A4.447 4.447 0 0 1 7.532 1h7.67Zm-.309 10.188a4.503 4.503 0 0 1-3.296 2.823l1.019-3.036a4.448 4.448 0 0 1 3.264-2.826l-.987 3.04ZM5.593 5.545h2.928l-1.83 5.488h2.068l.247-.795.246-.795.422-1.266.564-1.548.393-1.084h2.815l.52-1.632h-7.81l-.563 1.632Z" fill="currentColor"/></svg> Subscriptions &  Plans</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./pro">PRO subscription</a>
@@ -20,7 +20,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./rate-limits">Rate Limits</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-orange-100 bg-linear-to-br from-orange-50/50 dark:from-orange-500/10 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-orange-100 bg-linear-to-br from-orange-50 dark:from-orange-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-orange-600 dark:text-white mb-2">
  <svg class="shrink-0 mr-1.5 text-orange-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><path fill="currentColor" d="M2.6 10.59L8.38 4.8l1.69 1.7c-.24.85.15 1.78.93 2.23v5.54c-.6.34-1 .99-1 1.73a2 2 0 0 0 2 2a2 2 0 0 0 2-2c0-.74-.4-1.39-1-1.73V9.41l2.07 2.09c-.07.15-.07.32-.07.5a2 2 0 0 0 2 2a2 2 0 0 0 2-2a2 2 0 0 0-2-2c-.18 0-.35 0-.5.07L13.93 7.5a1.98 1.98 0 0 0-1.15-2.34c-.43-.16-.88-.2-1.28-.09L9.8 3.38l.79-.78c.78-.79 2.04-.79 2.82 0l7.99 7.99c.79.78.79 2.04 0 2.82l-7.99 7.99c-.78.79-2.04.79-2.82 0L2.6 13.41c-.79-.78-.79-2.04 0-2.82Z"></path></svg>Repositories</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./repositories-getting-started">Getting Started</a>
@@ -36,7 +36,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./repositories-licenses">Licenses</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-indigo-100 bg-linear-to-br from-indigo-50/50 dark:from-indigo-500/10 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-indigo-100 bg-linear-to-br from-indigo-50 dark:from-indigo-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-indigo-600 dark:text-white mb-2">
     <svg class="shrink-0 mr-1.5 text-indigo-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><path class="uim-quaternary" d="M20.23 7.24L12 12L3.77 7.24a1.98 1.98 0 0 1 .7-.71L11 2.76c.62-.35 1.38-.35 2 0l6.53 3.77c.29.173.531.418.7.71z" opacity=".25" fill="currentColor"></path><path class="uim-tertiary" d="M12 12v9.5a2.09 2.09 0 0 1-.91-.21L4.5 17.48a2.003 2.003 0 0 1-1-1.73v-7.5a2.06 2.06 0 0 1 .27-1.01L12 12z" opacity=".5" fill="currentColor"></path><path class="uim-primary" d="M20.5 8.25v7.5a2.003 2.003 0 0 1-1 1.73l-6.62 3.82c-.275.13-.576.198-.88.2V12l8.23-4.76c.175.308.268.656.27 1.01z" fill="currentColor"></path></svg> Models</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./models-the-hub">The Model Hub</a>
@@ -52,7 +52,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./models-download-stats">Download Stats</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-red-100 bg-linear-to-br from-red-50/50 dark:from-red-500/10 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-red-100 bg-linear-to-br from-red-50 dark:from-red-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-red-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-red-400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 25 25"><ellipse cx="12.5" cy="5" fill="currentColor" fill-opacity="0.25" rx="7.5" ry="2"></ellipse><path d="M12.5 15C16.6421 15 20 14.1046 20 13V20C20 21.1046 16.6421 22 12.5 22C8.35786 22 5 21.1046 5 20V13C5 14.1046 8.35786 15 12.5 15Z" fill="currentColor" opacity="0.5"></path><path d="M12.5 7C16.6421 7 20 6.10457 20 5V11.5C20 12.6046 16.6421 13.5 12.5 13.5C8.35786 13.5 5 12.6046 5 11.5V5C5 6.10457 8.35786 7 12.5 7Z" fill="currentColor" opacity="0.5"></path><path d="M5.23628 12C5.08204 12.1598 5 12.8273 5 13C5 14.1046 8.35786 15 12.5 15C16.6421 15 20 14.1046 20 13C20 12.8273 19.918 12.1598 19.7637 12C18.9311 12.8626 15.9947 13.5 12.5 13.5C9.0053 13.5 6.06886 12.8626 5.23628 12Z" fill="currentColor"></path></svg> Datasets</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets">Introduction</a>
@@ -70,7 +70,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./datasets-data-files-configuration">Data files Configuration</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-blue-100 bg-linear-to-br from-blue-50/50 dark:from-blue-500/10 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-blue-100 bg-linear-to-br from-blue-50 dark:from-blue-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-blue-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-blue-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" viewBox="0 0 25 25"><path opacity=".5" d="M6.016 14.674v4.31h4.31v-4.31h-4.31ZM14.674 14.674v4.31h4.31v-4.31h-4.31ZM6.016 6.016v4.31h4.31v-4.31h-4.31Z" fill="currentColor"></path><path opacity=".75" fill-rule="evenodd" clip-rule="evenodd" d="M3 4.914C3 3.857 3.857 3 4.914 3h6.514c.884 0 1.628.6 1.848 1.414a5.171 5.171 0 0 1 7.31 7.31c.815.22 1.414.964 1.414 1.848v6.514A1.914 1.914 0 0 1 20.086 22H4.914A1.914 1.914 0 0 1 3 20.086V4.914Zm3.016 1.102v4.31h4.31v-4.31h-4.31Zm0 12.968v-4.31h4.31v4.31h-4.31Zm8.658 0v-4.31h4.31v4.31h-4.31Zm0-10.813a2.155 2.155 0 1 1 4.31 0 2.155 2.155 0 0 1-4.31 0Z" fill="currentColor"></path><path opacity=".25" d="M16.829 6.016a2.155 2.155 0 1 0 0 4.31 2.155 2.155 0 0 0 0-4.31Z" fill="currentColor"></path></svg> Spaces</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces">Introduction</a>
@@ -86,7 +86,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./spaces-oauth">Sign in with HF</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-blue-100 bg-linear-to-br from-blue-50/50 dark:from-blue-500/10 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-blue-100 bg-linear-to-br from-blue-50 dark:from-blue-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-blue-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-blue-500" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 48 48" fill="none"><path opacity="0.25" d="M36 4H12C7.58172 4 4 7.58172 4 12V36C4 40.4183 7.58172 44 12 44H36C40.4183 44 44 40.4183 44 36V12C44 7.58172 40.4183 4 36 4Z" fill="currentColor"/><path opacity="0.5" d="M31 11H17C13.6863 11 11 13.6863 11 17V31C11 34.3137 13.6863 37 17 37H31C34.3137 37 37 34.3137 37 31V17C37 13.6863 34.3137 11 31 11Z" fill="currentColor"/><path d="M27 18H21C19.3431 18 18 19.3431 18 21V27C18 28.6569 19.3431 30 21 30H27C28.6569 30 30 28.6569 30 27V21C30 19.3431 28.6569 18 27 18Z" fill="currentColor"/></svg> Storage Buckets <span class="ml-1 rounded-sm bg-blue-500/10 px-1 text-xs leading-tight text-blue-700 dark:text-blue-200">new</span></div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./storage-buckets">Introduction</a>
@@ -97,7 +97,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./storage-buckets-security">Security & Compliance</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-teal-100 bg-linear-to-br from-teal-50/50 dark:from-teal-500/10 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-teal-100 bg-linear-to-br from-teal-50 dark:from-teal-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-teal-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-teal-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 18 18" fill="currentColor"><path d="M6.66667 12.4352V4.93521L11.6667 8.68521L6.66667 12.4352ZM8.33333 0.351877C7.23898 0.351877 6.15535 0.567425 5.1443 0.986215C4.13326 1.405 3.2146 2.01883 2.44078 2.79265C0.877974 4.35546 0 6.47507 0 8.68521C0 10.8953 0.877974 13.015 2.44078 14.5778C3.2146 15.3516 4.13326 15.9654 5.1443 16.3842C6.15535 16.803 7.23898 17.0185 8.33333 17.0185C10.5435 17.0185 12.6631 16.1406 14.2259 14.5778C15.7887 13.015 16.6667 10.8953 16.6667 8.68521C16.6667 7.59086 16.4511 6.50723 16.0323 5.49618C15.6135 4.48514 14.9997 3.56648 14.2259 2.79265C13.4521 2.01883 12.5334 1.405 11.5224 0.986215C10.5113 0.567425 9.42768 0.351877 8.33333 0.351877Z"></path></svg> Jobs</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./jobs">Introduction</a>
@@ -112,7 +112,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./jobs-reference">Reference</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-cyan-100 bg-linear-to-br from-cyan-50/50 dark:from-cyan-500/10 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-cyan-100 bg-linear-to-br from-cyan-50 dark:from-cyan-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-cyan-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-cyan-500" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" viewBox="0 0 12 12" fill="currentColor"><rect width="9.491" height="2.438" x="1.254" y="8.845" fill="currentColor" opacity=".5" rx="1.219"/><path fill="currentColor" d="M8.068 3.07a2.678 2.678 0 0 1 0 5.355H3.932a2.678 2.678 0 0 1 0-5.355h1.652v.412a.343.343 0 0 0 .684 0V3.07zM4.412 4.85a.898.898 0 1 0 0 1.796.898.898 0 0 0 0-1.795m3.177 0a.898.898 0 1 0 0 1.796.898.898 0 0 0 0-1.795"/><path fill="currentColor" d="M6.269 3.48a.342.342 0 0 1-.684 0V2.353a.9.9 0 0 0 .684 0z" opacity=".25"/><circle cx="5.927" cy="1.526" r=".894" fill="currentColor"/></svg> Agents</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./agents">Introduction</a>
@@ -125,7 +125,7 @@ The Hugging Face Hub is a platform with over 2M models, 500k datasets, and 1M de
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./agents-libraries">Agent Libraries</a>
 </div>
 
-<div class="group flex flex-col space-y-1 rounded-xl border border-green-100 bg-linear-to-br from-green-50/50 dark:from-green-500/10 px-6 py-4 dark:border-gray-850">
+<div class="group flex flex-col space-y-1 rounded-xl border border-green-100 bg-linear-to-br from-green-50 dark:from-green-500/10 px-6 py-4 dark:border-gray-850">
 <div class="flex items-center py-0.5 text-lg font-semibold text-green-600 dark:text-white mb-2">
 <svg class="shrink-0 mr-1.5 text-green-500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" role="img" width="1em" height="1em" viewBox="0 0 24 24"><path fill="currentColor" stroke="currentColor" d="M8.892 21.854a6.25 6.25 0 0 1-4.42-10.67l7.955-7.955a4.5 4.5 0 0 1 6.364 6.364l-6.895 6.894a2.816 2.816 0 0 1-3.89 0a2.75 2.75 0 0 1 .002-3.888l5.126-5.127a1 1 0 1 1 1.414 1.414l-5.126 5.127a.75.75 0 0 0 0 1.06a.768.768 0 0 0 1.06 0l6.895-6.894a2.503 2.503 0 0 0 0-3.535a2.56 2.56 0 0 0-3.536 0l-7.955 7.955a4.25 4.25 0 1 0 6.01 6.01l6.188-6.187a1 1 0 1 1 1.414 1.414l-6.187 6.186a6.206 6.206 0 0 1-4.42 1.832z"></path></svg> Other</div>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./organizations">Organizations</a>


### PR DESCRIPTION

<img width="1852" height="1396" alt="image" src="https://github.com/user-attachments/assets/d83dbc78-9773-4c32-a32f-faf1508e9494" />


## Summary
- Softer light-mode gradients (`from-*-50/50`) and subtle dark-mode tints (`dark:from-*-500/5`)
- Dark-mode section titles now use `dark:text-white`; unified card borders (`dark:border-gray-850`)
- Tighter inner card spacing (`space-y-1`); more breathing room under titles (`mb-2`)
- Links: `text-gray-700` default, `hover:text-gray-900`; in dark `dark:text-gray-400` → `dark:hover:text-white` (no more opacity fade)
- Removed `hover:shadow-sm` and `transition-colors` from the card container
- `not-prose` on the grid so the typography plugin doesn't restyle the card content
- Updated the *Subscriptions & Plans* icon to the TE brand mark and the *Agents* icon to the new chibi-bot used in the sidebar nav

## Test plan
- [ ] Preview `/docs/hub/index` locally (light + dark)
- [ ] Confirm all links resolve and headings render correctly

> Note: the renderer also needs the new utility classes whitelisted so Tailwind picks them up (handled in a companion internal PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only styling and SVG changes; main risk is minor visual regressions in light/dark mode rendering.
> 
> **Overview**
> Updates the `docs/hub/index.md` landing-page card grid to a new visual style: adds `not-prose` to prevent typography restyling, tightens spacing, unifies dark-mode borders/tints, and adjusts gradients.
> 
> Standardizes link and heading colors/hover behavior (removing opacity fade and card hover shadow), and swaps the inline SVG icons for **Subscriptions & Plans** and **Agents** to new brand assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 467c5f14c7088aec78d2f74d48b749a760276729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->