### PR TITLE
docs: update org network content access policy

### DIFF
--- a/docs/hub/enterprise-network-security.md
+++ b/docs/hub/enterprise-network-security.md
@@ -56,7 +56,7 @@ All public pages will show the following message if access is unauthenticated:
 
 ### Content Access Policy 
 
-Define a fine-grained Content Access Policy by blocking certain contents of the Hugging Face Hub. 
+Define a fine-grained Content Access Policy by blocking specific content of the Hugging Face Hub. 
 
 For example, you can block your organization's members from accessing Spaces. When users of your organization navigate to blocked content, they'll be presented the following page:
 
@@ -65,14 +65,14 @@ For example, you can block your organization's members from accessing Spaces. Wh
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/dark-network-sec-blocked-content.png" alt="Screenshot of blocked pages on the Hub."/>
 </div>
 
-To define Blocked Content, add rules that target a repository type, an organization, a specific repository, or a combination such as a repository type within a given organization (e.g. all Spaces from a specific organization).
+To define Blocked content, add rules that target a repository type, an organization, a specific repository, or a combination such as a repository type within a given organization (e.g. all Spaces from a specific organization).
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/network-sec-cap-v2.png" alt="Screenshot of access content policy settings on the Hub."/>
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/dark-network-sec-cap-v2.png" alt="Screenshot of access content policy settings on the Hub."/>
 </div>
 
-The Always Allowed field lets you define exceptions to the blocking rules. You can target content that should remain accessible regardless of the blocked rules.
+The Always allowed field lets you define exceptions to the blocking rules. You can target content that should remain accessible even when a block rule would otherwise apply.
 
 ## Manage Network Security via API
 

--- a/docs/hub/enterprise-network-security.md
+++ b/docs/hub/enterprise-network-security.md
@@ -56,23 +56,23 @@ All public pages will show the following message if access is unauthenticated:
 
 ### Content Access Policy 
 
-Define a fine-grained Content Access Policy by blocking certain sections of the Hugging Face Hub. 
+Define a fine-grained Content Access Policy by blocking certain contents of the Hugging Face Hub. 
 
-For example, you can block your organization's members from accessing Spaces by adding `/spaces/*` to the blocked URLs. When users of your organization navigate to a page that matches the URL pattern, they'll be presented the following page:
-
-<div class="flex justify-center">
-<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/network-sec-blocked-url.png" alt="Screenshot of blocked pages on the Hub."/>
-<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/dark-network-sec-blocked-url.png" alt="Screenshot of blocked pages on the Hub."/>
-</div>
-
-To define Blocked URLs, enter URL patterns, without the domain name, one per line:
+For example, you can block your organization's members from accessing Spaces. When users of your organization navigate to blocked content, they'll be presented the following page:
 
 <div class="flex justify-center">
-<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/network-sec-cap.png" alt="Screenshot of blocked pages on the Hub."/>
-<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/dark-network-sec-cap.png" alt="Screenshot of blocked pages on the Hub."/>
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/network-sec-blocked-content.png" alt="Screenshot of blocked pages on the Hub."/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/dark-network-sec-blocked-content.png" alt="Screenshot of blocked pages on the Hub."/>
 </div>
 
-The Allowed URLs field, enables you to define some exception to the blocking rules, especially. For example by allowing a specific URL within the Blocked URLs pattern, ie `/spaces/meta-llama/*`  
+To define Blocked Content, add rules that target a repository type, an organization, a specific repository, or a combination such as a repository type within a given organization (e.g. all Spaces from a specific organization).
+
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/network-sec-cap-v2.png" alt="Screenshot of access content policy settings on the Hub."/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/dark-network-sec-cap-v2.png" alt="Screenshot of access content policy settings on the Hub."/>
+</div>
+
+The Always Allowed field lets you define exceptions to the blocking rules. You can target content that should remain accessible regardless of the blocked rules.
 
 ## Manage Network Security via API
 


### PR DESCRIPTION
Update organization network security content access policy section including screenshots & wording to reflect UX changes recently made on the hub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update that changes wording and screenshots to match the updated Content Access Policy UI; no product logic is affected.
> 
> **Overview**
> Updates the *Content Access Policy* section of `docs/hub/enterprise-network-security.md` to reflect the new Hub UX by shifting guidance from **URL pattern blocking/allowlisting** to **rule-based content blocking** (repo type/org/repo combinations and an *Always allowed* exceptions field).
> 
> Replaces the associated screenshots and tweaks the example text to align with the new blocked-content behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 384bf02f271773d45f5575dbdeab0f4eb75a0492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->