### PR TITLE
docs: add API management section for network security settings

### DIFF
--- a/docs/hub/enterprise-network-security.md
+++ b/docs/hub/enterprise-network-security.md
@@ -73,3 +73,11 @@ To define Blocked URLs, enter URL patterns, without the domain name, one per lin
 </div>
 
 The Allowed URLs field, enables you to define some exception to the blocking rules, especially. For example by allowing a specific URL within the Blocked URLs pattern, ie `/spaces/meta-llama/*`  
+
+## Manage Network Security via API
+
+You can read and update your organization's network security settings programmatically via the Hub API.
+
+**OpenAPI reference:**
+- [GET /api/organizations/{name}/settings/network-security](https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/{name}/settings/network-security)
+- [PATCH /api/organizations/{name}/settings/network-security](https://huggingface.co/spaces/huggingface/openapi#tag/orgs/PATCH/api/organizations/{name}/settings/network-security)


### PR DESCRIPTION
Add mention of the `network-security` REST endpoints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds links to existing Hub API endpoints; no runtime or behavior changes.
> 
> **Overview**
> Adds a new **“Manage Network Security via API”** section to `docs/hub/enterprise-network-security.md`, describing that org network security settings can be read/updated programmatically.
> 
> Includes direct OpenAPI links for the `GET` and `PATCH /api/organizations/{name}/settings/network-security` endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c6ed167f0cdfb5b72160032328d79f4cee0e3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->