### PR TITLE
[CI] Use --admin to automatically merge inference-providers PR bot

### DIFF
--- a/.github/workflows/generate_inference_providers_documentation.yml
+++ b/.github/workflows/generate_inference_providers_documentation.yml
@@ -75,15 +75,9 @@ jobs:
             Wauplin
             hanouticelina
 
-      # Wait for PR CI checks to finish before merging.
-      # The build typically takes ~1min; 5min gives a safe buffer without needing --admin to bypass checks.
-      - name: Wait for PR CI to complete
-        if: env.changes_detected == 'true' && steps.create_pr.outputs.pull-request-number != ''
-        run: sleep 300
-
-      # Merge the Pull Request (no repo-level auto-merge setting required)
+      # Merge the Pull Request using --admin to bypass branch protection checks
       - name: Merge Pull Request
         if: env.changes_detected == 'true' && steps.create_pr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ secrets.TOKEN_INFERENCE_SYNC_BOT }}
-        run: gh pr merge --squash --delete-branch "${{ steps.create_pr.outputs.pull-request-number }}"
+        run: gh pr merge --squash --admin --delete-branch "${{ steps.create_pr.outputs.pull-request-number }}"


### PR DESCRIPTION
### Context: [slack thread](https://huggingface.slack.com/archives/CTKK32GE8/p1777022163589539)


Follow-up after https://github.com/huggingface/hub-docs/pull/2442.

The CI is still failing (see https://github.com/huggingface/hub-docs/actions/runs/25300928871/job/74167615111) because it needs at least 1 approval to merge. Let's just use `--admin` to force merge the PR (and therefore, no need to wait for checks to pass).

cc @Pierrci 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow now bypasses branch protection/required-review checks by using `gh pr merge --admin`, which can merge changes without CI/approvals and increases the chance of landing broken or unintended docs updates.
> 
> **Overview**
> Automated Inference Providers docs update workflow now merges its bot-created PRs with `gh pr merge --admin`, bypassing branch protection requirements.
> 
> Removes the explicit post-PR wait step and relies on admin merge behavior to complete merges even when checks/approvals would normally block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28ee6308699e04516fc2a6ee8540ab25871848a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->