### PR TITLE
docs: add user blocking docs and update comment reporting section

### DIFF
--- a/docs/hub/moderation.md
+++ b/docs/hub/moderation.md
@@ -27,7 +27,7 @@ While submitting the report, you also have the option to **block the comment aut
 
 Blocking a user prevents them from interacting with your repositories and other Hub content. When you block someone, any existing follow relationship between you and that user is also removed.
 
-To block a user, you can opt in to blocking them directly from the [comment report modal](#reporting-a-comment). Select "Report" from the comment's menu, fill in your reason, and check **"Yes, block this user"** before submitting.
+You can block a user from the [comment report modal](#reporting-a-comment). Select "Report" from the comment's menu, fill in your reason, and check **"Yes, block this user"** before submitting.
 
 > [!NOTE]
 > You must have a confirmed email address on your account to block users.

--- a/docs/hub/moderation.md
+++ b/docs/hub/moderation.md
@@ -14,9 +14,20 @@ To report a repository, you can click the three dots at the top right of a repos
 
 ## Reporting a comment
 
-To report a comment, you can click the three dots at the top right of a comment. That will submit a request for the Hugging Face team to review.
+To report a comment, click the three dots at the top right of a comment and select "Report". A modal will appear where you can describe the reason for your report — this will be reviewed by the Hugging Face moderation team.
+
+While submitting the report, you also have the option to **block the comment author** at the same time (see [Blocking a user](#blocking-a-user) below).
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/comment-report.png"/>
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/comment-report-dark.png"/>
 </div>
+
+## Blocking a user
+
+Blocking a user prevents them from interacting with your repositories and other Hub content. When you block someone, any existing follow relationship between you and that user is also removed.
+
+To block a user, you can opt in to blocking them directly from the [comment report modal](#reporting-a-comment). Select "Report" from the comment's menu, fill in your reason, and check **"Yes, block this user"** before submitting.
+
+> [!NOTE]
+> You must have a confirmed email address on your account to block users.


### PR DESCRIPTION
The comment report flow now uses a modal UI with a description field and an option to block the comment author at the same time. Documents the new blocking feature (what it does, how to trigger it, email requirement).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update describing the updated comment reporting UI and a new user-blocking option; no code or behavior changes.
> 
> **Overview**
> Updates Hub moderation docs to reflect the **new comment reporting flow**: reporting now opens a modal with a free-text reason reviewed by moderators.
> 
> Adds a new **“Blocking a user”** section explaining how to block a commenter directly from the report modal, what blocking does (prevents interaction and removes follow relationships), and the requirement for a confirmed email.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a74d72a1c588f5d69d52ab17b1d2a4ebdb10ee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->