### PR TITLE
Clarify Blog Articles content guidelines

### DIFF
--- a/docs/hub/blog-articles.md
+++ b/docs/hub/blog-articles.md
@@ -32,6 +32,13 @@ When creating the article, pick the namespace it should be published under from 
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/blog-creation-editor-dark.png"/>
 </div>
 
+## Content Guidelines
+
+Published articles should fall into one of two categories:
+
+- **Explore an AI science or engineering concept.** For example, [Uncensor any LLM with abliteration](https://huggingface.co/blog/mlabonne/abliteration) and [KV Caching Explained: Optimizing Transformer Inference Efficiency](https://huggingface.co/blog/not-lain/kv-caching).
+- **Announce the release of an open source artifact**, such as a model, dataset, or tool. For example, [Welcome NVIDIA Cosmos 3](https://huggingface.co/blog/nvidia/cosmos-3-for-physical-ai) and [OlmoEarth v1.1](https://huggingface.co/blog/allenai/olmoearth-v1-1).
+
 ## Editing an Article
 
 - Articles published under a user namespace can be edited by the original author and any coauthors listed on the article.


### PR DESCRIPTION
Adds a **Content Guidelines** section to the Blog Articles docs page describing the two categories a published article should fall into:

- **Explore an AI science or engineering concept** — e.g. [abliteration](https://huggingface.co/blog/mlabonne/abliteration), [KV caching](https://huggingface.co/blog/not-lain/kv-caching)
- **Announce the release of an open source artifact** (model, dataset, or tool) — e.g. [NVIDIA Cosmos 3](https://huggingface.co/blog/nvidia/cosmos-3-for-physical-ai), [OlmoEarth v1.1](https://huggingface.co/blog/allenai/olmoearth-v1-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or security impact.
> 
> **Overview**
> Adds a **Content Guidelines** section to `docs/hub/blog-articles.md`, placed after the creation flow and before **Editing an Article**. It states that published Hub blog posts should be either concept/engineering explorations or announcements of open-source models, datasets, or tools, with example links for each category.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68258af8d541e9597a98cc0e3a0e55d28d8ff48a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->