### PR TITLE
docs(spaces-dev-mode): surface SSH command, lead with SSH over VS Code

### DIFF
--- a/docs/hub/spaces-dev-mode.md
+++ b/docs/hub/spaces-dev-mode.md
@@ -1,9 +1,6 @@
 # Spaces Dev Mode: Seamless development in Spaces
 
 > [!WARNING]
-> This feature is still in Beta stage.
-
-> [!WARNING]
 > The Spaces Dev Mode is part of <a href="https://huggingface.co/pro">PRO</a> or <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 
 ## Spaces Dev Mode

--- a/docs/hub/spaces-dev-mode.md
+++ b/docs/hub/spaces-dev-mode.md
@@ -11,7 +11,7 @@ Whenever your commit some changes to your Space repo, the underlying Docker imag
 
 The Dev Mode allows you to update your Space much quicker by overriding the Docker image.
 
-The Dev Mode Docker image starts your application as a sub-process, allowing you to restart it without stopping the Space container itself. It also starts an SSH server (and a VS Code server on top of it) in the background, so you can connect to the Space from any editor or terminal.
+The Dev Mode Docker image starts your application as a sub-process, allowing you to restart it without stopping the Space container itself. It also starts an SSH server (for local editors and terminals) and a VS Code server (for the in-product VS Code Web) in the background, so you can connect to the Space.
 
 The ability to connect to the running Space unlocks several use cases:
 

--- a/docs/hub/spaces-dev-mode.md
+++ b/docs/hub/spaces-dev-mode.md
@@ -14,7 +14,7 @@ Whenever your commit some changes to your Space repo, the underlying Docker imag
 
 The Dev Mode allows you to update your Space much quicker by overriding the Docker image.
 
-The Dev Mode Docker image starts your application as a sub-process, allowing you to restart it without stopping the Space container itself. It also starts a VS Code server and a SSH server in the background for you to connect to the Space.
+The Dev Mode Docker image starts your application as a sub-process, allowing you to restart it without stopping the Space container itself. It also starts an SSH server (and a VS Code server on top of it) in the background, so you can connect to the Space from any editor or terminal.
 
 The ability to connect to the running Space unlocks several use cases:
 
@@ -39,16 +39,31 @@ The application does not restart automatically when you change the code. For you
   You will need to manually run `pip install` from VS Code or SSH.
 </div>
 
-### SSH connection and VS Code
+### Connecting
 
-The Dev Mode allows you to connect to your Space's docker container using SSH.
+Dev Mode exposes the running Space as a standard SSH host. VS Code and any other editor connect through that same SSH endpoint.
 
-Instructions to connect are listed in the Dev Mode controls modal.
+#### SSH
+
+Once Dev Mode is running, connect with:
+
+```shell
+ssh <space-subdomain>@ssh.hf.space
+```
+
+The subdomain is shown in the Dev Mode controls modal. You can also retrieve it programmatically:
+
+```python
+from huggingface_hub import HfApi
+print(HfApi().space_info("namespace/repo").subdomain)
+```
 
 You will need to add your machine's SSH public key to [your user account](https://huggingface.co/settings/keys) to be able to connect to the Space using SSH.
 Check out the [Git over SSH](./security-git-ssh#add-a-ssh-key-to-your-account) documentation for more detailed instructions.
 
-You can also use a local install of VS Code to connect to the Space container. To do so, you will need to install the [SSH Remote](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) extension.
+#### VS Code
+
+You can also use a local install of VS Code to connect to the Space container. To do so, install the [Remote - SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) extension and connect to the same `<space-subdomain>@ssh.hf.space` host.
 
 ### Persisting changes
 


### PR DESCRIPTION
## Summary
- Lead with SSH: Dev Mode runs an SSH server, VS Code sits on top.
- Show the `ssh <subdomain>@ssh.hf.space` command and a snippet to derive the subdomain, instead of pointing at the UI modal.

## Why
Today the SSH command lives only in the UI modal — invisible to agents and scripts reading the doc. A Codex agent recently spent ~15 min working around a VS Code marketplace 429 because the page made Dev Mode look VS-Code-shaped; once told "just SSH" it connected immediately.

Docs only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only changes that clarify how to connect via SSH/VS Code; no product code or behavior is modified.
> 
> **Overview**
> Updates the Spaces Dev Mode docs to **lead with SSH as the primary connection mechanism**, clarifying that VS Code/editor access is layered on top of the same SSH endpoint.
> 
> Adds an explicit `ssh <space-subdomain>@ssh.hf.space` command plus a small `huggingface_hub` snippet to fetch the Space subdomain programmatically, and rewords the intro to distinguish the SSH server (local editors/terminals) from the in-product VS Code Web server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e4daf6463491b71ece03bf5f268007c994d470d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->