### PR TITLE
Update academia-hub.md

### DIFF
--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -33,7 +33,7 @@ With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub 
 
 ## Pricing
 Starting at $10/seat/month, with volume-based discounts. 
-Minimum of 250 annual seats to enter the program.
+We require a minimum of 250 annual seats to enter the program. For smaller groups, we recommend starting with a <a href="https://huggingface.co/docs/hub/enterprise" target="_blank">Team plan.</a>
 <a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Contact</a> our Academia Hub Team for a bespoke package!
 
 ## How to get started

--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -8,9 +8,12 @@
 </a>
 
 ## Where universities build, teach, and publish AI.
-For universities, by design. One subscription gives your students, professors, and research staff the same tools used by the world's leading AI teams — open, auditable, and governed by your institution.
+For universities, by design. One subscription gives your students, professors, and research staff the same tools used by the world's leading AI teams: open, auditable, and governed by your institution.
 
-Universities don't just teach students how to use AI — they teach them how to understand, audit, and manage it. Academia Hub is our dedicated initiative to put those tools into the heart of the university ecosystem, so students move from being passive consumers to strategic architects of their own innovation.
+Universities don't just teach students how to use AI, they teach them how to understand, audit, and manage it. 
+Academia Hub is our dedicated initiative to put those tools into the heart of the university ecosystem, so students move from being passive consumers to strategic architects of their own innovation.
+
+With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub for students, researchers and staff.**
 
 <div class="flex flex-wrap justify-center items-center gap-8 my-8">
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/Zurich.png" alt="ETH Zurich logo" class="h-24 object-contain"/>
@@ -21,19 +24,19 @@ Universities don't just teach students how to use AI — they teach them how to 
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/hong-kong-polytechnic-university-logo.png" alt="HKPolyU logo" class="h-24 object-contain"/>
 </div>
 
-With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub for students, researchers and staff.**
-
 ## What's included in the subscription
-1. **Storage** 1 TB of private and 1 TB of public storage per seat, including our new <a href="https://huggingface.co/storage" target="_blank">Storage Buckets!</a>
-2. **Compute** $2/month/seat of credits for <a href="https://huggingface.co/docs/inference-providers/en/index" target="_blank">Inference Providers</a>, daily higher ZeroGPU priority access for <a href="https://huggingface.co/docs/hub/en/spaces-zerogpu" target="_blank">Spaces</a>, and higher Hub <a href="https://huggingface.co/docs/hub/rate-limits#rate-limit-tiers" target="_blank">rate limits</a>.
-3. **Collaboration tools** Resource Groups, Data Studio for private datasets, Audit Logs, and access controls.
-4. **Governance & security** Seat management, centralized admin, SSO, 2FA, SCIM, SOC 2 certified.
-5. **Global Open Source community** publish and collaborate alongside the researchers and builders working on the field's most-used models and datasets.
+1. **Storage:** 1 TB of private and 1 TB of public storage per seat, including our new <a href="https://huggingface.co/storage" target="_blank">Storage Buckets!</a>
+2. **Compute:** $2/month/seat of credits for <a href="https://huggingface.co/docs/inference-providers/en/index" target="_blank">Inference Providers</a>, daily higher ZeroGPU priority access for <a href="https://huggingface.co/docs/hub/en/spaces-zerogpu" target="_blank">Spaces</a>, and higher Hub <a href="https://huggingface.co/docs/hub/rate-limits#rate-limit-tiers" target="_blank">rate limits</a>.
+3. **Collaboration tools:** Resource Groups, Data Studio for private datasets, Audit Logs, and access controls.
+4. **Governance & security:** Seat management, centralized admin, SSO, 2FA, SCIM, SOC 2 certified.
+5. **Global Open Source community:** publish and collaborate alongside the researchers and builders working on the field's most-used models and datasets.
 
 
 ## Pricing
 Starting at $10/seat/month, with volume-based discounts. 
+
 We require a minimum of 250 annual seats to enter the program. For smaller groups, we recommend starting with a <a href="https://huggingface.co/docs/hub/enterprise" target="_blank">Team plan.</a>
+
 <a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Contact</a> our Academia Hub Team for a bespoke package!
 
 ## How to get started

--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -7,13 +7,13 @@
     <img class="block" src="https://huggingface.co/datasets/Chunte/documentation-images/resolve/main/AcademiaHub.png" />
 </a>
 
-## Accelerate your university's AI research, publication pipeline, and collaboration at scale
+## Where universities build, teach, and publish AI.
 
-The Hugging Face Hub is where leading researchers and developers across academia and industry collaborate on AI throughout the whole research lifecycle. 
+For universities, by design. One subscription gives your students, professors, and research staff the same tools used by the world's leading AI teams — open, auditable, and governed by your institution.
 
-Academia Hub brings that proven ecosystem to your university, giving your researchers everything they need to work securely, reproducibly, and at scale: compute, storage, collaboration, and governance, all managed through your institution.
+Universities don't just teach students how to use AI — they teach them how to understand, audit, and manage it. Academia Hub is our dedicated initiative to put those tools into the heart of the university ecosystem, so students move from being passive consumers to strategic architects of their own innovation.
 
-With Academia Hub, you get **university-level seat management and accounts for researchers, professors, and/or students.**
+With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub for students, researchers and staff.**
 
 <div class="flex flex-wrap justify-center items-center gap-8 my-8">
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/Zurich.png" alt="ETH Zurich logo" class="h-24 object-contain"/>
@@ -23,34 +23,27 @@ With Academia Hub, you get **university-level seat management and accounts for r
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/logo-UT-site.png" alt="UT logo" class="h-24 object-contain"/>
 </div>
 
-## Why Academia Hub: Built for the complete research lifecycle
-Academia Hub scales with your research from early prototypes to large-scale published models while ensuring security, reproducibility, and seamless collaboration across your entire institution.
+## What's included in the subscription
 
-1. **Store & version** datasets, models, and results with 1TB private storage per seat.
-2. **Collaborate & review** with co-authors and lab members in shared workspaces.
-3. **Prototype** ideas using interactive Spaces and hosted notebooks.
-4. **Train & scale** with managed GPUs and tracked runs.
-5. **Publish & share** using model cards, DOIs, and dataset releases.
-6. **Preserve** your work for reproducibility and future research. All backed by enterprise-grade infrastructure, institutional governance, and storage that grows with your needs.
+1. **Storage** 1 TB of private and 1 TB of public storage per seat, including our new <a href="https://huggingface.co/storage" target="_blank">Storage Buckets!</a>
+2. **Compute** $2/month/seat of credits for <a href="https://huggingface.co/docs/inference-providers/en/index" target="_blank">Inference Providers</a>, daily higher ZeroGPU priority access for <a href="https://huggingface.co/docs/hub/en/spaces-zerogpu" target="_blank">Spaces</a>, and higher Hub <a href="https://huggingface.co/docs/hub/rate-limits#rate-limit-tiers" target="_blank">rate limits</a>.
+3. **Collaboration tools** Resource Groups, Data Studio for private datasets, Audit Logs, and access controls.
+4. **Governance & security** Seat management, centralized admin, SSO, 2FA, SCIM, SOC 2 certified.
+5. **Global Open Source community** publish and collaborate alongside the researchers and builders working on the field's most-used models and datasets.
 
-## Key features of Academia Hub
 
-***For researchers and students***
-- **Storage**: 1 TB private storage per seat (e.g., 400 seats = 400 TB) powered by Xet, purpose-built for versioning large AI models and datasets; expanded public storage; Dataset Viewer for private datasets.
-- **Hosting & demos**: <a href="https://huggingface.co/docs/hub/spaces" target="_blank">Spaces</a> Hosting for scalable AI demos and applications powered by ZeroGPU (5× priority quota); <a href="https://huggingface.co/docs/hub/spaces-dev-mode" target="_blank">Dev Mode</a> with SSH/VS Code access for development.
-- **Compute**: Priority GPU access (H100/H200) for training; managed runs with experiment tracking.
-- **Collaboration**: Team workspaces with version control, peer review, and shared governance.
-- **Publishing**: Share the research artifacts like models and datasets with the global AI community through citable releases with model cards, dataset cards, and DOIs.
-
-***For administrators***
-- **Pricing**: $10/seat/month (volume-based pricing); $2/seat/month compute credits included (top-ups available).
-- **Admin & security**: University-level seat management for researchers, professors, and students; centralized administration; SSO with university domain.
-
-***For your research community***
-- **Community & resources**: Connect with peers; curated models/datasets/projects for academia.
+## Pricing
+Starting at $10/seat/month, with volume-based discounts. 
+Minimum of 250 annual seats to enter the program.
 
 ## How to get started
 
 Researchers and students: <a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Contact us</a> to express interest in Academia Hub and help us connect with your university's IT or Procurement Team.
 
 IT or Procurement staff: <a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Get in touch</a> directly to set up your institution's Academia Hub subscription or find out more about how your institution can benefit from Academia Hub.
+
+## Common use cases
+- A research lab storing private checkpoints and datasets during a multi-year project, and publishing final artefacts with DOIs — using the Hugging Face community blog to showcase their work.
+- A multi-campus collaboration sharing a single organization workspace with per-lab access controls.
+- A semester-long course distributing notebooks, assignments, and student-built Spaces under one institutional org.
+- Reproducible publication: keeping code, data, weights, and environment together so a result can be re-run years later.

--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -12,8 +12,6 @@ For universities, by design. One subscription gives your students, professors, a
 
 Universities don't just teach students how to use AI — they teach them how to understand, audit, and manage it. Academia Hub is our dedicated initiative to put those tools into the heart of the university ecosystem, so students move from being passive consumers to strategic architects of their own innovation.
 
-With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub for students, researchers and staff.**
-
 <div class="flex flex-wrap justify-center items-center gap-8 my-8">
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/Zurich.png" alt="ETH Zurich logo" class="h-24 object-contain"/>
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/ESCP_LOGO_CMJN.png" alt="ESCP Business School logo" class="h-24 object-contain"/>
@@ -22,6 +20,8 @@ With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub 
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/logo-UT-site.png" alt="UT logo" class="h-24 object-contain"/>
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/hong-kong-polytechnic-university-logo.png" alt="HKPolyU logo" class="h-24 object-contain"/>
 </div>
+
+With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub for students, researchers and staff.**
 
 ## What's included in the subscription
 1. **Storage** 1 TB of private and 1 TB of public storage per seat, including our new <a href="https://huggingface.co/storage" target="_blank">Storage Buckets!</a>
@@ -34,7 +34,7 @@ With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub 
 ## Pricing
 Starting at $10/seat/month, with volume-based discounts. 
 Minimum of 250 annual seats to enter the program.
-<a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Contact</a> our Sales Team for a bespoke package!
+<a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Contact</a> our Academia Hub Team for a bespoke package!
 
 ## How to get started
 Researchers and students: <a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Contact us</a> to express interest in Academia Hub and help us connect with your university's IT or Procurement Team.

--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -8,7 +8,7 @@
 </a>
 
 ## Where universities build, teach, and publish AI.
-For universities, by design. One subscription gives your students, professors, and research staff the same tools used by the world's leading AI teams: open, auditable, and governed by your institution.
+For universities, by design. One subscription gives your students, faculty, and research staff the same tools used by the world's leading AI teams: open, auditable, and governed by your institution.
 
 Universities don't just teach students how to use AI, they teach them how to understand, audit, and manage it. 
 Academia Hub is our dedicated initiative to put those tools into the heart of the university ecosystem, so students move from being passive consumers to strategic architects of their own innovation.

--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -20,6 +20,7 @@ With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub 
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/The_2025_MBZUAI_logo.png" alt="MBZUAI logo" class="h-24 object-contain"/>
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/epita.png" alt="EPITA logo" class="h-24 object-contain"/>
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/logo-UT-site.png" alt="UT logo" class="h-24 object-contain"/>
+  <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/hong-kong-polytechnic-university-logo.png" alt="HKPolyU logo" class="h-24 object-contain"/>
 </div>
 
 ## What's included in the subscription

--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -34,10 +34,9 @@ With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub 
 
 ## Pricing
 Starting at $10/seat/month, with volume-based discounts. 
+<a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Contact</a> our Academia Hub Team for a bespoke package!
 
 We require a minimum of 250 annual seats to enter the program. For smaller groups, we recommend starting with a <a href="https://huggingface.co/docs/hub/enterprise" target="_blank">Team plan.</a>
-
-<a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Contact</a> our Academia Hub Team for a bespoke package!
 
 ## How to get started
 Researchers and students: <a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Contact us</a> to express interest in Academia Hub and help us connect with your university's IT or Procurement Team.

--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -45,7 +45,15 @@ Researchers and students: <a href="https://huggingface.co/contact/sales?from=aca
 IT or Procurement staff: <a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Get in touch</a> directly to set up your institution's Academia Hub subscription or find out more about how your institution can benefit from Academia Hub.
 
 ## Common use cases
-- A research lab storing private checkpoints and datasets during a multi-year project, and publishing final artefacts with DOIs — using the Hugging Face community blog to showcase their work.
-- A multi-campus collaboration sharing a single organization workspace with per-lab access controls.
-- A semester-long course distributing notebooks, assignments, and student-built Spaces under one institutional org.
-- Reproducible publication: keeping code, data, weights, and environment together so a result can be re-run years later.
+🎓 Teaching & Coursework
+- Distribute notebooks, datasets, models and student Spaces under one institutional org.
+- Test and compare models interactively without necessarily writing code.
+- Fine-tune a base model on a Hub dataset for a downstream task.
+
+🔬 Research & Publication
+- Store private checkpoints and datasets, then publish final artefacts with DOIs.
+- Keep code, data, and weights together for reproducible results.
+- Showcase work on the Hugging Face community blog.
+
+🤝 Collaboration
+- Share an org workspace across labs or campuses with granular access controls.

--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -26,7 +26,7 @@ With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub 
 ## What's included in the subscription
 1. **Storage:** 1 TB of private and 1 TB of public storage per seat, including our new <a href="https://huggingface.co/storage" target="_blank">Storage Buckets!</a>
 2. **Compute:** $2/month/seat of credits for <a href="https://huggingface.co/docs/inference-providers/en/index" target="_blank">Inference Providers</a>, daily higher ZeroGPU priority access for <a href="https://huggingface.co/docs/hub/en/spaces-zerogpu" target="_blank">Spaces</a>, and higher Hub <a href="https://huggingface.co/docs/hub/rate-limits#rate-limit-tiers" target="_blank">rate limits</a>.
-3. **Collaboration tools:** [Resource Groups](./security-resource-groups), [Data Studio](./data-studio) for private datasets, Audit Logs, and access controls.
+3. **Collaboration tools:** [Resource Groups](./security-resource-groups), [Data Studio](./data-studio) for private datasets, [Audit Logs](./audit-logs), and access controls.
 4. **Governance & security:** Seat management, centralized admin, SSO, 2FA, SCIM, SOC 2 certified.
 5. **Global Open Source community:** publish and collaborate alongside the researchers and builders working on the field's most-used models and datasets.
 

--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -10,8 +10,7 @@
 ## Where universities build, teach, and publish AI.
 For universities, by design. One subscription gives your students, faculty, and research staff the same tools used by the world's leading AI teams: open, auditable, and governed by your institution.
 
-Universities don't just teach students how to use AI, they teach them how to understand, audit, and manage it. 
-Academia Hub is our dedicated initiative to put those tools into the heart of the university ecosystem, so students move from being passive consumers to strategic architects of their own innovation.
+Academia Hub gives universities the tools and ecosystem to put open-source AI at the center of how students learn, experiment, and build with it.
 
 With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub for students, researchers and staff.**
 

--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -8,7 +8,6 @@
 </a>
 
 ## Where universities build, teach, and publish AI.
-
 For universities, by design. One subscription gives your students, professors, and research staff the same tools used by the world's leading AI teams — open, auditable, and governed by your institution.
 
 Universities don't just teach students how to use AI — they teach them how to understand, audit, and manage it. Academia Hub is our dedicated initiative to put those tools into the heart of the university ecosystem, so students move from being passive consumers to strategic architects of their own innovation.
@@ -24,7 +23,6 @@ With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub 
 </div>
 
 ## What's included in the subscription
-
 1. **Storage** 1 TB of private and 1 TB of public storage per seat, including our new <a href="https://huggingface.co/storage" target="_blank">Storage Buckets!</a>
 2. **Compute** $2/month/seat of credits for <a href="https://huggingface.co/docs/inference-providers/en/index" target="_blank">Inference Providers</a>, daily higher ZeroGPU priority access for <a href="https://huggingface.co/docs/hub/en/spaces-zerogpu" target="_blank">Spaces</a>, and higher Hub <a href="https://huggingface.co/docs/hub/rate-limits#rate-limit-tiers" target="_blank">rate limits</a>.
 3. **Collaboration tools** Resource Groups, Data Studio for private datasets, Audit Logs, and access controls.
@@ -35,9 +33,9 @@ With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub 
 ## Pricing
 Starting at $10/seat/month, with volume-based discounts. 
 Minimum of 250 annual seats to enter the program.
+<a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Contact</a> our Sales Team for a bespoke package!
 
 ## How to get started
-
 Researchers and students: <a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Contact us</a> to express interest in Academia Hub and help us connect with your university's IT or Procurement Team.
 
 IT or Procurement staff: <a href="https://huggingface.co/contact/sales?from=academia" target="_blank">Get in touch</a> directly to set up your institution's Academia Hub subscription or find out more about how your institution can benefit from Academia Hub.

--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -44,12 +44,10 @@ IT or Procurement staff: <a href="https://huggingface.co/contact/sales?from=acad
 
 ## Common use cases
 🎓 Teaching & Coursework
-- Distribute notebooks, datasets, models and student Spaces under one institutional org.
-- Test and compare models interactively without necessarily writing code.
+- Explore, test and compare models interactively without necessarily writing code.
 - Fine-tune a base model on a Hub dataset for a downstream task.
-- Launch jobs on Hugging Face infra to run experiments and assignments.
-- Preserve data and class materials on the Hub, mount or use locally when needed.
-- Easily find models and datasets to use in your project through agent-friendly interfaces.
+- Sync agent traces to buckets for shared collaboration and reuse.
+- Use thousands of Spaces to solve tasks in agentic workflows.
 
 🔬 Research & Publication
 - Store private checkpoints and datasets, then publish final artefacts with DOIs.
@@ -58,3 +56,5 @@ IT or Procurement staff: <a href="https://huggingface.co/contact/sales?from=acad
 
 🤝 Collaboration
 - Share an org workspace across labs or campuses with granular access controls.
+- Preserve data and class materials under one institutional organisation, mount or use locally when needed.
+

--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -27,7 +27,7 @@ With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub 
 ## What's included in the subscription
 1. **Storage:** 1 TB of private and 1 TB of public storage per seat, including our new <a href="https://huggingface.co/storage" target="_blank">Storage Buckets!</a>
 2. **Compute:** $2/month/seat of credits for <a href="https://huggingface.co/docs/inference-providers/en/index" target="_blank">Inference Providers</a>, daily higher ZeroGPU priority access for <a href="https://huggingface.co/docs/hub/en/spaces-zerogpu" target="_blank">Spaces</a>, and higher Hub <a href="https://huggingface.co/docs/hub/rate-limits#rate-limit-tiers" target="_blank">rate limits</a>.
-3. **Collaboration tools:** Resource Groups, Data Studio for private datasets, Audit Logs, and access controls.
+3. **Collaboration tools:** [Resource Groups](./security-resource-groups), [Data Studio](./data-studio) for private datasets, Audit Logs, and access controls.
 4. **Governance & security:** Seat management, centralized admin, SSO, 2FA, SCIM, SOC 2 certified.
 5. **Global Open Source community:** publish and collaborate alongside the researchers and builders working on the field's most-used models and datasets.
 

--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -49,6 +49,9 @@ IT or Procurement staff: <a href="https://huggingface.co/contact/sales?from=acad
 - Distribute notebooks, datasets, models and student Spaces under one institutional org.
 - Test and compare models interactively without necessarily writing code.
 - Fine-tune a base model on a Hub dataset for a downstream task.
+- Launch jobs on Hugging Face infra to run experiments and assignments.
+- Preserve data and class materials on the Hub, mount or use locally when needed.
+- Easily find models and datasets to use in your project through agent-friendly interfaces.
 
 🔬 Research & Publication
 - Store private checkpoints and datasets, then publish final artefacts with DOIs.

--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -27,7 +27,7 @@ With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub 
 1. **Storage:** 1 TB of private and 1 TB of public storage per seat, including our new <a href="https://huggingface.co/storage" target="_blank">Storage Buckets!</a>
 2. **Compute:** $2/month/seat of credits for <a href="https://huggingface.co/docs/inference-providers/en/index" target="_blank">Inference Providers</a>, daily higher ZeroGPU priority access for <a href="https://huggingface.co/docs/hub/en/spaces-zerogpu" target="_blank">Spaces</a>, and higher Hub <a href="https://huggingface.co/docs/hub/rate-limits#rate-limit-tiers" target="_blank">rate limits</a>.
 3. **Collaboration tools:** [Resource Groups](./security-resource-groups), [Data Studio](./data-studio) for private datasets, [Audit Logs](./audit-logs), and access controls.
-4. **Governance & security:** Seat management, centralized admin, SSO, 2FA, SCIM, SOC 2 certified.
+4. **Governance & security:** Seat management, centralized admin, [SSO](https://huggingface.co/docs/hub/en/enterprise-sso), [2FA](https://huggingface.co/docs/hub/en/enterprise-advanced-security), [SCIM](https://huggingface.co/docs/hub/en/enterprise-sso#user-provisioning-scim), SOC 2 certified.
 5. **Global Open Source community:** publish and collaborate alongside the researchers and builders working on the field's most-used models and datasets.
 
 


### PR DESCRIPTION
Student-oriented, less research.
Based on discussions, traction and current partners: AH customers get the sub for their students. Researchers go for Teams - have their own budget for HF. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes updating marketing copy, pricing notes, and links with no product or code-path impact.
> 
> **Overview**
> Updates `docs/hub/academia-hub.md` to reposition Academia Hub around teaching and institutional adoption, replacing the prior research-lifecycle pitch.
> 
> Adds a clearer breakdown of what the subscription includes (storage/compute/collaboration/governance/community), introduces explicit pricing plus a 250-seat minimum, and appends a new **Common use cases** section. Also updates partner logos (adds HKPolyU) and refreshes several linked product references (e.g., Storage Buckets, Inference Providers, rate limits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f72ae637c9040354dbe798e4081ef8141417c0a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->