### PR TITLE
docs: warn that README Space must be Public for org card to appear

### DIFF
--- a/docs/hub/organizations-cards.md
+++ b/docs/hub/organizations-cards.md
@@ -12,7 +12,7 @@ An organization card is displayed on an organization's profile:
 If you're a member of an organization, you'll see a button to create or edit your organization card on the organization's main page. Organization cards are a `README.md` static file inside a Space repo named `README`. The card can be as simple as Markdown text, or you can create a more customized appearance with HTML.
 
 > [!WARNING]
-> The README Space must be set to **Public** visibility. If it is set to Protected or Private, the organization card will not appear on your organization's profile page.
+> The `README` Space must be set to **Public** visibility. If it is set to Protected or Private, the organization card will not appear on your organization's profile page.
 
 The card for the [Hugging Face Course organization](https://huggingface.co/huggingface-course), shown above, [contains the following HTML](https://huggingface.co/spaces/huggingface-course/README/blob/main/README.md):
 

--- a/docs/hub/organizations-cards.md
+++ b/docs/hub/organizations-cards.md
@@ -1,6 +1,6 @@
 # Organization cards
 
-You can create an organization card to help users learn more about what your organization is working on and how users can use your libraries, models, datasets, and Spaces. 
+You can create an organization card to help users learn more about what your organization is working on and how users can use your libraries, models, datasets, and Spaces.
 
 An organization card is displayed on an organization's profile:
 
@@ -9,18 +9,23 @@ An organization card is displayed on an organization's profile:
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-card-dark.png"/>
 </div>
 
-
 If you're a member of an organization, you'll see a button to create or edit your organization card on the organization's main page. Organization cards are a `README.md` static file inside a Space repo named `README`. The card can be as simple as Markdown text, or you can create a more customized appearance with HTML.
+
+> [!WARNING]
+> The README Space must be set to **Public** visibility. If it is set to Protected or Private, the organization card will not appear on your organization's profile page.
 
 The card for the [Hugging Face Course organization](https://huggingface.co/huggingface-course), shown above, [contains the following HTML](https://huggingface.co/spaces/huggingface-course/README/blob/main/README.md):
 
 ```html
 <p>
-This is the organization grouping all the models and datasets used in the <a href="https://huggingface.co/course/chapter1" class="underline">Hugging Face course</a>.
+  This is the organization grouping all the models and datasets used in the
+  <a href="https://huggingface.co/course/chapter1" class="underline"
+    >Hugging Face course</a
+  >.
 </p>
 ```
 
 For more examples, take a look at:
 
-* [Amazon's](https://huggingface.co/spaces/amazon/README/blob/main/README.md) organization card source code
-* [spaCy's](https://huggingface.co/spaces/spacy/README/blob/main/README.md) organization card source code.
+- [Amazon's](https://huggingface.co/spaces/amazon/README/blob/main/README.md) organization card source code
+- [spaCy's](https://huggingface.co/spaces/spacy/README/blob/main/README.md) organization card source code.

--- a/docs/hub/organizations-cards.md
+++ b/docs/hub/organizations-cards.md
@@ -19,9 +19,7 @@ The card for the [Hugging Face Course organization](https://huggingface.co/huggi
 ```html
 <p>
   This is the organization grouping all the models and datasets used in the
-  <a href="https://huggingface.co/course/chapter1" class="underline"
-    >Hugging Face course</a
-  >.
+  <a href="https://huggingface.co/course/chapter1" class="underline">Hugging Face course</a>.
 </p>
 ```
 

--- a/docs/hub/organizations-cards.md
+++ b/docs/hub/organizations-cards.md
@@ -11,8 +11,7 @@ An organization card is displayed on an organization's profile:
 
 If you're a member of an organization, you'll see a button to create or edit your organization card on the organization's main page. Organization cards are a `README.md` static file inside a Space repo named `README`. The card can be as simple as Markdown text, or you can create a more customized appearance with HTML.
 
-> [!WARNING]
-> The `README` Space must be set to **Public** visibility. If it is set to Protected or Private, the organization card will not appear on your organization's profile page.
+The Space must be set to **Public** visibility. If it is set to Protected or Private, the organization card will not appear on your organization's profile page.
 
 The card for the [Hugging Face Course organization](https://huggingface.co/huggingface-course), shown above, [contains the following HTML](https://huggingface.co/spaces/huggingface-course/README/blob/main/README.md):
 


### PR DESCRIPTION
## Summary

- Adds a `[!WARNING]` callout to the Organization Cards doc noting that the README Space must be set to **Public** visibility


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies a visibility requirement; no product or runtime behavior is modified.
> 
> **Overview**
> Clarifies in `docs/hub/organizations-cards.md` that the org-card `README` Space must be **Public** for the card to appear on the organization profile.
> 
> Also makes minor markdown formatting cleanups (line wrapping and list formatting) in the same doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e18d3bf791332caf3ca9863d7a2d66c2b5a7c22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->