### PR TITLE
docs: fix jobs overview typo

### DIFF
--- a/docs/hub/jobs-overview.md
+++ b/docs/hub/jobs-overview.md
@@ -12,7 +12,7 @@ The Hugging Face Hub provides compute for AI and data workflows via Jobs.
 
 Jobs runs on Hugging Face infrastructure and aim at providing AI builders, Data engineers, developers and AI agents an easy access to cloud infrastructure to run their workloads. They are ideal to fine tune AI models and run inference with GPUs, but also for data ingestion and processing as well.
 
-A job is defined with a command to run (e.g. a UV or python command), a hardware flavor (CPU, GPU, TPU), and optionally a Docker Image from Hugging Face Spaces or Docker Hub. Many jobs can run in parallel, which is useful e.g. for parameters tuning or parallel inference and data processing.
+A job is defined with a command to run (e.g. a UV or python command), a hardware flavor (CPU, GPU, TPU), and optionally a Docker Image from Hugging Face Spaces or Docker Hub. Many jobs can run in parallel, which is useful e.g. for parameter tuning or parallel inference and data processing.
 
 ## Run Jobs from anywhere
 

--- a/docs/hub/jobs-overview.md
+++ b/docs/hub/jobs-overview.md
@@ -12,7 +12,7 @@ The Hugging Face Hub provides compute for AI and data workflows via Jobs.
 
 Jobs runs on Hugging Face infrastructure and aim at providing AI builders, Data engineers, developers and AI agents an easy access to cloud infrastructure to run their workloads. They are ideal to fine tune AI models and run inference with GPUs, but also for data ingestion and processing as well.
 
-A job is defined with a command to run (e.g. a UV or python command), a hardware flavor (CPU, GPU, TPU), and optionnally a Docker Image from Hugging Face Spaces or Docker Hub. Many jobs can run in parallel, which is useful e.g. for parameters tuning or parallel inference and data processing.
+A job is defined with a command to run (e.g. a UV or python command), a hardware flavor (CPU, GPU, TPU), and optionally a Docker Image from Hugging Face Spaces or Docker Hub. Many jobs can run in parallel, which is useful e.g. for parameters tuning or parallel inference and data processing.
 
 ## Run Jobs from anywhere
 

--- a/docs/hub/jobs-overview.md
+++ b/docs/hub/jobs-overview.md
@@ -12,7 +12,7 @@ The Hugging Face Hub provides compute for AI and data workflows via Jobs.
 
 Jobs runs on Hugging Face infrastructure and aim at providing AI builders, Data engineers, developers and AI agents an easy access to cloud infrastructure to run their workloads. They are ideal to fine tune AI models and run inference with GPUs, but also for data ingestion and processing as well.
 
-A job is defined with a command to run (e.g. a UV or python command), a hardware flavor (CPU, GPU, TPU), and optionally a Docker Image from Hugging Face Spaces or Docker Hub. Many jobs can run in parallel, which is useful e.g. for parameter tuning or parallel inference and data processing.
+A job is defined with a command to run (e.g. a UV or python command), a hardware flavor (CPU, GPU, TPU), and optionally a Docker image from Hugging Face Spaces or Docker Hub. Many jobs can run in parallel, which is useful e.g. for parameter tuning or parallel inference and data processing.
 
 ## Run Jobs from anywhere
 


### PR DESCRIPTION
## Summary
- fix a typo in the Jobs overview docs

## Related issue
- N/A (trivial docs typo)

## Guideline alignment
- Reviewed `README.md`
- Kept the change to one documentation file with no behavior impact

## Validation
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only wording change with no behavioral impact.
> 
> **Overview**
> Updates `docs/hub/jobs-overview.md` to fix spelling/wording in the job definition sentence (e.g., `optionnally`→`optionally`, `parameter` tuning) for clearer documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620f0548cddddf1b49de0585942dd7a2b4a54dde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->