### PR TITLE
docs: clarify role options for RG creation

### DIFF
--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -83,7 +83,7 @@ The available options are:
 - **Admins only** (default) — only org admins can create Resource Groups.
 - **Write** — members with Write or Admin role can create Resource Groups.
 - **Contributor** — members with Contributor, Write, or Admin role can create Resource Groups.
-- **All members** — any org member can create Resource Groups.
+- **Read+** — any org member can create Resource Groups.
 
 When a non-admin member creates a Resource Group through the UI, they are automatically added as an **admin** of that newly created group. Through the API, this does not happen automatically, since API callers may be creating groups on behalf of others. Non-admin API callers must include at least one user with the admin role in the group's initial member list.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the described Resource Group creation permission option name; no product or API behavior changes.
> 
> **Overview**
> Updates the Resource Groups documentation to reflect the current UI/setting name for the lowest creation-permission tier, changing **All members** to **Read+** (any org member can create Resource Groups).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 827f599ed0d15af9d5df5bf9561ec87646e76a56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->