### PR TITLE
Reword Jobs availability tip to mention positive credit balance

### DIFF
--- a/docs/hub/jobs-pricing.md
+++ b/docs/hub/jobs-pricing.md
@@ -3,7 +3,7 @@
 Hugging Face Jobs let you run compute tasks on Hugging Face infrastructure without managing it yourself. Simply define a command, a Docker image, and a hardware flavor among various CPU and GPU options.
 
 > [!TIP]
-> Jobs are available to all users and organizations with [pre-paid credits](https://huggingface.co/settings/billing).
+> Jobs are available to any user or organization with a positive [credit balance](https://huggingface.co/settings/billing).
 
 Billing on Jobs is based on hardware usage and is computed by the minute: you get charged for every minute the Jobs runs on the requested hardware.
 


### PR DESCRIPTION
## Summary
- Follow-up to #2429 addressing @julien-c's review comment.
- Rewords the Jobs availability tip in `docs/hub/jobs-pricing.md` to: "Jobs are available to any user or organization with a positive [credit balance](https://huggingface.co/settings/billing)."

## Test plan
- [ ] Docs preview renders the updated TIP correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change clarifying Jobs availability criteria; no runtime or API behavior is affected.
> 
> **Overview**
> Updates `docs/hub/jobs-pricing.md` to reword the Jobs availability *TIP* from requiring “pre-paid credits” to requiring a **positive credit balance**, clarifying eligibility without changing any product behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 332d6af425203bad7b13ae85be000684f60f14d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->