### PR TITLE
Remove `preload_from_hub` documentation from spaces config reference

### DIFF
--- a/docs/hub/spaces-config-reference.md
+++ b/docs/hub/spaces-config-reference.md
@@ -123,23 +123,3 @@ custom_headers:
 ```
 
 *Note:* all headers and values must be lowercase.
-
-**`preload_from_hub`**: _List[string]_
-Specify a list of Hugging Face Hub models or other large files to be preloaded during the build time of your Space. This optimizes the startup time by having the files ready when your application starts. This is particularly useful for Spaces that rely on large models or datasets that would otherwise need to be downloaded at runtime.
-
-The format for each item is `"repository_name"` to download all files from a repository, or `"repository_name file1,file2"` for downloading specific files within that repository. You can also specify a specific commit to download using the format `"repository_name file1,file2 commit_sha256"`. 
-
-Example usage:
-```yaml
-preload_from_hub:
-  - warp-ai/wuerstchen-prior text_encoder/model.safetensors,prior/diffusion_pytorch_model.safetensors
-  - coqui/XTTS-v1
-  - openai-community/gpt2 config.json 11c5a3d5811f50298f278a704980280950aedb10
-```
-In this example, the Space will preload specific .safetensors files from `warp-ai/wuerstchen-prior`, the complete `coqui/XTTS-v1` repository, and a specific revision of the `config.json` file in the `openai-community/gpt2` repository from the Hugging Face Hub during build time.
-
-> [!WARNING]
-> Files are saved in the default `huggingface_hub` disk cache `~/.cache/huggingface/hub`. If your application expects them elsewhere or you changed your `HF_HOME` variable, this preloading does not follow that at this time.
-
-> [!NOTE]
-> Preloading of private repos is not supported yet.


### PR DESCRIPTION
Deprecated in favor of mounting volumes

related [slack thread](https://huggingface.slack.com/archives/C0256NXF0A2/p1776713912103899)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes guidance for a deprecated config option; no runtime behavior is affected.
> 
> **Overview**
> Removes the `preload_from_hub` section from the Spaces configuration reference (`spaces-config-reference.md`), including its YAML examples and caveats, reflecting that this option is no longer documented/encouraged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 476d8161cadfc7fc2b135adc804f8326d5f7a0d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->