### PR TITLE
docs: fix "Similarly" spelling in JavaScript pricing section

### DIFF
--- a/docs/inference-providers/pricing.md
+++ b/docs/inference-providers/pricing.md
@@ -179,7 +179,7 @@ print(response.json()["choices"][0]["message"])
 
 </hfoptions>
 
-Similarily in JavaScript:
+Similarly in JavaScript:
 
 <hfoptions id="javascript-clients">
 


### PR DESCRIPTION
## Summary
- Fix `Similarily` -> `Similarly` in `docs/inference-providers/pricing.md`.

## Related issue
- N/A (trivial docs typo fix)

## Guideline alignment
- Followed repo contribution guidance from README.
- Single-file, docs-only correction.

## Validation
- Not run; docs-only wording change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that corrects a single word spelling and does not affect runtime behavior.
> 
> **Overview**
> Fixes a typo in `docs/inference-providers/pricing.md`, changing **“Similarily in JavaScript”** to **“Similarly in JavaScript”** in the JavaScript pricing/billing section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46c215f10c29bb170155a61670a4e381e55cac08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->