### PR TITLE
[Inference Providers] Document `/v1/models`

### DIFF
--- a/docs/inference-providers/hub-api.md
+++ b/docs/inference-providers/hub-api.md
@@ -125,7 +125,7 @@ None
 The router exposes an OpenAI-compatible endpoint to list chat-completion models served by Inference Providers, together with provider metadata used for routing and comparison:
 
 ```sh
-~ curl -s https://router.huggingface.co/v1/models | jq '.data[0]'
+~ curl -s https://router.huggingface.co/v1/models | jq '.data'
 {
   "id": "deepseek-ai/DeepSeek-V4-Pro",
   "object": "model",
@@ -199,6 +199,7 @@ The router exposes an OpenAI-compatible endpoint to list chat-completion models 
     }
   ]
 }
+...
 ```
 
 To retrieve a single model, append its model id to the endpoint:

--- a/docs/inference-providers/hub-api.md
+++ b/docs/inference-providers/hub-api.md
@@ -120,6 +120,109 @@ None
 
 </inferencesnippet>
 
+## List OpenAI-compatible models
+
+The router exposes an OpenAI-compatible endpoint to list chat-completion models served by Inference Providers, together with provider metadata used for routing and comparison:
+
+```sh
+~ curl -s https://router.huggingface.co/v1/models | jq '.data[0]'
+{
+  "id": "deepseek-ai/DeepSeek-V4-Pro",
+  "object": "model",
+  "created": 1776837885,
+  "owned_by": "deepseek-ai",
+  "architecture": {
+    "input_modalities": [
+      "text"
+    ],
+    "output_modalities": [
+      "text"
+    ]
+  },
+  "providers": [
+    {
+      "provider": "novita",
+      "status": "live",
+      "context_length": 1048576,
+      "pricing": {
+        "input": 1.69,
+        "output": 3.38
+      },
+      "supports_tools": true,
+      "supports_structured_output": false,
+      "first_token_latency_ms": 1490,
+      "throughput": 24.69124008437934,
+      "is_model_author": false
+    },
+    {
+      "provider": "together",
+      "status": "live",
+      "context_length": 512000,
+      "pricing": {
+        "input": 2.1,
+        "output": 4.4
+      },
+      "supports_tools": true,
+      "supports_structured_output": true,
+      "first_token_latency_ms": 611,
+      "throughput": 40.13113557470821,
+      "is_model_author": false
+    },
+    {
+      "provider": "fireworks-ai",
+      "status": "live",
+      "context_length": 1048576,
+      "supports_tools": true,
+      "supports_structured_output": true,
+      "first_token_latency_ms": 588.4,
+      "throughput": 45.42948747753918,
+      "is_model_author": false
+    },
+    {
+      "provider": "featherless-ai",
+      "status": "live",
+      "is_model_author": false
+    },
+    {
+      "provider": "deepinfra",
+      "status": "live",
+      "context_length": 65536,
+      "pricing": {
+        "input": 1.74,
+        "output": 3.48
+      },
+      "supports_tools": true,
+      "supports_structured_output": true,
+      "first_token_latency_ms": 525.8,
+      "throughput": 34.615908579189465,
+      "is_model_author": false
+    }
+  ]
+}
+```
+
+To retrieve a single model, append its model id to the endpoint:
+
+```sh
+~ curl -s https://router.huggingface.co/v1/models/deepseek-ai/DeepSeek-V4-Pro | jq '.'
+```
+
+Each provider entry may include the following fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `provider` | string | Provider identifier |
+| `status` | string | `live` or `error` |
+| `context_length` | number | Maximum context length supported by this provider for the model, when available |
+| `pricing` | object | `input` and `output` prices in USD per million tokens, when available |
+| `supports_tools` | boolean | Whether the provider supports tool calling, when available |
+| `supports_structured_output` | boolean | Whether the provider supports structured output, when available |
+| `first_token_latency_ms` | number | Time to first token in milliseconds from the latest validation probe, when available |
+| `throughput` | number | Output throughput in tokens per second from the latest validation probe, when available |
+| `is_model_author` | boolean | Whether the model was published by this provider |
+
+These metrics are the same provider performance signals shown in the [provider comparison table](https://huggingface.co/inference/models). They are optional because some providers or models may not have the latest probe data available.
+
 ## Get model providers
 
 If you are interested by a specific model and want to check the list of providers serving it, you can request the `inferenceProviderMapping` attribute in the model info endpoint:

--- a/docs/inference-providers/index.md
+++ b/docs/inference-providers/index.md
@@ -536,7 +536,7 @@ curl https://router.huggingface.co/v1/chat/completions \
 **Key Features:**
 
 - **Server-Side Provider Selection**: The server automatically selects the fastest available provider by default (`:fastest` policy)
-- **Model Listing**: GET `/v1/models` returns available models across all providers
+- **Model Listing**: GET `/v1/models` returns available models across all providers, including per-provider pricing, context length, latency, and throughput when available
 - **OpenAI SDK Compatibility**: Works with existing OpenAI client libraries
 - **Chat Tasks Only**: Limited to conversational workloads
 


### PR DESCRIPTION
This PR adds documentation for Inference Providers' `GET /v1/models` and `GET /v1/models/{repo_id}` responses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds examples/field descriptions for the router model-listing endpoints and clarifies that per-provider metrics may be returned when available.
> 
> **Overview**
> Documents the OpenAI-compatible router model listing endpoints by adding a new section for `GET /v1/models` and `GET /v1/models/{model_id}`, including an example response and a table describing per-provider fields (pricing, context length, tool/structured-output support, and latency/throughput signals).
> 
> Updates the Inference Providers overview to clarify that `GET /v1/models` can return per-provider metadata and performance metrics when available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86fef8bf6128ef64ceed06df1a2f5a39adf7128e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->