### PR TITLE
docs: add hf-mount as an access method to download docs

### DIFF
--- a/docs/hub/datasets-downloading.md
+++ b/docs/hub/datasets-downloading.md
@@ -50,3 +50,14 @@ git clone git@hf.co:datasets/<dataset ID> # example: git clone git@hf.co:dataset
 If you have write-access to the particular dataset repo, you'll also have the ability to commit and push revisions to the dataset.
 
 Add your SSH public key to [your user settings](https://huggingface.co/settings/keys) to push changes and/or access private repos.
+
+## Using hf-mount
+
+For large datasets, you can mount a repo as a local filesystem with [hf-mount](./storage-buckets-access#mount-as-a-local-filesystem) instead of downloading the full repo. Files are fetched lazily — only the bytes your code reads hit the network. Useful when your workflow expects local file paths (e.g. `tarfile`, `zipfile`, `imagefolder`) rather than Python iterators.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
+hf-mount start repo datasets/stanfordnlp/imdb /tmp/imdb
+```
+
+Repos are mounted read-only. See the [hf-mount repository](https://github.com/huggingface/hf-mount) for full documentation including backend options and caching.

--- a/docs/hub/datasets-downloading.md
+++ b/docs/hub/datasets-downloading.md
@@ -53,11 +53,11 @@ Add your SSH public key to [your user settings](https://huggingface.co/settings/
 
 ## Using hf-mount
 
-For large datasets, you can mount a repo as a local filesystem with [hf-mount](./storage-buckets-access#mount-as-a-local-filesystem) instead of downloading the full repo. Files are fetched lazily — only the bytes your code reads hit the network. Useful when your workflow expects local file paths (e.g. `tarfile`, `zipfile`, `imagefolder`) rather than Python iterators.
+For large datasets, you can mount a repo as a local filesystem with [hf-mount](https://github.com/huggingface/hf-mount) instead of downloading the full repo. Files are fetched lazily — only the bytes your code reads hit the network. Useful when your workflow expects local file paths (e.g. `tarfile`, `zipfile`, `imagefolder`) rather than Python iterators.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
 hf-mount start repo datasets/stanfordnlp/imdb /tmp/imdb
 ```
 
-Repos are mounted read-only. See the [hf-mount repository](https://github.com/huggingface/hf-mount) for full documentation including backend options and caching.
+Repos are mounted read-only. See [Mount as a Local Filesystem](./storage-buckets-access#mount-as-a-local-filesystem) for full setup details, backend options, and caching.

--- a/docs/hub/models-downloading.md
+++ b/docs/hub/models-downloading.md
@@ -61,11 +61,11 @@ HF_XET_HIGH_PERFORMANCE=1 hf download ...
 
 ## Using hf-mount
 
-For large models, you can mount a repo as a local filesystem with [hf-mount](./storage-buckets-access#mount-as-a-local-filesystem) instead of downloading the full repo. Files are fetched lazily — only the bytes your code reads hit the network.
+For large models, you can mount a repo as a local filesystem with [hf-mount](https://github.com/huggingface/hf-mount) instead of downloading the full repo. Files are fetched lazily — only the bytes your code reads hit the network.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
 hf-mount start repo openai-community/gpt2 /tmp/gpt2
 ```
 
-Repos are mounted read-only. See the [hf-mount repository](https://github.com/huggingface/hf-mount) for full documentation including backend options and caching.
+Repos are mounted read-only. See [Mount as a Local Filesystem](./storage-buckets-access#mount-as-a-local-filesystem) for full setup details, backend options, and caching.

--- a/docs/hub/models-downloading.md
+++ b/docs/hub/models-downloading.md
@@ -58,3 +58,14 @@ For most machines — including data center environments — the default setting
 ```bash
 HF_XET_HIGH_PERFORMANCE=1 hf download ...
 ```
+
+## Using hf-mount
+
+For large models, you can mount a repo as a local filesystem with [hf-mount](./storage-buckets-access#mount-as-a-local-filesystem) instead of downloading the full repo. Files are fetched lazily — only the bytes your code reads hit the network.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
+hf-mount start repo openai-community/gpt2 /tmp/gpt2
+```
+
+Repos are mounted read-only. See the [hf-mount repository](https://github.com/huggingface/hf-mount) for full documentation including backend options and caching.


### PR DESCRIPTION
## Summary
- Add `## Using hf-mount` section to `docs/hub/datasets-downloading.md` and `docs/hub/models-downloading.md`
- Describes mounting a repo as a local filesystem with [hf-mount](https://github.com/huggingface/hf-mount) as an alternative to downloading the full repo
- Currently hf-mount is only mentioned once in hub-docs (as a subsection of `storage-buckets-access.md`); these cross-refs promote it as a peer access method alongside `hf download`, the client library, and git clone

## Placement
- On `models-downloading.md`, placed *after* `## Faster downloads` so Xet-based downloads (the recommended default) stay more prominent
- On `datasets-downloading.md`, at the end (page has no Faster downloads section)
- Follows the existing file structure: one paragraph + install + example + link to canonical docs

## Verified locally
Tested both examples with hf-mount v0.3.1 (NFS backend):

```
$ hf-mount start repo hf-internal-testing/tiny-random-gpt2 /tmp/mount-test-model
$ ls /tmp/mount-test-model
config.json  merges.txt  model.safetensors  pytorch_model.bin  ...

$ hf-mount start repo datasets/stanfordnlp/imdb /tmp/mount-test-ds
$ ls /tmp/mount-test-ds
plain_text  README.md
```

The `datasets/` prefix on dataset repo IDs is the canonical form per `hf-mount-nfs repo --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk doc-only change that adds a new recommended access option; main risk is user confusion if `hf-mount` behavior/commands change or platform support differs.
> 
> **Overview**
> Adds a new **"Using hf-mount"** section to the model and dataset download guides, presenting `hf-mount` as an alternative to fully downloading repos by mounting them as a local, read-only filesystem with lazy fetching.
> 
> Includes install + example `hf-mount start repo ...` commands for a model and a dataset, and links back to `storage-buckets-access` for full setup, backend options, and caching details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1adf9373016b8aa78ebac0e44f516f9c5bdf908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->