### PR TITLE
docs: promote brew install for hf-mount

### DIFF
--- a/docs/hub/datasets-downloading.md
+++ b/docs/hub/datasets-downloading.md
@@ -56,7 +56,7 @@ Add your SSH public key to [your user settings](https://huggingface.co/settings/
 For large datasets, you can mount a repo as a local filesystem with [hf-mount](https://github.com/huggingface/hf-mount) instead of downloading the full repo. Files are fetched lazily — only the bytes your code reads hit the network. Useful when your workflow expects local file paths (e.g. `tarfile`, `zipfile`, `imagefolder`) rather than Python iterators.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
+brew install hf-mount
 hf-mount start repo datasets/stanfordnlp/imdb /tmp/imdb
 ```
 

--- a/docs/hub/datasets-downloading.md
+++ b/docs/hub/datasets-downloading.md
@@ -55,9 +55,21 @@ Add your SSH public key to [your user settings](https://huggingface.co/settings/
 
 For large datasets, you can mount a repo as a local filesystem with [hf-mount](https://github.com/huggingface/hf-mount) instead of downloading the full repo. Files are fetched lazily — only the bytes your code reads hit the network. Useful when your workflow expects local file paths (e.g. `tarfile`, `zipfile`, `imagefolder`) rather than Python iterators.
 
+Install with [Homebrew](https://brew.sh/) (macOS, Linux):
+
 ```bash
 brew install hf-mount
-# or: curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
+```
+
+Or using an installation script:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
+```
+
+Then mount:
+
+```bash
 hf-mount start repo datasets/stanfordnlp/imdb /tmp/imdb
 ```
 

--- a/docs/hub/datasets-downloading.md
+++ b/docs/hub/datasets-downloading.md
@@ -55,21 +55,8 @@ Add your SSH public key to [your user settings](https://huggingface.co/settings/
 
 For large datasets, you can mount a repo as a local filesystem with [hf-mount](https://github.com/huggingface/hf-mount) instead of downloading the full repo. Files are fetched lazily — only the bytes your code reads hit the network. Useful when your workflow expects local file paths (e.g. `tarfile`, `zipfile`, `imagefolder`) rather than Python iterators.
 
-Install with [Homebrew](https://brew.sh/) (macOS, Linux):
-
 ```bash
 brew install hf-mount
-```
-
-Or using an installation script:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
-```
-
-Then mount:
-
-```bash
 hf-mount start repo datasets/stanfordnlp/imdb /tmp/imdb
 ```
 

--- a/docs/hub/datasets-downloading.md
+++ b/docs/hub/datasets-downloading.md
@@ -57,6 +57,7 @@ For large datasets, you can mount a repo as a local filesystem with [hf-mount](h
 
 ```bash
 brew install hf-mount
+# or: curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
 hf-mount start repo datasets/stanfordnlp/imdb /tmp/imdb
 ```
 

--- a/docs/hub/models-downloading.md
+++ b/docs/hub/models-downloading.md
@@ -64,7 +64,7 @@ HF_XET_HIGH_PERFORMANCE=1 hf download ...
 For large models, you can mount a repo as a local filesystem with [hf-mount](https://github.com/huggingface/hf-mount) instead of downloading the full repo. Files are fetched lazily — only the bytes your code reads hit the network.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
+brew install hf-mount
 hf-mount start repo openai-community/gpt2 /tmp/gpt2
 ```
 

--- a/docs/hub/models-downloading.md
+++ b/docs/hub/models-downloading.md
@@ -65,6 +65,7 @@ For large models, you can mount a repo as a local filesystem with [hf-mount](htt
 
 ```bash
 brew install hf-mount
+# or: curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
 hf-mount start repo openai-community/gpt2 /tmp/gpt2
 ```
 

--- a/docs/hub/models-downloading.md
+++ b/docs/hub/models-downloading.md
@@ -63,21 +63,8 @@ HF_XET_HIGH_PERFORMANCE=1 hf download ...
 
 For large models, you can mount a repo as a local filesystem with [hf-mount](https://github.com/huggingface/hf-mount) instead of downloading the full repo. Files are fetched lazily — only the bytes your code reads hit the network.
 
-Install with [Homebrew](https://brew.sh/) (macOS, Linux):
-
 ```bash
 brew install hf-mount
-```
-
-Or using an installation script:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
-```
-
-Then mount:
-
-```bash
 hf-mount start repo openai-community/gpt2 /tmp/gpt2
 ```
 

--- a/docs/hub/models-downloading.md
+++ b/docs/hub/models-downloading.md
@@ -63,9 +63,21 @@ HF_XET_HIGH_PERFORMANCE=1 hf download ...
 
 For large models, you can mount a repo as a local filesystem with [hf-mount](https://github.com/huggingface/hf-mount) instead of downloading the full repo. Files are fetched lazily — only the bytes your code reads hit the network.
 
+Install with [Homebrew](https://brew.sh/) (macOS, Linux):
+
 ```bash
 brew install hf-mount
-# or: curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
+```
+
+Or using an installation script:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
+```
+
+Then mount:
+
+```bash
 hf-mount start repo openai-community/gpt2 /tmp/gpt2
 ```
 

--- a/docs/hub/storage-buckets-access.md
+++ b/docs/hub/storage-buckets-access.md
@@ -17,7 +17,13 @@ Access through the S3 API is not currently supported, but is on the roadmap.
 
 [hf-mount](https://github.com/huggingface/hf-mount) lets you mount buckets (and repos) as local filesystems via NFS (recommended) or FUSE. Files are fetched lazily — only the bytes your code reads hit the network.
 
-Install:
+Install with [Homebrew](https://brew.sh/) (macOS, Linux):
+
+```bash
+brew install hf-mount
+```
+
+Or using an installation script:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh

--- a/docs/hub/storage-buckets-access.md
+++ b/docs/hub/storage-buckets-access.md
@@ -17,16 +17,10 @@ Access through the S3 API is not currently supported, but is on the roadmap.
 
 [hf-mount](https://github.com/huggingface/hf-mount) lets you mount buckets (and repos) as local filesystems via NFS (recommended) or FUSE. Files are fetched lazily — only the bytes your code reads hit the network.
 
-Install with [Homebrew](https://brew.sh/) (macOS, Linux):
+Install with [Homebrew](https://brew.sh/):
 
 ```bash
 brew install hf-mount
-```
-
-Or using an installation script:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh
 ```
 
 Mount a bucket:


### PR DESCRIPTION
## Summary

`hf-mount` is now in homebrew-core and `brew install hf-mount` is the install path. Per @XciD's [review note](https://github.com/huggingface/hub-docs/pull/2437#discussion_r3146939995), the `install.sh` script has been removed from the hf-mount repo — so this PR drops curl references entirely and uses brew everywhere.

## Files changed

- `docs/hub/storage-buckets-access.md` — main hf-mount install section
- `docs/hub/models-downloading.md` — "Using hf-mount" subsection
- `docs/hub/datasets-downloading.md` — "Using hf-mount" subsection

Follow-up to #2406 — addresses @julien-c's review note: ["remember to mention brew after it's in brew"](https://github.com/huggingface/hub-docs/pull/2406#discussion_r3119115952).

## Test plan
- [x] CI green
- [x] Preview renders correctly on the three pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)