### PR TITLE
docs: fix DuckDB SQL example spelling

### DIFF
--- a/docs/hub/datasets-duckdb-sql.md
+++ b/docs/hub/datasets-duckdb-sql.md
@@ -101,7 +101,7 @@ WHERE  subject = 'nutrition' LIMIT 3;
 │       question       │  subject  │                                                                               choices                                                                               │ answer │
 │       varchar        │  varchar  │                                                                              varchar[]                                                                              │ int64  │
 ├──────────────────────┼───────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────┤
-│ Which foods tend t…  │ nutrition │ [Meat, Confectionary, Fruits and vegetables, Potatoes]                                                                                                              │      2 │
+│ Which foods tend t…  │ nutrition │ [Meat, Confectionery, Fruits and vegetables, Potatoes]                                                                                                              │      2 │
 │ In which one of th…  │ nutrition │ [If the incidence rate of the disease falls., If survival time with the disease increases., If recovery of the disease is faster., If the population in which the…  │      1 │
 │ Which of the follo…  │ nutrition │ [The flavonoid class comprises flavonoids and isoflavonoids., The digestibility and bioavailability of isoflavones in soya food products are not changed by proce…  │      0 │
 └──────────────────────┴───────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴────────┘


### PR DESCRIPTION
Summary
- fix the "Confectionery" spelling in the DuckDB SQL docs example output

Related issue
- N/A (trivial docs typo fix)

Guideline alignment
- docs-only wording fix in one file
- no behavior changes

Validation
- Ran `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that corrects a single word in a rendered DuckDB query output example; no code paths or behavior are affected.
> 
> **Overview**
> Fixes a typo in the DuckDB SQL docs example output by correcting the `choices` list spelling from **"Confectionary"** to **"Confectionery"** in `docs/hub/datasets-duckdb-sql.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d062e6f27470742d2cf4cc0283426467e7674602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->