### PR TITLE
docs: fix wording in Spaces dev mode guide

### DIFF
--- a/docs/hub/spaces-dev-mode.md
+++ b/docs/hub/spaces-dev-mode.md
@@ -18,7 +18,7 @@ The Dev Mode Docker image starts your application as a sub-process, allowing you
 
 The ability to connect to the running Space unlocks several use cases:
 
-    - You can make changes to the app code without the Space rebuilding everytime
+    - You can make changes to the app code without the Space rebuilding every time
     - You can debug a running application and monitor resources live
 
 Overall it makes developing and experimenting with Spaces much faster by skipping the Docker image rebuild phase.


### PR DESCRIPTION
Summary
- fix the "every time" wording in the Spaces dev mode guide

Related issue
- N/A (trivial docs typo fix)

Guideline alignment
- docs-only wording fix in one file
- no behavior changes

Validation
- Ran `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only wording fix; no behavior or API changes.
> 
> **Overview**
> Fixes a small typo in `docs/hub/spaces-dev-mode.md` by changing “everytime” to “every time” in the Dev Mode use-cases list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a5dc20a90ef92cfb2c3eca5f8e7ab0f1605302. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->