### PR TITLE
docs: fix Jobs image install typo

### DIFF
--- a/docs/hub/jobs-popular-images.md
+++ b/docs/hub/jobs-popular-images.md
@@ -2,7 +2,7 @@
 
 Here is the list of ready-to-use Docker images from popular frameworks that you can use in Jobs with uv.
 
-These Docker images already have uv installed but if you want to use an image + uv for an image without uv insalled you’ll need to make sure uv is installed first. This will work well in many cases but for LLM inference libraries which can have quite specific requirements, it can be useful to use a specific image that has the library installed.
+These Docker images already have uv installed but if you want to use an image + uv for an image without uv installed you’ll need to make sure uv is installed first. This will work well in many cases but for LLM inference libraries which can have quite specific requirements, it can be useful to use a specific image that has the library installed.
 
 ## vLLM
 


### PR DESCRIPTION
## Summary
- fix a typo in the Jobs popular images guide

## Related issue
- N/A (trivial docs typo)

## Guideline alignment
- reviewed the repository guidance in `README.md`
- kept the change to one docs file with no behavior impact

## Validation
- not run (content-only Markdown change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that fixes a typo with no behavioral impact.
> 
> **Overview**
> Fixes a typo in `docs/hub/jobs-popular-images.md` by correcting "uv insalled" to "uv installed" in the Jobs popular images guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fddc2d98819bf88bbca05b77c24ba4ba78d52b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->