### PR TITLE
docs(local-cache): split table into Libraries / Applications, add LlamaBarn

### DIFF
--- a/docs/hub/local-cache.md
+++ b/docs/hub/local-cache.md
@@ -2,17 +2,25 @@
 
 This document describes the on-disk layout of the HF Hub local cache. It is intended as a reference for reimplementing the cache system in any language.
 
-Here is a partial list of applications and libraries that use this cache layout. Please open a PR to add your own.
+Here is a partial list of libraries and applications that use this cache layout. Please open a PR to add your own.
 
-| Library or Application | Language | Notes |
+### Libraries
+
+| Library | Language | Notes |
 |---------|----------|-------|
 | [`huggingface_hub`](https://github.com/huggingface/huggingface_hub) | Python | And any library that depends on it (e.g. `transformers`, `diffusers`, `datasets`, `mlx`, `vllm` …) |
 | [`hf-hub`](https://github.com/huggingface/hf-hub) | Rust | |
 | [`swift-huggingface`](https://github.com/huggingface/swift-huggingface) | Swift | |
 | [`@huggingface/hub`](https://github.com/huggingface/huggingface.js) | JavaScript | Node.js only |
-| [`HuggingFaceModelDownloader`](https://github.com/bodaay/HuggingFaceModelDownloader) | Go | |
-| [`llama.cpp`](https://github.com/ggml-org/llama.cpp) | C++ | *Work in progress* |
 | [`SMILE`](https://github.com/haifengl/smile) | Java | See [`HuggingFaceHub`](https://haifengl.github.io/api/java/smile/util/HuggingFaceHub.html) documentation |
+
+### Applications
+
+| Application | Language | Notes |
+|-------------|----------|-------|
+| [`llama.cpp`](https://github.com/ggml-org/llama.cpp) | C++ | Since [#20775](https://github.com/ggml-org/llama.cpp/pull/20775) |
+| [`LlamaBarn`](https://github.com/ggml-org/LlamaBarn) | Swift | macOS app, built on `llama.cpp` |
+| [`HuggingFaceModelDownloader`](https://github.com/bodaay/HuggingFaceModelDownloader) | Go | |
 
 ## Cache location
 


### PR DESCRIPTION
## Summary
- Split the local-cache implementers table into **Libraries** and **Applications**.
- Move `llama.cpp` and `HuggingFaceModelDownloader` under Applications, and add `LlamaBarn`.
- Replace the "Work in progress" note next to `llama.cpp` with a link to [ggml-org/llama.cpp#20775](https://github.com/ggml-org/llama.cpp/pull/20775), which added standard Hugging Face cache support.

## Test plan
- [ ] Render `docs/hub/local-cache.md` and confirm both tables display correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only restructuring and link updates; low risk aside from potential markdown rendering issues in the tables.
> 
> **Overview**
> Reformats `docs/hub/local-cache.md` to split the cache-layout implementers list into separate **Libraries** and **Applications** tables.
> 
> Moves `llama.cpp` and `HuggingFaceModelDownloader` into the Applications section, adds `LlamaBarn`, and updates the `llama.cpp` note to reference the PR that introduced HF cache support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af27153c178689fbce01874c3b0803085564573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->