### PR TITLE
Add granular download data section to download stats docs

### DIFF
--- a/docs/hub/datasets-download-stats.md
+++ b/docs/hub/datasets-download-stats.md
@@ -10,3 +10,14 @@ The Hub used to provide download stats only for the datasets loadable via the `d
 
 * The download count was the same regardless of whether the data is directly stored on the Hub repo or if the repository has a [script](/docs/datasets/dataset_script) to load the data from an external source.
 * If a user manually downloaded the data using tools like `wget` or the Hub's user interface (UI), those downloads were not included in the download count.
+
+## What if I need more granular download data for my datasets?
+
+If you need more granular download data, for instance to:
+- distinguish data files from metadata,
+- exclude downloads from CI/CD pipelines,
+- or deduplicate users (i.e. count unique downloaders),
+
+then [Publisher Analytics](https://huggingface.co/docs/hub/publisher-analytics), and in particular the [granular logs](https://huggingface.co/docs/hub/publisher-analytics#unique-downloaders-and-more-granular-logs) feature, can provide anonymized, request-level access logs for all the models and datasets published by your organization.
+
+These are provided as raw logs, since most organizations will want to apply their own custom rules.

--- a/docs/hub/datasets-download-stats.md
+++ b/docs/hub/datasets-download-stats.md
@@ -18,6 +18,6 @@ If you need more granular download data, for instance to:
 - exclude downloads from CI/CD pipelines,
 - or deduplicate users (i.e. count unique downloaders),
 
-then [Publisher Analytics](https://huggingface.co/docs/hub/publisher-analytics), and in particular the [granular logs](https://huggingface.co/docs/hub/publisher-analytics#unique-downloaders-and-more-granular-logs) feature, can provide anonymized, request-level access logs for all the models and datasets published by your organization.
+then [Publisher Analytics](./publisher-analytics), and in particular the [granular logs](./publisher-analytics#unique-downloaders-and-more-granular-logs) feature, can provide anonymized, request-level access logs for all the models and datasets published by your organization.
 
 These are provided as raw logs, since most organizations will want to apply their own custom rules.

--- a/docs/hub/models-download-stats.md
+++ b/docs/hub/models-download-stats.md
@@ -58,6 +58,6 @@ If you need more granular download data, for instance to:
 - exclude downloads from CI/CD pipelines,
 - or deduplicate users (i.e. count unique downloaders),
 
-then [Publisher Analytics](https://huggingface.co/docs/hub/publisher-analytics), and in particular the [granular logs](https://huggingface.co/docs/hub/publisher-analytics#unique-downloaders-and-more-granular-logs) feature, can provide anonymized, request-level access logs for all the models and datasets published by your organization.
+then [Publisher Analytics](./publisher-analytics), and in particular the [granular logs](./publisher-analytics#unique-downloaders-and-more-granular-logs) feature, can provide anonymized, request-level access logs for all the models and datasets published by your organization.
 
 These are provided as raw logs, since most organizations will want to apply their own custom rules.

--- a/docs/hub/models-download-stats.md
+++ b/docs/hub/models-download-stats.md
@@ -50,3 +50,15 @@ filter: [
 	]
 }
 ```
+
+## What if I need more granular download data on my models?
+
+If you need granular download data, for instance to:
+- differentiate config.json from model weights
+- exclude CI/CD
+- deduplicate users ie. count unique downloaders
+- etc,
+
+[Publisher Analytics]https://huggingface.co/docs/hub/publisher-analytics and in particular the "granular logs" (https://huggingface.co/docs/hub/publisher-analytics#unique-downloaders-and-more-granular-logs) feature can provide anonymized, request-level access logs for all of the models and datasets published by your organization.
+
+This is provided as raw logs given most organizations will want to apply their own custom rules.

--- a/docs/hub/models-download-stats.md
+++ b/docs/hub/models-download-stats.md
@@ -51,14 +51,13 @@ filter: [
 }
 ```
 
-## What if I need more granular download data on my models?
+## What if I need more granular download data for my models?
 
-If you need granular download data, for instance to:
-- differentiate config.json from model weights
-- exclude CI/CD
-- deduplicate users ie. count unique downloaders
-- etc,
+If you need more granular download data, for instance to:
+- distinguish `config.json` from model weights,
+- exclude downloads from CI/CD pipelines,
+- or deduplicate users (i.e. count unique downloaders),
 
-[Publisher Analytics]https://huggingface.co/docs/hub/publisher-analytics and in particular the "granular logs" (https://huggingface.co/docs/hub/publisher-analytics#unique-downloaders-and-more-granular-logs) feature can provide anonymized, request-level access logs for all of the models and datasets published by your organization.
+then [Publisher Analytics](https://huggingface.co/docs/hub/publisher-analytics), and in particular the [granular logs](https://huggingface.co/docs/hub/publisher-analytics#unique-downloaders-and-more-granular-logs) feature, can provide anonymized, request-level access logs for all the models and datasets published by your organization.
 
-This is provided as raw logs given most organizations will want to apply their own custom rules.
+These are provided as raw logs, since most organizations will want to apply their own custom rules.


### PR DESCRIPTION
## What

Adds a new "What if I need more granular download data?" section to both the models and datasets download stats docs, pointing users to [Publisher Analytics](./docs/hub/publisher-analytics) and its granular logs feature.

## Changes

- **`models-download-stats.md`**: new section on getting granular, request-level download data (distinguish `config.json` from weights, exclude CI/CD, deduplicate users).
- **`datasets-download-stats.md`**: equivalent section adapted for datasets.
- Links to Publisher Analytics are relative (`./publisher-analytics`), matching the in-repo doc style.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime or security impact.
> 
> **Overview**
> Adds a **“What if I need more granular download data?”** section to both `models-download-stats.md` and `datasets-download-stats.md`, so readers know how to go beyond default Hub download counters.
> 
> Each page lists typical needs (e.g. split file types, drop CI/CD traffic, unique downloaders) and points to **Publisher Analytics** and its **granular logs** anchor for anonymized, request-level logs across an org’s models and datasets. The models doc calls out `config.json` vs weights; the datasets doc calls out data vs metadata. Both note that logs are raw so orgs can apply their own rules. Links use relative `./publisher-analytics` paths consistent with neighboring hub docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 997d1bf43e75232612cd5982d09e3d42b1939fa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->