### PR TITLE
[Internal] bump docs workflows

### DIFF
--- a/.github/workflows/api_inference_build_documentation.yml
+++ b/.github/workflows/api_inference_build_documentation.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
     with:
       commit_sha: ${{ github.sha }}
       package: hub-docs

--- a/.github/workflows/api_inference_build_pr_documentation.yml
+++ b/.github/workflows/api_inference_build_pr_documentation.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/api_inference_upload_pr_documentation.yml
+++ b/.github/workflows/api_inference_upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@9ad2de8582b56c017cb530c1165116d40433f1c6  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
     with:
       package_name: inference-providers
     secrets:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only change that updates reusable workflow references; risk is limited to potential documentation CI/build behavior changes if the new `doc-builder` revision differs.
> 
> **Overview**
> Bumps the pinned `huggingface/doc-builder` commit SHA used by the Inference Providers documentation workflows for both main-branch builds (`api_inference_build_documentation.yml`) and PR doc uploads (`api_inference_upload_pr_documentation.yml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7687f310d1c3b0949c536a6d6673408d3941ac5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->