### PR TITLE
Fix doc build error in enterprise-network-security page

### DIFF
--- a/docs/hub/enterprise-network-security.md
+++ b/docs/hub/enterprise-network-security.md
@@ -79,5 +79,5 @@ The Allowed URLs field, enables you to define some exception to the blocking rul
 You can read and update your organization's network security settings programmatically via the Hub API.
 
 **OpenAPI reference:**
-- [GET /api/organizations/{name}/settings/network-security](https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/{name}/settings/network-security)
-- [PATCH /api/organizations/{name}/settings/network-security](https://huggingface.co/spaces/huggingface/openapi#tag/orgs/PATCH/api/organizations/{name}/settings/network-security)
+- [`GET /api/organizations/{name}/settings/network-security`](https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/%7Bname%7D/settings/network-security)
+- [`PATCH /api/organizations/{name}/settings/network-security`](https://huggingface.co/spaces/huggingface/openapi#tag/orgs/PATCH/api/organizations/%7Bname%7D/settings/network-security)

--- a/docs/hub/enterprise-network-security.md
+++ b/docs/hub/enterprise-network-security.md
@@ -79,5 +79,5 @@ The Allowed URLs field, enables you to define some exception to the blocking rul
 You can read and update your organization's network security settings programmatically via the Hub API.
 
 **OpenAPI reference:**
-- <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/%7Bname%7D/settings/network-security" rel="nofollow">GET — read network security settings</a>
+- <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/%7Bname%7D/settings/network-security" rel="nofollow">GET /api/organizations/<name>/settings/network-security</a>
 - <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/PATCH/api/organizations/%7Bname%7D/settings/network-security" rel="nofollow">PATCH — update network security settings</a>

--- a/docs/hub/enterprise-network-security.md
+++ b/docs/hub/enterprise-network-security.md
@@ -79,5 +79,5 @@ The Allowed URLs field, enables you to define some exception to the blocking rul
 You can read and update your organization's network security settings programmatically via the Hub API.
 
 **OpenAPI reference:**
-- <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/&lcub;name&rcub;/settings/network-security" rel="nofollow">GET /api/organizations/&lcub;name&rcub;/settings/network-security</a>
-- <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/PATCH/api/organizations/&lcub;name&rcub;/settings/network-security" rel="nofollow">PATCH /api/organizations/&lcub;name&rcub;/settings/network-security</a>
+- <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/%7Bname%7D/settings/network-security" rel="nofollow">GET — read network security settings</a>
+- <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/PATCH/api/organizations/%7Bname%7D/settings/network-security" rel="nofollow">PATCH — update network security settings</a>

--- a/docs/hub/enterprise-network-security.md
+++ b/docs/hub/enterprise-network-security.md
@@ -79,5 +79,5 @@ The Allowed URLs field, enables you to define some exception to the blocking rul
 You can read and update your organization's network security settings programmatically via the Hub API.
 
 **OpenAPI reference:**
-- [`GET /api/organizations/{name}/settings/network-security`](https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/%7Bname%7D/settings/network-security)
-- [`PATCH /api/organizations/{name}/settings/network-security`](https://huggingface.co/spaces/huggingface/openapi#tag/orgs/PATCH/api/organizations/%7Bname%7D/settings/network-security)
+- <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/&#123;name&#125;/settings/network-security" rel="nofollow">GET /api/organizations/&#123;name&#125;/settings/network-security</a>
+- <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/PATCH/api/organizations/&#123;name&#125;/settings/network-security" rel="nofollow">PATCH /api/organizations/&#123;name&#125;/settings/network-security</a>

--- a/docs/hub/enterprise-network-security.md
+++ b/docs/hub/enterprise-network-security.md
@@ -80,4 +80,4 @@ You can read and update your organization's network security settings programmat
 
 **OpenAPI reference:**
 - <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/%7Bname%7D/settings/network-security" rel="nofollow">GET /api/organizations/<name>/settings/network-security</a>
-- <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/PATCH/api/organizations/%7Bname%7D/settings/network-security" rel="nofollow">PATCH — update network security settings</a>
+- <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/PATCH/api/organizations/%7Bname%7D/settings/network-security" rel="nofollow">PATCH /api/organizations/<name>/settings/network-security</a>

--- a/docs/hub/enterprise-network-security.md
+++ b/docs/hub/enterprise-network-security.md
@@ -79,5 +79,5 @@ The Allowed URLs field, enables you to define some exception to the blocking rul
 You can read and update your organization's network security settings programmatically via the Hub API.
 
 **OpenAPI reference:**
-- <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/&#123;name&#125;/settings/network-security" rel="nofollow">GET /api/organizations/&#123;name&#125;/settings/network-security</a>
-- <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/PATCH/api/organizations/&#123;name&#125;/settings/network-security" rel="nofollow">PATCH /api/organizations/&#123;name&#125;/settings/network-security</a>
+- <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/&lcub;name&rcub;/settings/network-security" rel="nofollow">GET /api/organizations/&lcub;name&rcub;/settings/network-security</a>
+- <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/PATCH/api/organizations/&lcub;name&rcub;/settings/network-security" rel="nofollow">PATCH /api/organizations/&lcub;name&rcub;/settings/network-security</a>


### PR DESCRIPTION
Fixes failing CI introduced in https://github.com/huggingface/hub-docs/pull/2426 cc @alexpouliquen @Pierrci 

---

The doc builder parses markdown with Svelte, which interprets unescaped `{name}` as a template expression and fails the build with `ReferenceError: name is not defined` (see e.g. [this run](https://github.com/huggingface/hub-docs/actions/runs/25048185301/job/73368753967?pr=2444)).

Wraps the API paths in backticks so they render as code spans in the link text, and URL-encodes the braces in the link targets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts link text/URLs to prevent the doc builder from evaluating `{name}` as a template expression.
> 
> **Overview**
> Fixes a docs build error on `enterprise-network-security.md` by replacing the OpenAPI reference markdown links that contained `{name}` with explicit anchor links that URL-encode the braces (`%7Bname%7D`) and avoid Svelte interpolation in the rendered text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ae26905ec2559dd2d7b928b4f75553eca2be03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->