### PR TITLE
[new] agentic rl env datasets

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -234,8 +234,8 @@
     title: Downloading Datasets
   - local: datasets-streaming
     title: Streaming Datasets
-  - local: datasets-rl-environments
-    title: RL Environment Datasets
+  - local: datasets-environments
+    title: Environment Datasets
   - local: datasets-libraries
     title: Integrated Libraries
     sections:

--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -234,6 +234,8 @@
     title: Downloading Datasets
   - local: datasets-streaming
     title: Streaming Datasets
+  - local: datasets-rl-environments
+    title: RL Environment Datasets
   - local: datasets-libraries
     title: Integrated Libraries
     sections:

--- a/docs/hub/datasets-environments.md
+++ b/docs/hub/datasets-environments.md
@@ -1,9 +1,9 @@
 # Environment Datasets
 
-Environment datasets are ordinary dataset repositories with an optional `environment.yaml` file at the repository root. When a dataset includes a valid `environment.yaml`, the Hub shows an Environment badge, adds framework/library chips for supported frameworks, generates usage snippets, and exposes the parsed declarations at:
+Environment datasets are dataset repositories that can be used to create environments for training and evaluation. When a dataset includes a valid `environment.yaml`, the Hub shows an Environment badge, adds framework/library chips for supported frameworks, generates usage snippets, and exposes the parsed declarations at:
 
 ```text
-/api/datasets/{repo_id}/rl-environments
+/api/datasets/{repo_id}/environments
 ```
 
 ## Add environment.yaml
@@ -11,7 +11,7 @@ Environment datasets are ordinary dataset repositories with an optional `environ
 Add `environment.yaml` to the root of the dataset repository:
 
 ```yaml
-spec_version: hf-rl-env-0.1
+spec_version: hf-env-0.1
 environments:
   - id: terminal-bench-2
     title: Terminal-Bench 2.0
@@ -27,7 +27,7 @@ environments:
 
 Required top-level fields:
 
-- `spec_version`: currently `hf-rl-env-0.1`.
+- `spec_version`: currently `hf-env-0.1`.
 - `environments`: a non-empty list of environment declarations.
 
 Required per-environment fields:
@@ -81,7 +81,7 @@ env = vf.Env(taskset=taskset, harness=vf.OpenCode())
 Use `openenv` for an OpenEnv runtime package, Space, or container image. For a Space-backed environment:
 
 ```yaml
-spec_version: hf-rl-env-0.1
+spec_version: hf-env-0.1
 environments:
   - id: coding-env
     frameworks:
@@ -105,4 +105,3 @@ openenv:
   mode: container
   image: registry/repo:tag
 ```
-

--- a/docs/hub/datasets-rl-environments.md
+++ b/docs/hub/datasets-rl-environments.md
@@ -1,0 +1,108 @@
+# Environment Datasets
+
+Environment datasets are ordinary dataset repositories with an optional `environment.yaml` file at the repository root. When a dataset includes a valid `environment.yaml`, the Hub shows an Environment badge, adds framework/library chips for supported frameworks, generates usage snippets, and exposes the parsed declarations at:
+
+```text
+/api/datasets/{repo_id}/rl-environments
+```
+
+## Add environment.yaml
+
+Add `environment.yaml` to the root of the dataset repository:
+
+```yaml
+spec_version: hf-rl-env-0.1
+environments:
+  - id: terminal-bench-2
+    title: Terminal-Bench 2.0
+    config_name: harbor_tasks
+    splits: [train, validation]
+    frameworks:
+      harbor:
+        min_version: ">=0.1.0"
+      verifiers:
+        min_version: ">=0.1.14"
+        adapter: verifiers.v1.packages.tasksets.HarborTaskset
+```
+
+Required top-level fields:
+
+- `spec_version`: currently `hf-rl-env-0.1`.
+- `environments`: a non-empty list of environment declarations.
+
+Required per-environment fields:
+
+- `id`: a stable identifier within the dataset repository.
+- `frameworks`: one or more supported framework declarations.
+
+Optional per-environment fields:
+
+- `title`: display name for the environment.
+- `config_name`: matching Dataset Viewer or `datasets.load_dataset` config.
+- `splits`: valid split names for the environment subset.
+- `dataset`: repo, config, split, path, or index locations.
+- `runtime`: isolation, resource, network, and secret expectations.
+- `reward`: scalar or object reward convention.
+
+## Supported Frameworks
+
+The v1 manifest supports `harbor`, `verifiers`, and `openenv`.
+
+### Harbor
+
+Use `harbor` for filesystem task bundles. A Harbor task directory contains `instruction.md` and `task.toml`, with optional runtime files such as `environment/Dockerfile`, `tests/test.sh`, and `solution/solve.sh`.
+
+The Hub can generate a command like:
+
+```shell
+harbor run \
+    --dataset hf://datasets/harborframework/terminal-bench-2.0/terminal-bench-2 \
+    --agent oracle
+```
+
+### Verifiers
+
+Use `verifiers` for Dataset Viewer-compatible row tables. Rows should contain either `prompt` chat messages or a `question` string. Optional fields include `answer`, `info`, `task_id`, `system_prompt`, `max_turns`, `sandbox`, `program`, and `toolsets`.
+
+```python
+import verifiers as vf
+
+taskset = vf.HarborTaskset(
+    config=vf.HarborTasksetConfig(
+        dataset="hf://datasets/harborframework/terminal-bench-2.0",
+        split="train",
+    )
+)
+env = vf.Env(taskset=taskset, harness=vf.OpenCode())
+```
+
+### OpenEnv
+
+Use `openenv` for an OpenEnv runtime package, Space, or container image. For a Space-backed environment:
+
+```yaml
+spec_version: hf-rl-env-0.1
+environments:
+  - id: coding-env
+    frameworks:
+      openenv:
+        manifest: openenv.yaml
+        mode: space
+        space_id: openenv/coding_env
+```
+
+```python
+from openenv import AutoEnv
+
+env = AutoEnv.from_env("openenv/coding_env", trust_remote_code=False)
+```
+
+For a container-backed environment, use `mode: container` and provide an `image`:
+
+```yaml
+openenv:
+  manifest: openenv.yaml
+  mode: container
+  image: registry/repo:tag
+```
+

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,25 @@
+spec_version: env-0.1
+environments:
+  - id: terminal-bench-2
+    title: Terminal-Bench 2.0
+    config_name: harbor_tasks
+    splits: [train, validation]
+    frameworks:
+      harbor:
+        min_version: ">=0.1.0"
+      verifiers:
+        min_version: ">=0.1.14"
+        adapter: verifiers.v1.packages.tasksets.HarborTaskset
+    runtime:
+      isolation: container
+      network: disabled
+    reward:
+      type: scalar
+
+  - id: coding-env
+    title: OpenEnv Coding Environment
+    frameworks:
+      openenv:
+        manifest: openenv.yaml
+        mode: space
+        space_id: openenv/coding_env

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,4 +1,4 @@
-spec_version: env-0.1
+spec_version: hf-env-0.1
 environments:
   - id: terminal-bench-2
     title: Terminal-Bench 2.0


### PR DESCRIPTION
This is a draft of RL Environments on the hub. Please could you review the proposed yaml spec and snippets. 

We're still waiting for PRs on Harbor and Moon to make this work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and an example manifest only; no application or API implementation changes in this diff.
> 
> **Overview**
> Introduces **Environment Datasets** on the Hub: dataset repos can ship a root **`environment.yaml`** (`spec_version: hf-env-0.1`) so the Hub can show an Environment badge, framework chips, usage snippets, and expose declarations via **`/api/datasets/{repo_id}/environments`**.
> 
> Adds **`docs/hub/datasets-environments.md`** documenting required/optional manifest fields and three frameworks—**Harbor** (task bundles), **Verifiers** (row-based tasksets), and **OpenEnv** (Space or container)—with example YAML and CLI/Python snippets. The Datasets section of **`docs/hub/_toctree.yml`** now links **Environment Datasets** after Streaming Datasets.
> 
> Includes a sample **`environment.yaml`** at the repo root (Terminal-Bench–style Harbor/Verifiers env plus an OpenEnv coding env) as a concrete spec example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e94c191abfe71c1e8391d9507a9a99bfa84b815. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->