### PR TITLE
docs(sso): clarify role fallback order when SSO role mapping finds no match

### DIFF
--- a/docs/hub/security-sso-user-management.md
+++ b/docs/hub/security-sso-user-management.md
@@ -41,7 +41,13 @@ This section allows you to define a mapping from your IdP's user profile data to
 
 If the attribute in the IdP response contains multiple values (e.g. a list of groups), the **first matching mapping** will be used to determine the user's role.
 
-If there is no match, a user will be assigned the default role for your organization. The default role can be customized in the `Members` section of the organization's settings.
+If there is no match, the role is determined as follows:
+
+- If the user was invited to the organization with a specific role, that invitation role is used as a fallback.
+- Otherwise, the user is assigned the default role for your organization. The default role can be customized in the `Members` section of the organization's settings.
+
+> [!NOTE]
+> When inviting a user whose role will be controlled by SSO role mapping, the role selected in the invite modal only applies if the user does not yet have a role assigned in your SSO provider.
 
 Role synchronization is performed on every login.
 


### PR DESCRIPTION
When SSO role mapping is enabled and no IdP role match is found for a user, the invitation role (if set during invite) takes precedence over the default org role. Add a note in the invite modal context clarifying this fallback behaviour.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies existing SSO role fallback behavior; no runtime or security logic is modified.
> 
> **Overview**
> Clarifies `Role Mapping` behavior in `security-sso-user-management.md` when no IdP attribute mapping matches: the user’s *invitation role* (if set) is applied before falling back to the organization’s default role.
> 
> Adds a note explaining that the role chosen in the invite modal only takes effect when the user has no role assigned by the SSO provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adbfa28de6b5f5ff6ebbc8b5a90333f03c5f35f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->