### PR TITLE
docs: add reviewedAt field to gated repo access report documentation

### DIFF
--- a/docs/hub/datasets-gated.md
+++ b/docs/hub/datasets-gated.md
@@ -72,6 +72,7 @@ You can download a report of all access requests for a gated datasets with the *
 - **status**: status of the request. Either `"pending"`, `"accepted"` or `"rejected"`.
 - **email**: email of the user.
 - **time**: datetime when the user initially made the request.
+- **reviewedAt**: datetime when the request was accepted or rejected. Not set for pending requests.
 
 <a id="modifying-the-prompt"></a> <!-- backward compatible anchor -->
 

--- a/docs/hub/models-gated.md
+++ b/docs/hub/models-gated.md
@@ -73,6 +73,7 @@ You can download a report of all access requests for a gated model with the **do
 - **status**: status of the request. Either `"pending"`, `"accepted"` or `"rejected"`.
 - **email**: email of the user.
 - **time**: datetime when the user initially made the request.
+- **reviewedAt**: datetime when the request was accepted or rejected. Not set for pending requests.
 
 <a id="modifying-the-prompt"></a> <!-- backward compatible anchor -->
 


### PR DESCRIPTION
Document the new `reviewedAt` timestamp field added to the access request download report and API responses, which indicates when a request was accepted or rejected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a newly exposed field description; no product logic or APIs are modified.
> 
> **Overview**
> Documents a new `reviewedAt` timestamp in the downloaded access report for both gated datasets and gated models, indicating when an access request was accepted or rejected (and absent for pending requests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdb7ad2731a03636f63cbdc4e93c0ec7fd92477c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->