### PR TITLE
Document org-member gating option for gated repos

### DIFF
--- a/docs/hub/datasets-gated.md
+++ b/docs/hub/datasets-gated.md
@@ -126,6 +126,18 @@ extra_gated_button_content: "Acknowledge license"
 ---
 ```
 
+### Gate access for organization members
+
+For gated datasets hosted under an organization, you can also require the organization's **own members** to submit an access request. On the dataset settings page, under the gating options, enable **Also gate access for members of `{org}`**.
+
+When this option is enabled, organization members must request access to the dataset like any other user. The following roles bypass the request and keep direct access:
+
+- Organization admins
+- The user who created the repo
+- [Resource Group](./security-resource-groups) admins, when the dataset belongs to a Resource Group
+
+All other members — including regular `read`, `contributor`, and `write` org roles, as well as Resource Group members without the `admin` role — must go through the access request flow.
+
 ## Manage gated datasets as an organization (Team & Enterprise)
 
 [Team & Enterprise](https://huggingface.co/docs/hub/en/enterprise) subscribers can create a Gating Group Collection to grant (or reject) access to all the models and datasets in a collection at once.

--- a/docs/hub/datasets-gated.md
+++ b/docs/hub/datasets-gated.md
@@ -136,7 +136,7 @@ When this option is enabled, organization members must request access to the dat
 - The user who created the repo
 - [Resource Group](./security-resource-groups) admins, when the dataset belongs to a Resource Group
 
-All other members — including regular `read`, `contributor`, and `write` org roles, as well as Resource Group members without the `admin` role — must go through the access request flow.
+All other members must go through the access request flow. This includes members with the read, contributor, or write org role, and Resource Group members without the admin role.
 
 ## Manage gated datasets as an organization (Team & Enterprise)
 

--- a/docs/hub/models-gated.md
+++ b/docs/hub/models-gated.md
@@ -140,6 +140,18 @@ Possible use cases of programmatic management include:
     - Here's an [example repo](https://huggingface.co/Trelis/openchat_3.5-function-calling-v3) from TrelisResearch that uses this use case.
    - [@RonanMcGovern](https://huggingface.co/RonanMcGovern) has posted a [video about the flow](https://www.youtube.com/watch?v=2OT2SI5auQU) and tips on how to implement it.
 
+### Gate access for organization members
+
+For gated models hosted under an organization, you can also require the organization's **own members** to submit an access request. On the model settings page, under the gating options, enable **Also gate access for members of `{org}`**.
+
+When this option is enabled, organization members must request access to the model like any other user. The following roles bypass the request and keep direct access:
+
+- Organization admins
+- The user who created the repo
+- [Resource Group](./security-resource-groups) admins, when the model belongs to a Resource Group
+
+All other members — including regular `read`, `contributor`, and `write` org roles, as well as Resource Group members without the `admin` role — must go through the access request flow.
+
 ## Manage gated models as an organization (Team & Enterprise)
 
 [Team & Enterprise](https://huggingface.co/docs/hub/en/enterprise) subscribers can create a Gating Group Collection to grant (or reject) access to all the models and datasets in a collection at once.

--- a/docs/hub/models-gated.md
+++ b/docs/hub/models-gated.md
@@ -150,7 +150,7 @@ When this option is enabled, organization members must request access to the mod
 - The user who created the repo
 - [Resource Group](./security-resource-groups) admins, when the model belongs to a Resource Group
 
-All other members — including regular `read`, `contributor`, and `write` org roles, as well as Resource Group members without the `admin` role — must go through the access request flow.
+All other members must go through the access request flow. This includes members with the read, contributor, or write org role, and Resource Group members without the admin role.
 
 ## Manage gated models as an organization (Team & Enterprise)
 


### PR DESCRIPTION
cc @alexpouliquen @Charlie-Boyer to review/approve

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change describing an existing gating option; no product logic or APIs are modified.
> 
> **Overview**
> Documents a new **organization-member gating** option for gated repos in both `datasets-gated.md` and `models-gated.md`.
> 
> Adds a short section explaining how to enable *Also gate access for members of `{org}`* and clarifies which roles (org admins, repo creator, and relevant Resource Group admins) bypass the access-request flow versus which members must request access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe6d19f0caab285437722af428ae177a3eaee8ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->