### PR TITLE
docs: note that buckets render README.md

### DIFF
--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -22,7 +22,7 @@ The Hub offers two types of storage: Git-based **repositories** for versioned, c
 | Operations         | Hub API, Git push/pull          | S3-like `sync`, `cp`, `rm`          |
 | Deduplication      | Xet chunk-level                 | Xet chunk-level                     |
 | Pull Requests      | Yes                             | No                                  |
-| Model/Dataset Cards| Yes                             | No                                  |
+| Model/Dataset Cards| Yes                             | No (plain README rendered)          |
 
 Use **repositories** when you want version history, collaboration features (PRs, discussions), and library integrations. Use **buckets** when you need fast, mutable storage for data that changes frequently — files can be overwritten or deleted in place.
 
@@ -93,6 +93,10 @@ Every bucket has a page on the Hub where you can browse its contents, navigate d
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/buckets/buckets-file-browser.png"/>
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/buckets/buckets-file-browser-dark.png"/>
 </div>
+
+### README rendering
+
+If a directory in your bucket contains a `README.md` file, the Hub renders it below the file list on that directory's page. This works both at the bucket root and inside any subdirectory — useful for documenting what a bucket contains, how data is organized, or how downstream tools should consume it.
 
 You can also list bucket contents from the CLI:
 

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -22,7 +22,7 @@ The Hub offers two types of storage: Git-based **repositories** for versioned, c
 | Operations         | Hub API, Git push/pull          | S3-like `sync`, `cp`, `rm`          |
 | Deduplication      | Xet chunk-level                 | Xet chunk-level                     |
 | Pull Requests      | Yes                             | No                                  |
-| Model/Dataset Cards| Yes                             | No (but plain README rendered)          |
+| Model/Dataset Cards| Yes                             | No (but plain README rendered)      |
 
 Use **repositories** when you want version history, collaboration features (PRs, discussions), and library integrations. Use **buckets** when you need fast, mutable storage for data that changes frequently — files can be overwritten or deleted in place.
 

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -98,6 +98,8 @@ Every bucket has a page on the Hub where you can browse its contents, navigate d
 
 If a directory in your bucket contains a `README.md` file, the Hub renders it below the file list on that directory's page. This works both at the bucket root and inside any subdirectory — useful for documenting what a bucket contains, how data is organized, or how downstream tools should consume it.
 
+### Listing from the CLI
+
 You can also list bucket contents from the CLI:
 
 ```bash

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -22,7 +22,7 @@ The Hub offers two types of storage: Git-based **repositories** for versioned, c
 | Operations         | Hub API, Git push/pull          | S3-like `sync`, `cp`, `rm`          |
 | Deduplication      | Xet chunk-level                 | Xet chunk-level                     |
 | Pull Requests      | Yes                             | No                                  |
-| Model/Dataset Cards| Yes                             | No (plain README rendered)          |
+| Model/Dataset Cards| Yes                             | No (but plain README rendered)          |
 
 Use **repositories** when you want version history, collaboration features (PRs, discussions), and library integrations. Use **buckets** when you need fast, mutable storage for data that changes frequently — files can be overwritten or deleted in place.
 


### PR DESCRIPTION
## Summary
- Documents that buckets now render `README.md` on the Hub (both root and subdirectories).
- Updates the comparison table row for Model/Dataset Cards to clarify that buckets render a plain README.

Verified against a test bucket at `davanstrien/readme-render-test`.

## Test plan
- [x] Preview renders correctly in docs build
- [x] No broken links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates clarifying bucket UI behavior; no product code, APIs, or data handling are changed.
> 
> **Overview**
> Documents that Hub **storage buckets render `README.md`** beneath the file listing for both the bucket root and any subdirectory.
> 
> Updates the buckets-vs-repos comparison table to clarify that while buckets don’t support Model/Dataset Cards, they *do* render a plain `README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bef1eee49646153cfae3a6206aa8812ddf95e863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->