### PR TITLE
Merge inference-providers bot PR without --auto

### DIFF
--- a/.github/workflows/generate_inference_providers_documentation.yml
+++ b/.github/workflows/generate_inference_providers_documentation.yml
@@ -75,9 +75,9 @@ jobs:
             Wauplin
             hanouticelina
 
-      # Automatically merge the Pull Request
+      # Merge the Pull Request immediately (no repo-level auto-merge setting required)
       - name: Merge Pull Request
         if: env.changes_detected == 'true' && steps.create_pr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ secrets.TOKEN_INFERENCE_SYNC_BOT }}
-        run: gh pr merge --squash --delete-branch --auto "${{ steps.create_pr.outputs.pull-request-number }}"
+        run: gh pr merge --squash --delete-branch "${{ steps.create_pr.outputs.pull-request-number }}"


### PR DESCRIPTION
## Summary
- The daily Inference Providers docs workflow currently calls `gh pr merge --auto`, which fails with `Auto merge is not allowed for this repository (enablePullRequestAutoMerge)` (see [run 24976327903](https://github.com/huggingface/hub-docs/actions/runs/24976327903/job/73128882964)).
- Fixing it by enabling the repo-level "Allow auto-merge" setting is undesirable: once enabled, **any** contributor can toggle auto-merge on their own PR, and a PR can end up merged even with unresolved review comments/suggestions unless the merge policy is further tightened.
- This drops `--auto` so the bot merges its own PR directly. `main` has no branch protection or rulesets requiring status checks, so a plain `gh pr merge --squash` succeeds immediately without the repo-level toggle. Only the bot's token can perform this merge — third-party contributors can't opt themselves into auto-merge.

Refs #2434.

## Test plan
- [ ] Trigger the workflow manually via `Actions → Generate Inference Providers Documentation → Run workflow` and confirm the bot PR is created and merged in a single run, without enabling repo-level auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small GitHub Actions change that only alters how the bot merges its own PR and avoids relying on the repo auto-merge setting.
> 
> **Overview**
> The `generate_inference_providers_documentation` workflow now merges the bot-created documentation PR directly by removing `gh pr merge --auto` and using an immediate squash merge instead.
> 
> This avoids requiring the repository-level auto-merge setting while keeping the same branch deletion behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 272daff4fbfaf70fc8c488ff6344adab19fbdc74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->