### PR TITLE
docs: fix LM Studio shortcut typo

### DIFF
--- a/docs/hub/lmstudio.md
+++ b/docs/hub/lmstudio.md
@@ -30,7 +30,7 @@ To try LM Studio with a trending model, find them here: [https://huggingface.co/
 
 ### Option 2: Use LM Studio's In-App Downloader
 
-Open the LM Studio app and search for any model by presssing ⌘ + Shift + M on Mac, or Ctrl + Shift + M on PC (M stands for Models). You can even paste entire Hugging Face URLs into the search bar!
+Open the LM Studio app and search for any model by pressing ⌘ + Shift + M on Mac, or Ctrl + Shift + M on PC (M stands for Models). You can even paste entire Hugging Face URLs into the search bar!
 
 <div class="flex justify-center">
   <img


### PR DESCRIPTION
## Summary
- fix the LM Studio shortcut typo in the GGUF usage guide

## Related issue
- N/A (trivial docs typo)

## Guideline alignment
- reviewed the repository guidance in `README.md`
- kept the change to one docs file with no behavior impact

## Validation
- not run (content-only Markdown change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only edits correcting a keyboard shortcut typo and ensuring the file ends with a newline; no runtime behavior changes.
> 
> **Overview**
> Fixes a typo in `docs/hub/lmstudio.md` where the LM Studio model search shortcut instruction misspelled "pressing".
> 
> Also normalizes the file ending by restoring the trailing newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52290303ccde5d9e5ebfc9fec5334cb62207bf0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->