### PR TITLE
docs: add Spaces as Agent Tools page

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -339,6 +339,8 @@
     title: Spaces Custom Domain
   - local: spaces-mcp-servers
     title: Spaces as MCP servers
+  - local: spaces-agents
+    title: Spaces as Agent Tools
   - local: spaces-api-endpoints
     title: Spaces as API Endpoints
   - local: spaces-sdks-gradio

--- a/docs/hub/spaces-agents.md
+++ b/docs/hub/spaces-agents.md
@@ -2,7 +2,7 @@
 
 Every Gradio Space exposes a plain-text `agents.md` that coding agents (Claude Code, Codex, OpenCode, Pi, etc.) can call directly. Find one via semantic search on [huggingface.co/spaces](https://huggingface.co/spaces) (e.g. "audio transcription"), optionally try it in the UI first, then point your agent at its `agents.md`. The response is four lines: schema URL, call template, poll template, auth hint.
 
-This gets powerful when **chaining Spaces**. An agent can turn a prompt into a 3D asset by calling [`black-forest-labs/flux-klein-9b-kv`](https://huggingface.co/spaces/black-forest-labs/flux-klein-9b-kv) for an image, then passing the generated image into [`microsoft/TRELLIS.2`](https://huggingface.co/spaces/microsoft/TRELLIS.2) for the 3D model. No client library, no hardcoded integration.
+This gets even more powerful when **chaining Spaces**. An agent can turn a prompt into a 3D asset by calling [`black-forest-labs/flux-klein-9b-kv`](https://huggingface.co/spaces/black-forest-labs/flux-klein-9b-kv) for an image, then passing the generated image into [`microsoft/TRELLIS.2`](https://huggingface.co/spaces/microsoft/TRELLIS.2) for the 3D model. No client library, no hardcoded integration.
 
 All you need is an [HF_TOKEN](https://huggingface.co/settings/tokens) set in your environment to get started.
 

--- a/docs/hub/spaces-agents.md
+++ b/docs/hub/spaces-agents.md
@@ -1,6 +1,6 @@
 # Spaces as Agent Tools
 
-Every compatible Gradio Space exposes a plain-text `agents.md` that coding agents (Claude Code, Codex, OpenCode, Pi, etc.) can call directly. Find one via semantic search on [huggingface.co/spaces](https://huggingface.co/spaces) (e.g. "audio transcription"), optionally try it in the UI first, then point your agent at its `agents.md`. The response is four lines: schema URL, call template, poll template, auth hint.
+Every Gradio Space exposes a plain-text `agents.md` that coding agents (Claude Code, Codex, OpenCode, Pi, etc.) can call directly. Find one via semantic search on [huggingface.co/spaces](https://huggingface.co/spaces) (e.g. "audio transcription"), optionally try it in the UI first, then point your agent at its `agents.md`. The response is four lines: schema URL, call template, poll template, auth hint.
 
 This gets powerful when **chaining Spaces**. An agent can turn a prompt into a 3D asset by calling [`black-forest-labs/flux-klein-9b-kv`](https://huggingface.co/spaces/black-forest-labs/flux-klein-9b-kv) for an image, then passing the generated image into [`microsoft/TRELLIS.2`](https://huggingface.co/spaces/microsoft/TRELLIS.2) for the 3D model. No client library, no hardcoded integration.
 

--- a/docs/hub/spaces-agents.md
+++ b/docs/hub/spaces-agents.md
@@ -1,0 +1,54 @@
+# Spaces as Agent Tools
+
+Every compatible Gradio Space exposes a plain-text `agents.md` that coding agents (Claude Code, Codex, OpenCode, Pi, etc.) can call directly. Find one via semantic search on [huggingface.co/spaces](https://huggingface.co/spaces) (e.g. "audio transcription"), optionally try it in the UI first, then point your agent at its `agents.md`. The response is four lines: schema URL, call template, poll template, auth hint.
+
+This gets powerful when **chaining Spaces**. An agent can turn a prompt into a 3D asset by calling [`black-forest-labs/flux-klein-9b-kv`](https://huggingface.co/spaces/black-forest-labs/flux-klein-9b-kv) for an image, then passing the generated image into [`microsoft/TRELLIS.2`](https://huggingface.co/spaces/microsoft/TRELLIS.2) for the 3D model. No client library, no hardcoded integration.
+
+All you need is an `HF_TOKEN` set in your environment to get started.
+
+## From the UI
+
+Every compatible Space page has an **Agents** button in the header. Click it to copy the `curl` command for that Space's `agents.md`, then paste it into your agent.
+
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-agents-popover.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-agents-popover-dark.png"/>
+</div>
+
+## The agents.md endpoint
+
+```
+https://huggingface.co/spaces/<namespace>/<repo>/agents.md
+```
+
+Example:
+
+```bash
+curl https://huggingface.co/spaces/Tongyi-MAI/Z-Image-Turbo/agents.md
+```
+
+Returns:
+
+```
+To use this application (Tongyi-MAI/Z-Image-Turbo: Generate images from text prompts with customizable resolution):
+API schema: GET https://tongyi-mai-z-image-turbo.hf.space/gradio_api/info
+Call endpoint: POST https://tongyi-mai-z-image-turbo.hf.space/gradio_api/call/{endpoint} {"data": [...]}
+Poll result: GET https://tongyi-mai-z-image-turbo.hf.space/gradio_api/call/{endpoint}/{event_id}
+Auth: Bearer $HF_TOKEN
+```
+
+## Authentication and ZeroGPU
+
+Most popular Spaces run on [ZeroGPU](./spaces-zerogpu), which uses the caller's daily quota. Agents should always pass an `$HF_TOKEN` so calls are billed to your account rather than a throttled anonymous pool. The same token is also required for private Spaces.
+
+```bash
+curl -H "Authorization: Bearer $HF_TOKEN" \
+  https://tongyi-mai-z-image-turbo.hf.space/gradio_api/call/predict \
+  -d '{"data": ["a cat in Ghibli style"]}'
+```
+
+## How agents will use this
+
+1. The agent `curl`s `/agents.md` for the Space.
+2. It fetches `/gradio_api/info` to learn endpoint names and inputs.
+3. It POSTs to `/gradio_api/call/<endpoint>`, then GETs the poll URL to stream the result.

--- a/docs/hub/spaces-agents.md
+++ b/docs/hub/spaces-agents.md
@@ -4,7 +4,7 @@ Every Gradio Space exposes a plain-text `agents.md` that coding agents (Claude C
 
 This gets powerful when **chaining Spaces**. An agent can turn a prompt into a 3D asset by calling [`black-forest-labs/flux-klein-9b-kv`](https://huggingface.co/spaces/black-forest-labs/flux-klein-9b-kv) for an image, then passing the generated image into [`microsoft/TRELLIS.2`](https://huggingface.co/spaces/microsoft/TRELLIS.2) for the 3D model. No client library, no hardcoded integration.
 
-All you need is an `HF_TOKEN` set in your environment to get started.
+All you need is an [HF_TOKEN](https://huggingface.co/settings/tokens) set in your environment to get started.
 
 ## From the UI
 

--- a/docs/hub/spaces-agents.md
+++ b/docs/hub/spaces-agents.md
@@ -24,16 +24,16 @@ https://huggingface.co/spaces/<namespace>/<repo>/agents.md
 Example:
 
 ```bash
-curl https://huggingface.co/spaces/Tongyi-MAI/Z-Image-Turbo/agents.md
+curl https://huggingface.co/spaces/microsoft/TRELLIS.2/agents.md
 ```
 
 Returns:
 
 ```
-To use this application (Tongyi-MAI/Z-Image-Turbo: Generate images from text prompts with customizable resolution):
-API schema: GET https://tongyi-mai-z-image-turbo.hf.space/gradio_api/info
-Call endpoint: POST https://tongyi-mai-z-image-turbo.hf.space/gradio_api/call/{endpoint} {"data": [...]}
-Poll result: GET https://tongyi-mai-z-image-turbo.hf.space/gradio_api/call/{endpoint}/{event_id}
+To use this application (microsoft/TRELLIS.2: Create 3D model from a single image):
+API schema: GET https://microsoft-trellis-2.hf.space/gradio_api/info
+Call endpoint: POST https://microsoft-trellis-2.hf.space/gradio_api/call/{endpoint} {"data": [...]}
+Poll result: GET https://microsoft-trellis-2.hf.space/gradio_api/call/{endpoint}/{event_id}
 Auth: Bearer $HF_TOKEN
 ```
 
@@ -43,8 +43,8 @@ Most popular Spaces run on [ZeroGPU](./spaces-zerogpu), which uses the caller's 
 
 ```bash
 curl -H "Authorization: Bearer $HF_TOKEN" \
-  https://tongyi-mai-z-image-turbo.hf.space/gradio_api/call/predict \
-  -d '{"data": ["a cat in Ghibli style"]}'
+  https://microsoft-trellis-2.hf.space/gradio_api/call/predict \
+  -d '{"data": [{"path": "https://example.com/chair.png"}]}'
 ```
 
 ## How agents will use this


### PR DESCRIPTION
## Summary

- New page `spaces-agents.md` documenting the `/spaces/<id>/agents.md` endpoint shipped in moon-landing [#17771](https://github.com/huggingface-internal/moon-landing/pull/17771).
- Sidebar entry slots between *Spaces as MCP servers* and *Spaces as API Endpoints*.

Covers the Agents popover UI, the plain-text response, chaining Spaces (flux-klein → TRELLIS.2), ZeroGPU auth, and private Spaces.

## Test plan
- [ ] Verify the new sidebar entry renders between MCP servers and API Endpoints
- [ ] Confirm light/dark screenshots load from the documentation-images dataset
- [ ] Confirm internal links to \`./spaces-mcp-servers\`, \`./spaces-api-endpoints\`, \`./spaces-zerogpu\` resolve

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new page and sidebar entry; no runtime code paths are modified.
> 
> **Overview**
> Adds a new Hub docs page, `spaces-agents.md`, describing how coding agents can call a Space’s plain-text `agents.md` to discover the Gradio API schema, call/poll URLs, and auth requirements (including ZeroGPU token usage), with UI and `curl` examples.
> 
> Updates the Spaces documentation sidebar (`_toctree.yml`) to include **Spaces as Agent Tools** between `spaces-mcp-servers` and `spaces-api-endpoints`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65de6787de0a6e4b1a8e3f8ed1a8a4e123627f5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->