### PR TITLE
Point local hardware setup to the Hardware settings page

### DIFF
--- a/docs/hub/agents-local.md
+++ b/docs/hub/agents-local.md
@@ -8,7 +8,7 @@ You can run a coding agent entirely on your own hardware. Several open-source ag
 
 Set your local hardware so it can show you which models are compatible with your setup.
 
-Go to [huggingface.co/settings/local-apps](https://huggingface.co/settings/local-apps) and configure your local hardware profile. Select `llama.cpp` in the Local Apps section as this will be the engine you'll use.
+Go to [huggingface.co/settings/hardware](https://huggingface.co/settings/hardware) and configure your local hardware profile. Then select `llama.cpp` in your [Local Apps settings](https://huggingface.co/settings/local-apps), as this will be the engine you'll use.
 
 ### 2. Find a Compatible Model
 


### PR DESCRIPTION
## What

The local hardware profile now lives on its own **Settings > Hardware** page, separate from **Local Apps**. The "Set Your Local Hardware" step in the local agents guide still pointed to `/settings/local-apps`, where hardware can no longer be configured.

This updates `docs/hub/agents-local.md` to:
- Send users to [`/settings/hardware`](https://huggingface.co/settings/hardware) to configure their hardware profile.
- Keep [`/settings/local-apps`](https://huggingface.co/settings/local-apps) for selecting the `llama.cpp` engine.

## Note

The `/settings/hardware` page should be live in production before this is merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and wording change with no product or security impact.
> 
> **Overview**
> **Step 1** in the local agents guide now matches the split between **Hardware** and **Local Apps** settings: users configure their hardware profile at **`/settings/hardware`**, then choose **`llama.cpp`** under **`/settings/local-apps`**. The previous single link to Local Apps for both steps is removed so readers are not sent to the wrong page for hardware setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ce406acdb813d09d33a68348599fe230da575d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->