### PR TITLE
Add Hardware settings doc page

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -183,6 +183,8 @@
     title: Model Release Checklist
   - local: local-apps
     title: Local Apps
+  - local: hardware
+    title: Hardware
   - local: models-faq
     title: Frequently Asked Questions
     sections:

--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -181,10 +181,10 @@
     title: Models Download Stats
   - local: model-release-checklist
     title: Model Release Checklist
-  - local: local-apps
-    title: Local Apps
   - local: hardware
     title: Hardware
+  - local: local-apps
+    title: Local Apps
   - local: models-faq
     title: Frequently Asked Questions
     sections:

--- a/docs/hub/hardware.md
+++ b/docs/hub/hardware.md
@@ -1,0 +1,34 @@
+# Hardware
+
+Tell the Hub which compute hardware you own (GPUs, CPUs, or Apple Silicon) and it will help you find models that run on your setup, show your setup on your profile, and let you compare it with the rest of the community.
+
+Manage it any time from your [Hardware settings](https://huggingface.co/settings/hardware).
+
+## Add your hardware
+
+On your [Hardware settings](https://huggingface.co/settings/hardware) page, add each piece of hardware you own:
+
+1. Pick a **type**: GPU, CPU, or Apple Silicon.
+2. Choose the **provider** and **model** (for example, NVIDIA RTX 4090).
+3. Set the **memory** (VRAM, RAM, or unified memory) and the **number of units** you have.
+
+Add as many items as you like. If you own several, mark one as your **primary** hardware so it appears first on model pages.
+
+> [!TIP]
+> Your hardware is private by default. Use the **Publicly Visible** toggle to show it on your profile.
+
+## See which models fit your hardware
+
+On model pages that offer [GGUF](./gguf) or MLX files, a **Hardware compatibility** panel estimates whether each quantization will run on your saved hardware, so you can choose a size that fits before downloading. Pair it with [Local Apps](./local-apps) to go from "will it run?" to running it in a couple of clicks.
+
+## Share and compare
+
+Once your hardware is public:
+
+- A **TFLOPS** badge appears on your profile, summarizing your total compute power.
+- You can browse [what the community is running](https://huggingface.co/hardware) and see how your setup compares across GPUs, CPUs, and Apple Silicon.
+
+## Next steps
+
+- [Use AI Models Locally](./local-apps) — run models with your favorite local app.
+- [Local Agents with llama.cpp](./agents-local) — build a coding agent on your own hardware.

--- a/docs/hub/hardware.md
+++ b/docs/hub/hardware.md
@@ -4,6 +4,11 @@ Tell the Hub which compute hardware you own (GPUs, CPUs, or Apple Silicon) and i
 
 Manage it any time from your [Hardware settings](https://huggingface.co/settings/hardware).
 
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/hardware-settings-light.png" alt="Hardware settings page in light mode."/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/hardware-settings-dark.png" alt="Hardware settings page in dark mode."/>
+</div>
+
 ## Add your hardware
 
 On your [Hardware settings](https://huggingface.co/settings/hardware) page, add each piece of hardware you own:

--- a/docs/hub/hardware.md
+++ b/docs/hub/hardware.md
@@ -1,6 +1,6 @@
 # Hardware
 
-Tell the Hub which compute hardware you own (GPUs, CPUs, or Apple Silicon) and it will help you find models that run on your setup, show your setup on your profile, and let you compare it with the rest of the community.
+Tell the Hub which compute hardware you own (GPUs, CPUs, or Apple Silicon) and it will help you find models that run on your setup. It also appears on your public profile, so you can compare your setup with the community, and you can make it private any time.
 
 Manage it any time from your [Hardware settings](https://huggingface.co/settings/hardware).
 
@@ -15,17 +15,17 @@ On your [Hardware settings](https://huggingface.co/settings/hardware) page, add 
 Add as many items as you like. If you own several, mark one as your **primary** hardware so it appears first on model pages.
 
 > [!TIP]
-> Your hardware is private by default. Use the **Publicly Visible** toggle to show it on your profile.
+> Your hardware is public by default. Turn off the **Publicly Visible** toggle to keep it private.
 
 ## See which models fit your hardware
 
-On model pages that offer [GGUF](./gguf) or MLX files, a **Hardware compatibility** panel estimates whether each quantization will run on your saved hardware, so you can choose a size that fits before downloading. Pair it with [Local Apps](./local-apps) to go from "will it run?" to running it in a couple of clicks.
+On model pages that offer [GGUF](./gguf) or MLX files, a **Hardware compatibility** panel estimates whether each quantization will run on your saved hardware, so you can choose a size that fits before downloading. Pair it with [Local Apps](./local-apps) to get up and running in a couple of clicks.
 
 ## Share and compare
 
-Once your hardware is public:
+While your hardware is public:
 
-- A **TFLOPS** badge appears on your profile, summarizing your total compute power.
+- A **TFLOPS** badge appears on your profile, summarizing your estimated total compute power.
 - You can browse [what the community is running](https://huggingface.co/hardware) and see how your setup compares across GPUs, CPUs, and Apple Silicon.
 
 ## Next steps


### PR DESCRIPTION
## What

Adds a short documentation page for the dedicated **Hardware** settings page (`huggingface.co/settings/hardware`), which lets users register the compute hardware they own (GPUs, CPUs, Apple Silicon).

The page covers:
- **Adding hardware** (type, provider/model, memory, count, primary).
- **Model compatibility**: how saved hardware drives the "Hardware compatibility" estimate on GGUF/MLX model pages.
- **Share & compare**: the profile TFLOPS badge and the community hardware page at `huggingface.co/hardware`.

New file `docs/hub/hardware.md`, registered in `_toctree.yml` in the Models section next to **Local Apps**.

## Notes

- Text-only for now; screenshots can be added later.
- Verified locally with `doc-builder build` (page renders, internal links to `./gguf`, `./local-apps`, `./agents-local` resolve).
- The `/settings/hardware` page should be live in production before this is merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no application or security impact.
> 
> **Overview**
> Adds Hub documentation for **Hardware** settings (`huggingface.co/settings/hardware`): registering GPUs/CPUs/Apple Silicon, the **Hardware compatibility** panel on GGUF/MLX model pages, profile TFLOPS and the community hardware page, plus light/dark screenshots and links to **Local Apps** and **agents-local**.
> 
> Registers `docs/hub/hardware.md` in `_toctree.yml` under **Models**, immediately before **Local Apps**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e85ccf777bbaf930f52278279ea6290eb3f50266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->