### PR TITLE
Auto-merge bot-generated Inference Providers docs PRs

### DIFF
--- a/.github/workflows/generate_inference_providers_documentation.yml
+++ b/.github/workflows/generate_inference_providers_documentation.yml
@@ -53,6 +53,7 @@ jobs:
 
       # Create or update Pull Request
       - name: Create Pull Request
+        id: create_pr
         if: env.changes_detected == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7
         with:
@@ -69,9 +70,14 @@ jobs:
             pnpm run generate
             ```
 
-            This PR was automatically created by the [Update Inference Providers Documentation workflow](https://github.com/huggingface/hub-docs/blob/main/.github/workflows/generate_inference_providers_documentation.yml).
-
-            Please review the changes before merging.
+            This PR was automatically created (and merged) by the [Update Inference Providers Documentation workflow](https://github.com/huggingface/hub-docs/blob/main/.github/workflows/generate_inference_providers_documentation.yml).
           reviewers: |
             Wauplin
             hanouticelina
+
+      # Automatically merge the Pull Request
+      - name: Merge Pull Request
+        if: env.changes_detected == 'true' && steps.create_pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN_INFERENCE_SYNC_BOT }}
+        run: gh pr merge --squash --delete-branch --auto "${{ steps.create_pr.outputs.pull-request-number }}"


### PR DESCRIPTION
Auto-merge the daily Inference Providers docs PR instead of requiring a manual click.

The workflow has been running without trouble for over a year (since 2025-04-15, #1687) and produces the same mechanical diff every run, so the human merge step is just a rubber-stamp.

**Requires:** repo-level "Allow auto-merge" enabled. `TOKEN_INFERENCE_SYNC_BOT` already has the needed scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables unattended `gh pr merge --auto` on bot-created PRs, which could merge unintended changes if the workflow or change-detection logic misbehaves, but is limited to a narrow automated docs update path.
> 
> **Overview**
> The `generate_inference_providers_documentation` workflow now **auto-merges** the bot-created documentation update PR when meaningful changes are detected.
> 
> It captures the created PR number from `peter-evans/create-pull-request` and runs `gh pr merge --squash --delete-branch --auto`, and updates the PR body to reflect that the workflow will create *and merge* the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9822e75c836bd7ba92d2a34514e0904d02c273d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->