### PR TITLE
Add Blog Articles docs and updates

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -552,6 +552,8 @@
     title: Paper Pages
   - local: academia-hub
     title: Academia Hub
+  - local: blog-articles
+    title: Blog Articles
   - local: search
     title: Search
   - local: doi

--- a/docs/hub/blog-articles.md
+++ b/docs/hub/blog-articles.md
@@ -8,8 +8,6 @@ To publish under **your personal namespace**, you need a confirmed email and mus
 
 - You have an active [PRO](./pro) subscription.
 - You are a member of a [Team or Enterprise](https://huggingface.co/enterprise) organization (with `write` or `admin` role in that organization).
-- You have at least 100 followers on your Hugging Face profile.
-- You are a member of the [`blog-explorers`](https://huggingface.co/blog-explorers) community organization.
 
 Managed users (users provisioned through Enterprise SSO) cannot publish under their personal namespace.
 

--- a/docs/hub/blog-articles.md
+++ b/docs/hub/blog-articles.md
@@ -9,7 +9,7 @@ To publish under **your personal namespace**, you need a confirmed email and mus
 - You have an active [PRO](./pro) subscription.
 - You are a member of a [Team or Enterprise](https://huggingface.co/enterprise) organization (with `write` or `admin` role in that organization).
 
-Managed users (users provisioned through Enterprise SSO) cannot publish under their personal namespace.
+Managed users (users provisioned through Enterprise IdP) cannot publish under their personal namespace.
 
 To publish under an **organization namespace**, both must hold:
 

--- a/docs/hub/blog-articles.md
+++ b/docs/hub/blog-articles.md
@@ -14,7 +14,7 @@ Managed users (users provisioned through Enterprise SSO) cannot publish under th
 To publish under an **organization namespace**, both must hold:
 
 - The organization is on the [Team or Enterprise](https://huggingface.co/enterprise) plan.
-- You have the `write` or `admin` role in that organization (or a custom role with the `WriteBlog` permission). See [Access Control in Organizations](./organizations-security) for more on roles.
+- You have the `write` or `admin` role in that organization. See [Access Control in Organizations](./organizations-security) for more on roles.
 
 See [Blog Articles for Organizations](./enterprise-blog-articles) for organization-specific details.
 
@@ -30,7 +30,7 @@ When creating the article, pick the namespace it should be published under from 
 ## Editing an Article
 
 - Articles published under a user namespace can be edited by the original author and any coauthors listed on the article.
-- Articles published under an organization namespace can be edited by any organization member with `write` or `admin` role (or a custom role with `WriteBlog`).
+- Articles published under an organization namespace can be edited by any organization member with `write` or `admin` role.
 
 ## Linking to Models and Datasets
 

--- a/docs/hub/blog-articles.md
+++ b/docs/hub/blog-articles.md
@@ -1,0 +1,43 @@
+# Blog Articles
+
+Blog Articles let you publish long-form content directly on the Hub — model releases, research updates, tutorials, and announcements — and share them with the broader community. Articles can be published under your personal namespace or under an [organization](./organizations) you belong to.
+
+## Who Can Publish Blog Articles
+
+To publish under **your personal namespace**, you need a confirmed email and must satisfy at least one of the following:
+
+- You have an active [PRO](./pro) subscription.
+- You are a member of a [Team or Enterprise](https://huggingface.co/enterprise) organization (with `write` or `admin` role in that organization).
+- You have at least 100 followers on your Hugging Face profile.
+- You are a member of the [`blog-explorers`](https://huggingface.co/blog-explorers) community organization.
+
+Managed users (users provisioned through Enterprise SSO) cannot publish under their personal namespace.
+
+To publish under an **organization namespace**, both must hold:
+
+- The organization is on the [Team or Enterprise](https://huggingface.co/enterprise) plan.
+- You have the `write` or `admin` role in that organization (or a custom role with the `WriteBlog` permission). See [Access Control in Organizations](./organizations-security) for more on roles.
+
+See [Blog Articles for Organizations](./enterprise-blog-articles) for organization-specific details.
+
+## Creating a Blog Article
+
+Go to [huggingface.co/new-blog](https://huggingface.co/new-blog) to start a new article. You can write in Markdown, embed media, and reference models, datasets, and Spaces hosted on the Hub.
+
+When creating the article, pick the namespace it should be published under from the dropdown:
+
+- **Your username** — the article appears on your user profile.
+- **An organization** — the article appears on that organization's profile page.
+
+## Editing an Article
+
+- Articles published under a user namespace can be edited by the original author and any coauthors listed on the article.
+- Articles published under an organization namespace can be edited by any organization member with `write` or `admin` role (or a custom role with `WriteBlog`).
+
+## Linking to Models and Datasets
+
+When a blog article mentions a model or dataset, and the article's author (user or organization) is the same as the repo's owner, the article will automatically appear in the sidebar of that model or dataset page under **"Article(s) mentioning [repo-id]"**. Up to three of the most recent matching articles are shown.
+
+This makes it easy for visitors to discover related write-ups, release announcements, and research notes alongside the repository itself.
+
+If the article references a [Collection](./collections), every model and dataset in that collection is treated as linked — the article will surface on each member repo's page (subject to the same ownership rule).

--- a/docs/hub/blog-articles.md
+++ b/docs/hub/blog-articles.md
@@ -27,6 +27,11 @@ When creating the article, pick the namespace it should be published under from 
 - **Your username** — the article appears on your user profile.
 - **An organization** — the article appears on that organization's profile page.
 
+<div class="flex justify-center">
+<img class="block dark:hidden" width="550" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/blog-creation-editor.png"/>
+<img class="hidden dark:block" width="550" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/blog-creation-editor-dark.png"/>
+</div>
+
 ## Editing an Article
 
 - Articles published under a user namespace can be edited by the original author and any coauthors listed on the article.
@@ -35,6 +40,11 @@ When creating the article, pick the namespace it should be published under from 
 ## Linking to Models and Datasets
 
 When a blog article mentions a model or dataset, and the article's author (user or organization) is the same as the repo's owner, the article will automatically appear in the sidebar of that model or dataset page under **"Article(s) mentioning [repo-id]"**. Up to three of the most recent matching articles are shown.
+
+<div class="flex justify-center">
+<img class="block dark:hidden" width="350" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/blog-articles-mentioning-sidebar.png"/>
+<img class="hidden dark:block" width="350" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/blog-articles-mentioning-sidebar-dark.png"/>
+</div>
 
 This makes it easy for visitors to discover related write-ups, release announcements, and research notes alongside the repository itself.
 

--- a/docs/hub/enterprise-blog-articles.md
+++ b/docs/hub/enterprise-blog-articles.md
@@ -18,8 +18,6 @@ To publish blog articles under an organization namespace, members need `write` o
 
 ## Linking to Models and Datasets
 
-When a blog article mentions a model or dataset owned by the same organization, the article will automatically appear in the sidebar of that model or dataset page under **"Article(s) mentioning [repo-id]"**. Up to three of the most recent matching articles are shown, making it easy for visitors to discover your organization's related content directly from the repository page.
-
-This also works for any models or datasets that belong to a [Collection](./collections) mentioned in the article — each member repo of a linked collection will surface the article on its page.
+Articles mentioning a model or dataset owned by the same organization will automatically surface on that repo's page. See [Linking to Models and Datasets](./blog-articles#linking-to-models-and-datasets) for details.
 
 See [Blog Articles](./blog-articles) for general information about authoring blog articles on the Hub.

--- a/docs/hub/enterprise-blog-articles.md
+++ b/docs/hub/enterprise-blog-articles.md
@@ -15,3 +15,11 @@ To publish blog articles under an organization namespace, members need `write` o
 
 > [!NOTE]
 > Blog article permissions are currently tied to organization-level roles and cannot be scoped using [Resource Groups](./security-resource-groups). Resource Groups only control access to repositories (models, datasets, and Spaces), not blog articles.
+
+## Linking to Models and Datasets
+
+When a blog article mentions a model or dataset owned by the same organization, the article will automatically appear in the sidebar of that model or dataset page under **"Article(s) mentioning [repo-id]"**. Up to three of the most recent matching articles are shown, making it easy for visitors to discover your organization's related content directly from the repository page.
+
+This also works for any models or datasets that belong to a [Collection](./collections) mentioned in the article — each member repo of a linked collection will surface the article on its page.
+
+See [Blog Articles](./blog-articles) for general information about authoring blog articles on the Hub.

--- a/docs/hub/index.md
+++ b/docs/hub/index.md
@@ -133,6 +133,8 @@ The Hugging Face Hub is the reference AI platform for open ML. It hosts over 2M 
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./security">Security</a>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./moderation">Moderation</a>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./paper-pages">Paper Pages</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./academia-hub">Academia Hub</a>
+<a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./blog-articles">Blog Articles</a>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./search">Search</a>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./doi">Digital Object Identifier (DOI)</a>
 <a class="no-underline! transform transition-colors hover:translate-x-px text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" href="./api">Hub API Endpoints</a>

--- a/docs/hub/models-faq.md
+++ b/docs/hub/models-faq.md
@@ -24,9 +24,7 @@ Spaces are a great way to show off a model you've made or explore new ways to us
 
 ## Are community blog articles linked to models?
 
-If you publish a [blog article](./blog-articles) that mentions a model and you are the same user or organization as the model's owner, the article will automatically appear in the model page sidebar under **"Article(s) mentioning [model-id]"**. Up to three of the most recent matching articles are shown.
-
-This makes it easy for visitors to discover related write-ups, release announcements, and research notes alongside the model itself. The same behavior applies to dataset pages.
+Yes — if you publish a [blog article](./blog-articles) that mentions a model you own (as a user or organization), it will automatically appear in the model page sidebar. The same applies to dataset pages. See [Linking to Models and Datasets](./blog-articles#linking-to-models-and-datasets) for details.
 
 ## How do I upload an update / new version of the model?
 

--- a/docs/hub/models-faq.md
+++ b/docs/hub/models-faq.md
@@ -22,6 +22,12 @@ The Hugging Face Hub is also home to Spaces, which are interactive demos used to
 
 Spaces are a great way to show off a model you've made or explore new ways to use existing models! Visit the [Spaces documentation](./spaces) to learn how to make your own.
 
+## Are community blog articles linked to models?
+
+If you publish a [blog article](./blog-articles) that mentions a model and you are the same user or organization as the model's owner, the article will automatically appear in the model page sidebar under **"Article(s) mentioning [model-id]"**. Up to three of the most recent matching articles are shown.
+
+This makes it easy for visitors to discover related write-ups, release announcements, and research notes alongside the model itself. The same behavior applies to dataset pages.
+
 ## How do I upload an update / new version of the model?
 
 Releasing an update to a model that you've already published can be done by pushing a new commit to your model's repo. To do this, go through the same process that you followed to upload your initial model. Your previous model versions will remain in the repository's commit history, so you can still download previous model versions from a specific git commit or tag or revert to previous versions if needed.


### PR DESCRIPTION
Adds a new Blog Articles docs page covering publishing eligibility, creation, editing, and the auto-link to model/dataset pages. Updates the enterprise blog articles page, the models FAQ, the toctree, and the index landing page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds new content and navigation links without affecting runtime code paths.
> 
> **Overview**
> Adds a new `Blog Articles` documentation page describing publishing eligibility, authoring/editing rules, and how articles automatically surface on owned model/dataset pages (including collection-based linking).
> 
> Updates navigation and cross-references by linking the new page from the Hub toctree and index, extends `enterprise-blog-articles` with the repo-linking behavior, and adds a related Q&A entry to `models-faq`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a43876b7a579d9031a64b163da37538f23ca0346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->