### PR TITLE
remove $2k included credits from Enterprise plan

### DIFF
--- a/docs/hub/enterprise.md
+++ b/docs/hub/enterprise.md
@@ -37,7 +37,7 @@ Team & Enterprise organization plans add advanced capabilities to organizations,
 | Serve models with Inference Providers                                                                                  | ✅ <br>PAYG | ✅ <br>$2/seat/mo included + PAYG | ✅ <br>$2/seat/mo included + PAYG | ✅ <br>$2/seat/mo included + PAYG |
 | [Usage & billing control](https://huggingface.co/docs/inference-providers/pricing#inference-providers-usage-breakdown) | ❌      | ✅                                | ✅                                | ✅                                |
 | Scale deployment with Inference Endpoints                                                                              | ✅ PAYG | ✅ PAYG                           | ✅ PAYG                           | ✅ PAYG                           |
-| Hub credits\* included in plan                                                                                         | ❌      | ❌ (bulk purchase available)      | $2k included                      | 5% of ACV included                |
+| Hub credits\* included in plan                                                                                         | ❌      | ❌ (bulk purchase available)      | ❌ (bulk purchase available)      | 5% of ACV included                |
 
 \* Hub credits can be utilized for inference providers, inference endpoints, Jobs, Space upgrade, ZeroGPU quota extension
 


### PR DESCRIPTION
## Problem
The Enterprise plan row in the Inference & Hub credits table shows `$2k included` for Hub credits, but this is no longer accurate.

## Fix
Align the Enterprise column with the Team column: `❌ (bulk purchase available)`.

Requested by @AdrianLepers.