### PR TITLE
docs: link hf CLI Skill from model release checklist

### DIFF
--- a/docs/hub/model-release-checklist.md
+++ b/docs/hub/model-release-checklist.md
@@ -3,6 +3,9 @@
 The [Hugging Face Hub](https://huggingface.co/models) is the go-to platform for sharing machine learning models.
 A well-executed release can boost your model's visibility and impact. This section covers **essential** steps for a concise, informative, and user-friendly model release.
 
+> [!TIP]
+> Releasing with a coding agent? Install the [`hf` CLI Skill](./agents-cli) to let your agent handle the upload, model card, and metadata for you.
+
 ## ⏳ Preparing Your Model for Release
 
 ### Upload Model Weights


### PR DESCRIPTION
## Summary
- Add a tip at the top of the model release checklist linking to the [`hf` CLI Skill](./agents-cli) install guide, so users releasing a model with a coding agent can have it handle the upload, model card, and metadata.

## Test plan
- [ ] Verify the `./agents-cli` link resolves to the "Hugging Face CLI for AI Agents" page in the rendered docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with a relative link to an existing hub doc page; no product or runtime behavior changes.
> 
> **Overview**
> Adds a **TIP** callout at the top of the **Model(s) Release Checklist** pointing readers who release with a coding agent to install the [`hf` CLI Skill](./agents-cli) so the agent can handle upload, model card, and metadata.
> 
> No other checklist content or release steps are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18aad5e3f886749f81a5ce4355c0478d9941c855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->