### PR TITLE
docs: fix Lance guide spelling

### DIFF
--- a/docs/hub/datasets-lance.md
+++ b/docs/hub/datasets-lance.md
@@ -71,7 +71,7 @@ for row in rows:
 
 ## Work with binary assets
 
-The example below shows how images are retreved from a Lance dataset as raw JPEG bytes in the `image` column, and used downstream.
+The example below shows how images are retrieved from a Lance dataset as raw JPEG bytes in the `image` column, and used downstream.
 Use `ds.take` to fetch the bytes and write them to disk so you can use them elsewhere.
 
 ```python
@@ -262,4 +262,3 @@ scalar metadata all in one place.
 Explore more Lance datasets on the [Hugging Face Hub](https://huggingface.co/datasets?format=format:lance),
 and share your own Lance datasets with others in the community!
 You can visit [lance.org](https://lance.org/integrations/huggingface/) for more code snippets and examples.
-


### PR DESCRIPTION
Summary
- fix the "retrieved" spelling in the Lance datasets guide

Related issue
- N/A (trivial docs typo fix)

Guideline alignment
- docs-only wording fix in one file
- no behavior changes

Validation
- Ran `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that fixes a spelling error and a minor trailing formatting artifact, with no behavior impact.
> 
> **Overview**
> Fixes a spelling mistake in `docs/hub/datasets-lance.md` ("retreved" → "retrieved") in the binary assets example.
> 
> Also removes a stray trailing line at the end of the document (minor formatting cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8bfa25def158ca50cf8af99d0b08cf7a35423a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->