### PR TITLE
docs: update SSO role mapping (most privileged role wins on multi-match)

### DIFF
--- a/docs/hub/security-sso-user-management.md
+++ b/docs/hub/security-sso-user-management.md
@@ -39,7 +39,7 @@ This section allows you to define a mapping from your IdP's user profile data to
 > [!WARNING]
 > You must map at least one `admin` role in your configuration.
 
-If the attribute in the IdP response contains multiple values (e.g. a list of groups), the **first matching mapping** will be used to determine the user's role.
+If the attribute in the IdP response contains multiple values (e.g. a list of groups) that match several mappings, the user is assigned the **most privileged matching role**. The role hierarchy, from least to most privileged, is `read` < `contributor` < `write` < `admin`.
 
 If there is no match, the role is determined as follows:
 


### PR DESCRIPTION
## Problem

The SSO doc still says the **first matching mapping** wins when an IdP attribute matches several role mappings.

## Fix

Update the doc to reflect the new behavior introduced in huggingface-internal/moon-landing#18282: the **most privileged matching role** is assigned, with hierarchy `read` < `contributor` < `write` < `admin`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates described SSO role-mapping precedence; no runtime behavior or security logic is modified.
> 
> **Overview**
> Updates `security-sso-user-management.md` to reflect that when an IdP attribute contains multiple values matching multiple role mappings, the assigned org role is now the **most privileged match** (with explicit hierarchy `read` < `contributor` < `write` < `admin`) rather than the first match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac0a64dbb2ba8c82bddc22a435cf605c28b96d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->