### PR TITLE
[CI] Sleep 5 min before merging inference-providers bot PR

### DIFF
--- a/.github/workflows/generate_inference_providers_documentation.yml
+++ b/.github/workflows/generate_inference_providers_documentation.yml
@@ -75,7 +75,13 @@ jobs:
             Wauplin
             hanouticelina
 
-      # Merge the Pull Request immediately (no repo-level auto-merge setting required)
+      # Wait for PR CI checks to finish before merging.
+      # The build typically takes ~1min; 5min gives a safe buffer without needing --admin to bypass checks.
+      - name: Wait for PR CI to complete
+        if: env.changes_detected == 'true' && steps.create_pr.outputs.pull-request-number != ''
+        run: sleep 300
+
+      # Merge the Pull Request (no repo-level auto-merge setting required)
       - name: Merge Pull Request
         if: env.changes_detected == 'true' && steps.create_pr.outputs.pull-request-number != ''
         env:

--- a/.github/workflows/generate_inference_providers_documentation.yml
+++ b/.github/workflows/generate_inference_providers_documentation.yml
@@ -76,10 +76,13 @@ jobs:
             hanouticelina
 
       # Wait for PR CI checks to finish before merging.
-      # The build typically takes ~1min; 5min gives a safe buffer without needing --admin to bypass checks.
+      # `gh pr checks --watch` blocks until all checks complete and exits non-zero if any fail,
+      # so we don't need --admin to bypass checks and we won't merge if CI is broken.
       - name: Wait for PR CI to complete
         if: env.changes_detected == 'true' && steps.create_pr.outputs.pull-request-number != ''
-        run: sleep 300
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN_INFERENCE_SYNC_BOT }}
+        run: gh pr checks --watch --fail-fast "${{ steps.create_pr.outputs.pull-request-number }}"
 
       # Merge the Pull Request (no repo-level auto-merge setting required)
       - name: Merge Pull Request

--- a/.github/workflows/generate_inference_providers_documentation.yml
+++ b/.github/workflows/generate_inference_providers_documentation.yml
@@ -76,13 +76,10 @@ jobs:
             hanouticelina
 
       # Wait for PR CI checks to finish before merging.
-      # `gh pr checks --watch` blocks until all checks complete and exits non-zero if any fail,
-      # so we don't need --admin to bypass checks and we won't merge if CI is broken.
+      # The build typically takes ~1min; 5min gives a safe buffer without needing --admin to bypass checks.
       - name: Wait for PR CI to complete
         if: env.changes_detected == 'true' && steps.create_pr.outputs.pull-request-number != ''
-        env:
-          GH_TOKEN: ${{ secrets.TOKEN_INFERENCE_SYNC_BOT }}
-        run: gh pr checks --watch --fail-fast "${{ steps.create_pr.outputs.pull-request-number }}"
+        run: sleep 300
 
       # Merge the Pull Request (no repo-level auto-merge setting required)
       - name: Merge Pull Request


### PR DESCRIPTION
### Context: [slack thread](https://huggingface.slack.com/archives/CTKK32GE8/p1777022163589539)

## Summary
- Follow-up to #2439. Without `--auto`, `gh pr merge` runs immediately and fails if required CI checks haven't completed yet.
- The PR build (`build_pr_documentation`, `trufflehog`, etc.) typically finishes in ~1 min, so a 5 min `sleep` before the merge step gives a safe buffer without needing `--admin` to bypass checks.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adds a fixed `sleep`; main risk is slower automation or still racing if CI exceeds the delay.
> 
> **Overview**
> The `generate_inference_providers_documentation` GitHub Actions workflow now **waits 5 minutes** after creating the bot PR before running `gh pr merge`, to reduce merge failures when required CI checks haven’t finished yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b760cd07939bb18eb424ae314c900f1a50d8dd22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->