### PR TITLE
docs: fix sentence-transformers example spelling

### DIFF
--- a/docs/hub/sentence-transformers.md
+++ b/docs/hub/sentence-transformers.md
@@ -34,7 +34,7 @@ model = SentenceTransformer('multi-qa-MiniLM-L6-cos-v1')
 
 query_embedding = model.encode('How big is London')
 passage_embedding = model.encode(['London has 9,787,426 inhabitants at the 2011 census',
-                                  'London is known for its finacial district'])
+                                  'London is known for its financial district'])
 
 print("Similarity:", util.dot_score(query_embedding, passage_embedding))
 ```


### PR DESCRIPTION
Summary
- fix the "financial" spelling in the sentence-transformers guide example

Related issue
- N/A (trivial docs typo fix)

Guideline alignment
- docs-only wording fix in one file
- no behavior changes

Validation
- Ran `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that corrects a spelling mistake in an example string, with no behavior or API impact.
> 
> **Overview**
> Fixes a typo in the `docs/hub/sentence-transformers.md` semantic search example by correcting the passage text from "finacial" to "financial".
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef6f9e8fcceb67d04958e8906eefd557801a7ef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->