### PR TITLE
Add SMILE Java client to local cache library list

### DIFF
--- a/docs/hub/local-cache.md
+++ b/docs/hub/local-cache.md
@@ -12,7 +12,7 @@ Here is a partial list of applications and libraries that use this cache layout.
 | [`@huggingface/hub`](https://github.com/huggingface/huggingface.js) | JavaScript | Node.js only |
 | [`HuggingFaceModelDownloader`](https://github.com/bodaay/HuggingFaceModelDownloader) | Go | |
 | [`llama.cpp`](https://github.com/ggml-org/llama.cpp) | C++ | *Work in progress* |
-| [`SMILE`](https://github.com/haifengl/smile) | Java | See [`HuggingFaceHub`](https://haifengl.github.io/api/java/smile/util/HuggingFaceHub.html) |
+| [`SMILE`](https://github.com/haifengl/smile) | Java | See [`HuggingFaceHub`](https://haifengl.github.io/api/java/smile/util/HuggingFaceHub.html) documentation |
 
 ## Cache location
 

--- a/docs/hub/local-cache.md
+++ b/docs/hub/local-cache.md
@@ -12,6 +12,7 @@ Here is a partial list of applications and libraries that use this cache layout.
 | [`@huggingface/hub`](https://github.com/huggingface/huggingface.js) | JavaScript | Node.js only |
 | [`HuggingFaceModelDownloader`](https://github.com/bodaay/HuggingFaceModelDownloader) | Go | |
 | [`llama.cpp`](https://github.com/ggml-org/llama.cpp) | C++ | *Work in progress* |
+| [`SMILE`](https://github.com/haifengl/smile) | Java | See [`HuggingFaceHub`](https://haifengl.github.io/api/java/smile/util/HuggingFaceHub.html) |
 
 ## Cache location
 


### PR DESCRIPTION
Adds [SMILE](https://github.com/haifengl/smile) to the list of libraries that implement the HF Hub local cache layout.

Closes #2440

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new entry to an existing table with no code or behavioral impact.
> 
> **Overview**
> Updates `docs/hub/local-cache.md` to include the Java library `SMILE` in the list of applications/libraries that implement the HF Hub local cache layout, with a link to its `HuggingFaceHub` documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a2cddef647cd75174cb1ea97529918d588a46fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->