### PR TITLE
docs: say "Hub and ecosystem" in the hf CLI Skill CTA

### DIFF
--- a/docs/hub/agents-cli.md
+++ b/docs/hub/agents-cli.md
@@ -1,6 +1,6 @@
 # Hugging Face CLI for AI Agents
 
-The `hf` CLI is a great way to connect your agents to the Hugging Face ecosystem. Search models, manage datasets and buckets, launch Spaces, and run jobs from any coding agent.
+The `hf` CLI is a great way to connect your agents to the Hugging Face Hub and ecosystem. Search models, manage datasets and buckets, launch Spaces, and run jobs from any coding agent.
 
 > [!TIP]
 > This is a quick guide on agents that use the CLI. For more detailed information, see the [CLI Reference itself](https://huggingface.co/docs/huggingface_hub/guides/cli).

--- a/docs/hub/agents-skills.md
+++ b/docs/hub/agents-skills.md
@@ -1,7 +1,7 @@
 # Skills
 
 > [!TIP]
-> Looking for the `hf` CLI Skill? It's the quickest way to connect your agent to the Hugging Face ecosystem. See the [Hugging Face CLI for AI Agents](./agents-cli) guide.
+> Looking for the `hf` CLI Skill? It's the quickest way to connect your agent to the Hugging Face Hub and ecosystem. See the [Hugging Face CLI for AI Agents](./agents-cli) guide.
 
 Hugging Face provides a curated set of Skills built for AI builders. Train models, create datasets, run evaluations, track experiments. Each Skill is a self-contained `SKILL.md` that your agent follows while working on the task.
 


### PR DESCRIPTION
## Summary
- Update the CTA on `agents-skills.md` and `agents-cli.md` so it says "Hugging Face Hub and ecosystem" instead of just "Hugging Face ecosystem".
- Keeps wording aligned with the matching note being added on the [skills repo README](https://github.com/huggingface/skills/pull/141).

## Test plan
- [ ] Render preview: confirm both pages read naturally with the updated phrasing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk wording-only docs change that doesn’t affect behavior or APIs.
> 
> **Overview**
> Updates the call-to-action phrasing in `agents-cli.md` and `agents-skills.md` to say “Hugging Face **Hub and ecosystem**” instead of just “ecosystem” when describing the `hf` CLI/Skill connection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3d81355adf3643b608d9db2f9a7b885e7806409. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->