### PR TITLE
Add agent memory search for OpenClaw and Hermes Agent using llama.cpp

### DIFF
--- a/docs/hub/agents-local.md
+++ b/docs/hub/agents-local.md
@@ -108,7 +108,7 @@ You can run local embedding models with Llama.cpp for your agent's memory search
 npm i node-llama-cpp 
 ```
 
-Here's an example snippet to run [quantized EmbeddingGemma-300M](https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF?show_file_info=embeddinggemma-300M-Q8_0.gguf) locally for memory search. OpenClaw automatically downloads and serves the model with below command.
+Here's an example snippet to run [quantized EmbeddingGemma-300M](https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF?show_file_info=embeddinggemma-300M-Q8_0.gguf) locally for memory search. OpenClaw automatically downloads and serves the model with the command below.
 
 ```bash
 openclaw config set agents.defaults.memorySearch.provider local

--- a/docs/hub/agents-local.md
+++ b/docs/hub/agents-local.md
@@ -102,11 +102,12 @@ You can also run `openclaw onboard` interactively, select `custom-compatibility`
 
 ### Local Memory Search for OpenClaw
 
-You can run local embedding models with Llama.cpp for your agent's memory search. To do so, make sure to have node-llama-cpp.
+You can run local embedding models with Llama.cpp for your agent's memory search. To do so, make sure to have node-llama-cpp. 
 
 ```bash
-npm ls -g node-llama-cpp --depth=0
+npm i node-llama-cpp 
 ```
+
 Here's an example snippet to run [quantized EmbeddingGemma-300M](https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF?show_file_info=embeddinggemma-300M-Q8_0.gguf) locally for memory search. OpenClaw automatically downloads and serves the model with below command.
 
 ```bash

--- a/docs/hub/agents-local.md
+++ b/docs/hub/agents-local.md
@@ -144,7 +144,7 @@ custom_providers:
 
 ### Local Memory Search for Hermes Agent
 
-Hermes Agent consumes served semantic search models through endpoints. Once you get the model up on endpoint 8080 with the inference engine of your choice, add the following to `~/.hermes/config.yaml`.
+Hermes Agent consumes semantic search models through endpoints. Once you get your preferred embedding model up on endpoint 8080 with llama.cpp or the inference engine of your choice, add the following to `~/.hermes/config.yaml`.
 
 ```bash
 auxiliary:
@@ -156,7 +156,7 @@ auxiliary:
     max_concurrency: 1
 ```
 
-Check if this works, none - built-in only shows that no other memory plug-ins are used.
+Check if this works, `none - built-in only` shows that no other memory plug-ins are used.
 
 ```bash
 $ hermes memory status

--- a/docs/hub/agents-local.md
+++ b/docs/hub/agents-local.md
@@ -157,7 +157,7 @@ auxiliary:
     max_concurrency: 1
 ```
 
-Check if this works, `none - built-in only` shows that no other memory plug-ins are used. Below output shows that local serving is active.
+Check if this works, `none - built-in only` shows that no other memory plug-ins are used. The output below shows that local serving is active.
 
 ```bash
 $ hermes memory status

--- a/docs/hub/agents-local.md
+++ b/docs/hub/agents-local.md
@@ -100,9 +100,33 @@ openclaw onboard --non-interactive \
 
 You can also run `openclaw onboard` interactively, select `custom-compatibility` with `openai`, and pass the same configuration.
 
-## Hermes
+### Local Memory Search for OpenClaw
 
-[Hermes](https://hermes-agent.nousresearch.com/) works locally with llama.cpp. Define a default config as:
+You can run local embedding models with Llama.cpp for your agent's memory search. To do so, make sure to have node-llama-cpp.
+
+```bash
+npm ls -g node-llama-cpp --depth=0
+```
+Here's an example snippet to run [quantized EmbeddingGemma-300M](https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF?show_file_info=embeddinggemma-300M-Q8_0.gguf) locally for memory search.
+
+```bash
+openclaw config set agents.defaults.memorySearch.provider local
+openclaw config set agents.defaults.memorySearch.local.modelPath "hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf"
+```
+
+Restart the gateway and validate.
+
+```bash
+openclaw gateway restart
+openclaw memory status
+# Memory Search (main)
+# Provider: local (requested: local)
+# Model: hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf
+```
+
+## Hermes Agent
+
+[Hermes Agent](https://hermes-agent.nousresearch.com/) works locally with llama.cpp. Define a default config as:
 
 ```yaml
 model:
@@ -116,6 +140,30 @@ custom_providers:
     base_url: http://127.0.0.1:8080/v1
     api_key: llama.cpp
     model: ggml-org/gemma-4-26B-A4B-it-GGUF:Q4_K_M
+```
+
+### Local Memory Search for Hermes Agent
+
+Hermes Agent consumes served semantic search models through endpoints. Once you get the model up on endpoint 8080 with the inference engine of your choice, add the following to `~/.hermes/config.yaml`.
+
+```bash
+auxiliary:
+  session_search:
+    base_url: "http://127.0.0.1:8080/v1"
+    api_key: "no-key-required"
+    model: "local-llama" # your model alias
+    timeout: 90
+    max_concurrency: 1
+```
+
+Check if this works, none - built-in only shows that no other memory plug-ins are used.
+
+```bash
+$ hermes memory status
+# Memory status
+#────────────────────────────────────────
+#  Built-in:  always active
+#  Provider:  (none — built-in only)
 ```
 
 ## OpenCode

--- a/docs/hub/agents-local.md
+++ b/docs/hub/agents-local.md
@@ -107,7 +107,7 @@ You can run local embedding models with Llama.cpp for your agent's memory search
 ```bash
 npm ls -g node-llama-cpp --depth=0
 ```
-Here's an example snippet to run [quantized EmbeddingGemma-300M](https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF?show_file_info=embeddinggemma-300M-Q8_0.gguf) locally for memory search.
+Here's an example snippet to run [quantized EmbeddingGemma-300M](https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF?show_file_info=embeddinggemma-300M-Q8_0.gguf) locally for memory search. OpenClaw automatically downloads and serves the model with below command.
 
 ```bash
 openclaw config set agents.defaults.memorySearch.provider local
@@ -156,7 +156,7 @@ auxiliary:
     max_concurrency: 1
 ```
 
-Check if this works, `none - built-in only` shows that no other memory plug-ins are used.
+Check if this works, `none - built-in only` shows that no other memory plug-ins are used. Below output shows that local serving is active.
 
 ```bash
 $ hermes memory status


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Documents how to run **local memory / semantic search** alongside the existing llama.cpp agent setups in `agents-local.md`.
> 
> For **OpenClaw**, a new subsection covers installing `node-llama-cpp`, setting `agents.defaults.memorySearch` to the `local` provider with an Hugging Face EmbeddingGemma GGUF path, restarting the gateway, and checking `openclaw memory status`.
> 
> For **Hermes Agent** (section title updated from “Hermes”), a matching subsection explains wiring `auxiliary.session_search` in `~/.hermes/config.yaml` to a local OpenAI-compatible embedding endpoint and validating with `hermes memory status`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c56c66ea8185fcff1ea39bb2ffd8fdab5c10c0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->