### PR TITLE
Update language to clarify that PRO is not required to launch HF Jobs

### DIFF
--- a/docs/hub/billing.md
+++ b/docs/hub/billing.md
@@ -32,7 +32,7 @@ The PRO subscription unlocks essential features for serious users, including:
 - Ability to create ZeroGPU Spaces and use Dev Mode
 - Ability to publish Social Posts and Community Blogs
 - Leverage the [Data Studio](./data-studio) on private datasets
-- Run and schedule serverless [CPU/ GPU Jobs](https://huggingface.co/docs/huggingface_hub/en/guides/jobs)
+- Purchase [pre-paid credits](https://huggingface.co/pricing) to run and schedule serverless [CPU/GPU Jobs](https://huggingface.co/docs/huggingface_hub/en/guides/jobs)
 
 View the full list of benefits at https://huggingface.co/pro then subscribe over at https://huggingface.co/subscribe/pro
 
@@ -166,4 +166,3 @@ Drop us a line at billing@huggingface.co with your feedback.
 **Q. My org has a Team or Enterprise subscription and I need to update the number of seats. How can I do this?**
 
 A. The number of seats will automatically be adjusted at the time of the subscription renewal to reflect any increases in the number of members in the organization during the previous period. There’s no need to update the subscribed number of seats during the month or year as it’s a flat fee subscription.
-

--- a/docs/hub/billing.md
+++ b/docs/hub/billing.md
@@ -32,7 +32,6 @@ The PRO subscription unlocks essential features for serious users, including:
 - Ability to create ZeroGPU Spaces and use Dev Mode
 - Ability to publish Social Posts and Community Blogs
 - Leverage the [Data Studio](./data-studio) on private datasets
-- Purchase [pre-paid credits](https://huggingface.co/pricing) to run and schedule serverless [CPU/GPU Jobs](https://huggingface.co/docs/huggingface_hub/en/guides/jobs)
 
 View the full list of benefits at https://huggingface.co/pro then subscribe over at https://huggingface.co/subscribe/pro
 

--- a/docs/hub/jobs-pricing.md
+++ b/docs/hub/jobs-pricing.md
@@ -3,7 +3,7 @@
 Hugging Face Jobs let you run compute tasks on Hugging Face infrastructure without managing it yourself. Simply define a command, a Docker image, and a hardware flavor among various CPU and GPU options.
 
 > [!TIP]
-> Jobs are available to any user or organization with [pre-paid credits](https://huggingface.co/pricing).
+> Jobs are available to all users and organizations with [pre-paid credits](https://huggingface.co/pricing).
 
 Billing on Jobs is based on hardware usage and is computed by the minute: you get charged for every minute the Jobs runs on the requested hardware.
 

--- a/docs/hub/jobs-pricing.md
+++ b/docs/hub/jobs-pricing.md
@@ -3,7 +3,7 @@
 Hugging Face Jobs let you run compute tasks on Hugging Face infrastructure without managing it yourself. Simply define a command, a Docker image, and a hardware flavor among various CPU and GPU options.
 
 > [!TIP]
-> Jobs are available to all users and organizations with [pre-paid credits](https://huggingface.co/pricing).
+> Jobs are available to all users and organizations with [pre-paid credits](https://huggingface.co/settings/billing).
 
 Billing on Jobs is based on hardware usage and is computed by the minute: you get charged for every minute the Jobs runs on the requested hardware.
 

--- a/docs/hub/jobs-quickstart.md
+++ b/docs/hub/jobs-quickstart.md
@@ -1,7 +1,7 @@
 # Quickstart
 
 In this guide you will run a Job to fine-tune an open source model on Hugging Face infrastructure in only a few minutes.
-Make sure you are logged in to Hugging Face and have access to your [Jobs page](https://huggingface.co/settings/jobs). Jobs are available to any user or organization with [pre-paid credits](https://huggingface.co/pricing).
+Make sure you are logged in to Hugging Face and have [pre-paid credits](https://huggingface.co/pricing) available on your account or organization. You can then access your [Jobs page](https://huggingface.co/settings/jobs) to create and manage Jobs.
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/jobs/jobs-page.png"/>

--- a/docs/hub/jobs-quickstart.md
+++ b/docs/hub/jobs-quickstart.md
@@ -1,7 +1,7 @@
 # Quickstart
 
 In this guide you will run a Job to fine-tune an open source model on Hugging Face infrastructure in only a few minutes.
-Make sure you are logged in to Hugging Face and have [pre-paid credits](https://huggingface.co/pricing) available on your account or organization. You can then access your [Jobs page](https://huggingface.co/settings/jobs) to create and manage Jobs.
+Make sure you are logged in to Hugging Face and have [pre-paid credits](https://huggingface.co/settings/billing) available on your account or organization. You can then access your [Jobs page](https://huggingface.co/settings/jobs) to create and manage Jobs.
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/jobs/jobs-page.png"/>

--- a/docs/hub/pro.md
+++ b/docs/hub/pro.md
@@ -9,7 +9,6 @@ The PRO subscription unlocks essential features for serious users, including:
 - Ability to create ZeroGPU Spaces and use [Dev Mode](./spaces-dev-mode)
 - Ability to publish Social Posts and Community Blogs
 - Leverage the [Data Studio](./data-studio) on private datasets
-- Purchase [pre-paid credits](https://huggingface.co/pricing) to run and schedule serverless [CPU/GPU Jobs](./jobs)
 
 
 <a href="https://huggingface.co/pro" target="_blank" class="flex justify-center">

--- a/docs/hub/pro.md
+++ b/docs/hub/pro.md
@@ -9,7 +9,7 @@ The PRO subscription unlocks essential features for serious users, including:
 - Ability to create ZeroGPU Spaces and use [Dev Mode](./spaces-dev-mode)
 - Ability to publish Social Posts and Community Blogs
 - Leverage the [Data Studio](./data-studio) on private datasets
-- Run and schedule serverless [CPU/GPU Jobs](./jobs)
+- Purchase [pre-paid credits](https://huggingface.co/pricing) to run and schedule serverless [CPU/GPU Jobs](./jobs)
 
 
 <a href="https://huggingface.co/pro" target="_blank" class="flex justify-center">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only edits that mainly change wording and links; no product or billing logic is affected.
> 
> **Overview**
> Clarifies Hugging Face Jobs prerequisites by updating the Jobs docs to point users to *pre-paid credits* in `settings/billing` (instead of `pricing`) and rewording the Jobs quickstart/setup guidance.
> 
> Removes the “serverless CPU/GPU Jobs” bullet from the PRO/billing benefit lists and fixes a small formatting artifact in the billing FAQ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db9d5b75f8fd948079abc302a01bcd132d513458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->