### PR TITLE
[ZeroGPU] Blackwell update

### DIFF
--- a/docs/hub/advanced-compute-options.md
+++ b/docs/hub/advanced-compute-options.md
@@ -7,7 +7,7 @@ Team & Enterprise organizations gain access to advanced compute options to accel
 
 ## Host ZeroGPU Spaces in your organization
 
-ZeroGPU is a dynamic GPU allocation system that optimizes AI deployment on Hugging Face Spaces. By automatically allocating and releasing NVIDIA H200 GPU slices (70GB VRAM) as needed, organizations can efficiently serve their AI applications without dedicated GPU instances.
+ZeroGPU is a dynamic GPU allocation system that optimizes AI deployment on Hugging Face Spaces. By automatically allocating and releasing NVIDIA RTX Pro 6000 Blackwell GPU slices (96GB VRAM) as needed, organizations can efficiently serve their AI applications without dedicated GPU instances.
 
 <div class="flex justify-center" style="max-width: 550px">
   <img
@@ -24,9 +24,9 @@ ZeroGPU is a dynamic GPU allocation system that optimizes AI deployment on Huggi
 
 **Key benefits for organizations**
 
-- **Free GPU Access**: Access powerful NVIDIA H200 GPUs at no additional cost through dynamic allocation
+- **Free GPU Access**: Access powerful NVIDIA RTX Pro 6000 Blackwell GPUs at no additional cost through dynamic allocation
 - **Enhanced Resource Management**: Host up to 50 ZeroGPU Spaces for efficient team-wide AI deployment
 - **Simplified Deployment**: Easy integration with PyTorch-based models, Gradio apps, and other Hugging Face libraries
-- **Enterprise-Grade Infrastructure**: Access to high-performance NVIDIA H200 GPUs with 70GB VRAM per workload
+- **Enterprise-Grade Infrastructure**: Access to high-performance NVIDIA RTX Pro 6000 Blackwell GPUs with up to 96GB VRAM per workload
 
 [Learn more about ZeroGPU →](https://huggingface.co/docs/hub/spaces-zerogpu)

--- a/docs/hub/advanced-compute-options.md
+++ b/docs/hub/advanced-compute-options.md
@@ -7,7 +7,7 @@ Team & Enterprise organizations gain access to advanced compute options to accel
 
 ## Host ZeroGPU Spaces in your organization
 
-ZeroGPU is a dynamic GPU allocation system that optimizes AI deployment on Hugging Face Spaces. By automatically allocating and releasing NVIDIA RTX Pro 6000 Blackwell GPU slices (96GB VRAM) as needed, organizations can efficiently serve their AI applications without dedicated GPU instances.
+ZeroGPU is a dynamic GPU allocation system that optimizes AI deployment on Hugging Face Spaces. By automatically allocating and releasing NVIDIA RTX Pro 6000 Blackwell GPUs (96GB VRAM) as needed, organizations can efficiently serve their AI applications without dedicated GPU instances.
 
 <div class="flex justify-center" style="max-width: 550px">
   <img

--- a/docs/hub/enterprise.md
+++ b/docs/hub/enterprise.md
@@ -46,7 +46,7 @@ Team & Enterprise organization plans add advanced capabilities to organizations,
 | Feature                                | Free      | Team        | Enterprise  | Enterprise Plus |
 | -------------------------------------- | --------- | ----------- | ----------- | --------------- |
 | Spaces – CPU-based runtime             | 8 units\* | ✅ No limit | ✅ No limit | ✅ No limit     |
-| Spaces – ZeroGPU usage tiers           | 3.5 min†  | 25 min†     | 45 min†     | 45 min†         |
+| Spaces – ZeroGPU usage tiers           | 5 min†    | 40 min†     | 60 min†     | 60 min†         |
 | Spaces – Upgraded hardware             | PAYG      | PAYG        | PAYG        | PAYG            |
 | Dev Mode / Custom domain for Spaces    | ❌        | ✅          | ✅          | ✅              |
 | Jobs & Scripts (train/fine-tune, eval) | PAYG      | PAYG        | PAYG        | PAYG            |

--- a/docs/hub/index.md
+++ b/docs/hub/index.md
@@ -184,7 +184,7 @@ The [🤗 `datasets`](https://huggingface.co/docs/datasets/index) library allows
 
 We currently support two awesome Python SDKs (**[Gradio](https://gradio.app/)** and **[Streamlit](./spaces-sdks-streamlit)**) that let you build cool apps in a matter of minutes. Users can also create static Spaces, which are simple HTML/CSS/JavaScript pages, or deploy any Docker-based application.
 
-If you need GPU power for your demos, try [**ZeroGPU**](./spaces-zerogpu): it dynamically provides NVIDIA H200 GPUs, in real-time, only when needed.
+If you need GPU power for your demos, try [**ZeroGPU**](./spaces-zerogpu): it dynamically provides NVIDIA RTX Pro 6000 Blackwell GPUs, in real-time, only when needed.
 
 After you've explored a few Spaces (take a look at our [Space of the Week!](https://huggingface.co/spaces)), dive into the [**Spaces documentation**](./spaces-overview) to learn all about how you can create your own Space. You'll also be able to upgrade your Space to run on a GPU or other accelerated hardware. ⚡️
 

--- a/docs/hub/spaces-api-endpoints.md
+++ b/docs/hub/spaces-api-endpoints.md
@@ -228,15 +228,15 @@ ZeroGPU Spaces have usage quotas based on your account type:
 | Account Type | Included Daily GPU Quota |
 |-------------|--------------------------|
 | Unauthenticated | 2 minutes |
-| Free account | 3.5 minutes |
-| PRO account | 25 minutes |
+| Free account | 5 minutes |
+| PRO account | 40 minutes |
 
 When you authenticate with your token, your account's GPU quota is consumed. Unauthenticated requests use a shared pool with stricter limits.
 
 PRO, Team, and Enterprise users can go beyond their included daily quota using pre-paid credits at the rate of **$1 per 10 minutes** of GPU time.
 
 > [!TIP]
-> You can [subscribe to PRO](https://huggingface.co/subscribe/pro) for 25 minutes of daily GPU quota, higher queue priority, and the ability to extend your quota with credits.
+> You can [subscribe to PRO](https://huggingface.co/subscribe/pro) for 40 minutes of daily GPU quota, higher queue priority, and the ability to extend your quota with credits.
 
 ## Common patterns
 

--- a/docs/hub/spaces-mcp-servers.md
+++ b/docs/hub/spaces-mcp-servers.md
@@ -28,7 +28,7 @@ From your [Hub MCP settings](https://huggingface.co/settings/mcp), select your M
 If your MCP client is configured correctly, the Spaces you added will be available instantly without changing anything (if it doesn't restart your client and it should appear). Most MCP clients will list what tools are currently loaded so you can make sure the Space is available.
 
 > [!TIP]
-> For ZeroGPU Spaces, your quota will be used when the tool is called, if you run out of quota you can <a href="https://huggingface.co/subscribe/pro?from=ZeroGPU" target="_blank">subscribe to PRO</a> to get 25 minutes of daily quota (x8 more quota than free users). For example your PRO account lets you generate up to 600 images per day using FLUX.1-schnell.
+> For ZeroGPU Spaces, your quota will be used when the tool is called, if you run out of quota you can <a href="https://huggingface.co/subscribe/pro?from=ZeroGPU" target="_blank">subscribe to PRO</a> to get 40 minutes of daily quota (x8 more quota than free users). For example your PRO account lets you generate up to 600 images per day using FLUX.1-schnell.
 
 ## Build your own MCP-compatible Gradio Space
 

--- a/docs/hub/spaces-zerogpu.md
+++ b/docs/hub/spaces-zerogpu.md
@@ -2,7 +2,7 @@
 
 <img src="https://cdn-uploads.huggingface.co/production/uploads/5f17f0a0925b9863e28ad517/naVZI-v41zNxmGlhEhGDJ.gif" style="max-width: 440px; width: 100%" alt="ZeroGPU schema" />
 
-ZeroGPU is a shared infrastructure that optimizes GPU usage for AI models and demos on Hugging Face Spaces. It dynamically allocates and releases NVIDIA H200 GPUs as needed, offering:
+ZeroGPU is a shared infrastructure that optimizes GPU usage for AI models and demos on Hugging Face Spaces. It dynamically allocates and releases NVIDIA RTX Pro 6000 Blackwell GPUs as needed, offering:
 
 1. **Free GPU Access**: Enables cost-effective GPU usage for Spaces.
 2. **Multi-GPU Support**: Allows Spaces to leverage multiple GPUs concurrently on a single application.
@@ -22,10 +22,10 @@ Unlike traditional single-GPU allocations, ZeroGPU's efficient system lowers bar
 
 ZeroGPU supports two GPU sizes
 
-| GPU size            | Backing hardware | Vram                     | Quota cost |
-|---------------------|------------------|--------------------------|------------|
-| `large` *(default)* | Half NVIDIA H200 | 70GB                     | 1×         |
-| `xlarge`            | Full NVIDIA H200 | 141GB                    | 2×         |
+| GPU size            | Backing hardware                   | Vram | Quota cost |
+|---------------------|------------------------------------|------|------------|
+| `large` *(default)* | Half NVIDIA RTX Pro 6000 Blackwell | 48GB | 1×         |
+| `xlarge`            | Full NVIDIA RTX Pro 6000 Blackwell | 96GB | 2×         |
 
 > [!NOTE]
 > See [GPU size selection](#gpu-size-selection) to learn how to use sizes
@@ -41,21 +41,14 @@ ZeroGPU Spaces are designed to be compatible with most PyTorch-based GPU Spaces.
 ### Supported Versions
 
 - **Gradio**: 4+
-- **PyTorch**: Almost all versions from **2.1.0** to **latest** are supported  
+- **PyTorch**: Almost all versions from **2.8.0** to **latest** are supported
   <details>
     <summary>See full list</summary>
 
-    - 2.1.0  
-    - 2.1.1  
-    - 2.1.2  
-    - 2.2.0  
-    - 2.2.2  
-    - 2.4.0  
-    - 2.5.1  
-    - 2.6.0  
-    - 2.7.1  
     - 2.8.0  
     - 2.9.1  
+    - 2.10.0  
+    - 2.11.0  
 
   </details>
 - **Python**:
@@ -106,9 +99,9 @@ Lazy-loading or moving models to CUDA inside `@spaces.GPU` is discouraged, as it
 
 ## GPU size selection
 
-The default size used by `@spaces.GPU` is `large` (half H200).
+The default size used by `@spaces.GPU` is `large` (half NVIDIA RTX Pro 6000 Blackwell).
 
-You can explicitly request a full H200 by specifying `size="xlarge"`:
+You can explicitly request a full NVIDIA RTX Pro 6000 Blackwell by specifying `size="xlarge"`:
 
 ``` python
 @spaces.GPU(size="xlarge")
@@ -163,10 +156,10 @@ GPU usage is subject to **daily** quotas, per account tier:
 | Account type                   | Included daily GPU quota | Queue priority  |
 | ------------------------------ | ------------------------ | --------------- |
 | Unauthenticated                | 2 minutes                | Low             |
-| Free account                   | 3.5 minutes              | Medium          |
-| PRO account                    | 25 minutes (extensible)  | Highest         |
-| Team organization member       | 25 minutes (extensible)  | Highest         |
-| Enterprise organization member | 45 minutes (extensible)  | Highest         |
+| Free account                   | 5 minutes                | Medium          |
+| PRO account                    | 40 minutes (extensible)  | Highest         |
+| Team organization member       | 40 minutes (extensible)  | Highest         |
+| Enterprise organization member | 60 minutes (extensible)  | Highest         |
 
 Included daily quota resets exactly 24 hours after your first GPU usage.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates, but they change published hardware specs and quota numbers, so incorrect values could mislead users if not aligned with product reality.
> 
> **Overview**
> Updates ZeroGPU documentation to reflect a **hardware refresh from NVIDIA H200 to NVIDIA RTX Pro 6000 Blackwell**, including updated VRAM figures and `large`/`xlarge` sizing details.
> 
> Refreshes ZeroGPU quota/plan messaging across Hub docs (Free/PRO/Team/Enterprise daily minutes) and updates compatibility notes (PyTorch support now starting at `2.8.0` with newer versions listed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dae5d4f328df629c0f998555a062f834a09e8778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->