### PR TITLE
clarify org-scoped oauth token access

### DIFF
--- a/docs/hub/oauth.md
+++ b/docs/hub/oauth.md
@@ -252,7 +252,7 @@ curl -X POST "https://huggingface.co/oauth/token" \
 
 Tokens issued via Token Exchange have built-in security restrictions:
 
-- **Organization-scoped**: Tokens can only access resources within your organization (models, datasets, Spaces owned by the org), plus any public gated repos outside the org that the user has been individually granted access to (read-only).
+- **Organization-scoped**: Tokens can only access resources within your organization (models, datasets, Spaces, and collections owned by the org). Outside the org, access is read-only and limited to: public collections from any user or organization, and public gated repos the user has been individually granted access to.
 - **No personal access**: Tokens cannot access the user's personal private repositories or private repos from other organizations.
 - **Short-lived**: Tokens expire after 8 hours by default. Organization administrators can configure the token duration (up to 30 days) in the OAuth app settings. No refresh tokens are provided.
 - **Auditable**: All token exchanges are logged and visible in your organization's [audit logs](./audit-logs).


### PR DESCRIPTION
companion of https://github.com/huggingface-internal/moon-landing/pull/17824

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change clarifying what organization-scoped Token Exchange tokens can and cannot access outside the org.
> 
> **Overview**
> Clarifies the *security restrictions* for Token Exchange “organization-scoped” tokens by explicitly stating that they also cover org-owned collections, and that out-of-org access is limited to **read-only** public collections plus individually granted public gated repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2108eda6c3d63afdeadbfcb5d838b0ad4d2f0731. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->