### PR TITLE
Remove fixed width on blog articles screenshots

### DIFF
--- a/docs/hub/blog-articles.md
+++ b/docs/hub/blog-articles.md
@@ -28,8 +28,8 @@ When creating the article, pick the namespace it should be published under from 
 - **An organization** — the article appears on that organization's profile page.
 
 <div class="flex justify-center">
-<img class="block dark:hidden" width="550" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/blog-creation-editor.png"/>
-<img class="hidden dark:block" width="550" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/blog-creation-editor-dark.png"/>
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/blog-creation-editor.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/blog-creation-editor-dark.png"/>
 </div>
 
 ## Editing an Article
@@ -42,8 +42,8 @@ When creating the article, pick the namespace it should be published under from 
 When a blog article mentions a model or dataset, and the article's author (user or organization) is the same as the repo's owner, the article will automatically appear in the sidebar of that model or dataset page under **"Article(s) mentioning [repo-id]"**. Up to three of the most recent matching articles are shown.
 
 <div class="flex justify-center">
-<img class="block dark:hidden" width="350" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/blog-articles-mentioning-sidebar.png"/>
-<img class="hidden dark:block" width="350" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/blog-articles-mentioning-sidebar-dark.png"/>
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/blog-articles-mentioning-sidebar.png"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/blog-articles-mentioning-sidebar-dark.png"/>
 </div>
 
 This makes it easy for visitors to discover related write-ups, release announcements, and research notes alongside the repository itself.


### PR DESCRIPTION
Drops the hardcoded `width` on the screenshot `<img>` tags in `blog-articles.md` so they render at their natural size.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it only affects how screenshots are rendered in the docs and could slightly alter layout/responsiveness.
> 
> **Overview**
> Removes hardcoded `width` attributes from the light/dark screenshot images in `docs/hub/blog-articles.md` so they render at their natural size and respond to CSS/layout styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca4242bcbf8b332f704fd0ed39aaea04bb9da236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->