### PR TITLE
remove huggingface-jobs skill from agents-skills.md

### DIFF
--- a/docs/hub/agents-skills.md
+++ b/docs/hub/agents-skills.md
@@ -56,7 +56,6 @@ Install via the Cursor plugin flow using the [repository URL](https://github.com
 | [`huggingface-llm-trainer`](https://github.com/huggingface/skills/tree/main/skills/huggingface-llm-trainer) | Train or fine-tune LLMs with TRL (SFT, DPO, GRPO) on HF Jobs |
 | [`huggingface-vision-trainer`](https://github.com/huggingface/skills/tree/main/skills/huggingface-vision-trainer) | Train object detection and image classification models |
 | [`huggingface-community-evals`](https://github.com/huggingface/skills/tree/main/skills/huggingface-community-evals) | Run evaluations against models on the Hugging Face Hub on local hardware |
-| [`huggingface-jobs`](https://github.com/huggingface/skills/tree/main/skills/huggingface-jobs) | Run compute jobs on Hugging Face infrastructure |
 | [`huggingface-trackio`](https://github.com/huggingface/skills/tree/main/skills/huggingface-trackio) | Track and visualize ML training experiments with Trackio |
 | [`huggingface-papers`](https://github.com/huggingface/skills/tree/main/skills/huggingface-papers) | Look up and read Hugging Face paper pages in markdown |
 | [`huggingface-paper-publisher`](https://github.com/huggingface/skills/tree/main/skills/huggingface-paper-publisher) | Publish and manage research papers on the Hub |


### PR DESCRIPTION
`jobs` skill was removed in skills repo due to overlap. The commit updates the Available skills table to get rid of the row.

Related to #2372

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that removes a stale reference; no runtime behavior or APIs are affected.
> 
> **Overview**
> Updates `docs/hub/agents-skills.md` to remove the `huggingface-jobs` row from the *Available Skills* table, aligning the documentation with the current Skills repository offerings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae3e11562f668183b38f42ac880912ff6f21863c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->