### PR TITLE
docs: remove --jinja flag from llama-server example

### DIFF
--- a/docs/hub/agents-local.md
+++ b/docs/hub/agents-local.md
@@ -20,7 +20,7 @@ Browse for [Llama.cpp-compatible models](https://huggingface.co/models?apps=llam
 On the model page, click the **"Use this model"** button and select `llama.cpp`. It will show you the exact commands for your setup. The first step is to start a llama.cpp server, e.g.
 
 ```bash
-llama-server -hf ggml-org/gemma-4-26b-a4b-it-GGUF:Q4_K_M --jinja
+llama-server -hf ggml-org/gemma-4-26b-a4b-it-GGUF:Q4_K_M
 ```
 
 This downloads the model and starts an OpenAI-compatible API server on your machine. See the [llama.cpp guide](./gguf-llamacpp) for installation instructions.


### PR DESCRIPTION
## Summary
- Remove `--jinja` from the `llama-server` example in `docs/hub/agents-local.md` since it's the default in llama.cpp now.

## Test plan
- [x] `grep -ri jinja` shows no remaining user-facing mentions of the flag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a command example to match current `llama.cpp` defaults.
> 
> **Overview**
> Updates `docs/hub/agents-local.md` to remove the `--jinja` flag from the `llama-server` example command, reflecting that templating is now enabled by default in `llama.cpp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9d7add769a21af639540f9e1ed67083b005e5b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->