### PR TITLE
docs(xet): update HF_XET_CLIENT_READ_TIMEOUT default to 300s

### DIFF
--- a/docs/hub/xet/using-xet-storage.md
+++ b/docs/hub/xet/using-xet-storage.md
@@ -169,7 +169,7 @@ By default, `xet-core` uses adaptive concurrency — dynamically adjusting paral
 | `HF_XET_CLIENT_RETRY_BASE_DELAY` | `3000ms` | Base delay between retries (with exponential backoff). |
 | `HF_XET_CLIENT_RETRY_MAX_DURATION` | `360s` | Maximum total time to spend retrying a request. |
 | `HF_XET_CLIENT_CONNECT_TIMEOUT` | `60s` | TCP connection timeout. |
-| `HF_XET_CLIENT_READ_TIMEOUT` | `120s` | Read timeout for HTTP responses. |
+| `HF_XET_CLIENT_READ_TIMEOUT` | `300s` | Read timeout for HTTP responses. |
 | `HF_XET_CLIENT_IDLE_CONNECTION_TIMEOUT` | `60s` | Timeout before idle connections are closed. |
 | `HF_XET_CLIENT_MAX_IDLE_CONNECTIONS` | `16` | Maximum number of idle connections in the pool. |
 


### PR DESCRIPTION
## Summary

Bumps the documented default for `HF_XET_CLIENT_READ_TIMEOUT` in the Xet env-var reference table from `120s` to `300s`, matching the xet-core default change in huggingface/xet-core#807.

## Why

The 120s default was cutting off slow-but-progressing uploads on high-latency / transatlantic links, producing a chronic 30–50% xorb POST failure rate fleet-wide (see [Notion investigation](https://www.notion.so/huggingface2/Julien-upload-stuck-upload_xorb-120s-timeouts-2026-04-21-3491384ebcac81a19d0af5394745cfff)).

## Test plan

- [ ] Preview `docs/hub/xet/using-xet-storage.md` renders the updated value
- [ ] Ship in the same release window as the xet-core PR so docs and runtime agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)