### PR TITLE
docs: make server-side repo→bucket copy easier to find

### DIFF
--- a/docs/hub/datasets-ingesting.md
+++ b/docs/hub/datasets-ingesting.md
@@ -87,7 +87,7 @@ If you are ingesting raw data that need further curation before being published 
 If your data already lives in a dataset, model, or Space repository, you can copy it into a bucket **server-side** — no download or re-upload — with `hf buckets cp`:
 
 ```bash
-hf buckets cp hf://datasets/username/my-dataset/ hf://buckets/username/my-bucket/
+hf cp hf://datasets/username/my-dataset/ hf://buckets/username/my-bucket/
 ```
 
 Only the Xet content hashes are migrated, so even very large files copy instantly. See [Copying files between repos and buckets](./storage-buckets#copying-files-between-repos-and-buckets).

--- a/docs/hub/datasets-ingesting.md
+++ b/docs/hub/datasets-ingesting.md
@@ -84,6 +84,14 @@ See the list of [Libraries supported by the Datasets Hub](./datasets-libraries) 
 
 If you are ingesting raw data that need further curation before being published as AI-ready datasets or if you need an S3-like experience, consider ingesting them to [Hugging Face Storage Buckets](./storage-buckets).
 
+If your data already lives in a dataset, model, or Space repository, you can copy it into a bucket **server-side** — no download or re-upload — with `hf buckets cp`:
+
+```bash
+hf buckets cp hf://datasets/username/my-dataset/ hf://buckets/username/my-bucket/
+```
+
+Only the Xet content hashes are migrated, so even very large files copy instantly. See [Copying files between repos and buckets](./storage-buckets#copying-files-between-repos-and-buckets).
+
 ## Scheduled ingestion
 
 There are some limitations when updating the same file on the Hub thousands of times.

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -286,7 +286,7 @@ For more deletion options (pattern-based filtering, recursive removal, etc.), se
 You can copy [Xet](./xet/index)-tracked files from any repository (model, dataset, Space) or bucket into a destination bucket without re-uploading the data. The copy is server-side: only the Xet content hashes are migrated, so even very large files are copied instantly thanks to [chunk-level deduplication](./xet/deduplication).
 
 > [!NOTE]
-> Only Xet-tracked files are copied server-to-server. Small non-Xet files (e.g., config files and READMEs) are automatically downloaded and re-uploaded.
+> Only Xet-tracked files are copied server-to-server. Small non-Xet files (e.g., config files and READMEs) are automatically downloaded and re-uploaded. Server-side copy also requires the source and destination to be in the same storage region.
 
 **CLI:**
 ```bash

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -154,6 +154,8 @@ hf buckets list julien-c/my-training-bucket --tree -h -R
 
 You can upload and download files directly from the bucket page on the Hub, or use the CLI and Python API for programmatic access. Bucket files are referenced using `hf://buckets/` paths (e.g., `hf://buckets/username/my-bucket/path/to/file`). The `hf buckets cp` command handles individual file transfers while `hf buckets sync` is better suited for directories. All commands work in both directions — local-to-remote and remote-to-local.
 
+If your data already lives in a model, dataset, or Space repository (or another bucket), you can copy it in **server-side** with `hf buckets cp` — no download or re-upload required. See [Copying files between repos and buckets](#copying-files-between-repos-and-buckets).
+
 ### Uploading files
 
 For quick uploads, you can drag and drop files directly on the bucket page in your browser. For programmatic use, `hf buckets cp` copies individual files into a bucket. The source is a local path and the destination is an `hf://buckets/` path. You can also pipe data from stdin, which is handy for programmatically generated content.
@@ -281,7 +283,7 @@ For more deletion options (pattern-based filtering, recursive removal, etc.), se
 
 ### Copying files between repos and buckets
 
-You can copy [Xet](./xet/index)-tracked files from any repository (model, dataset, Space) or bucket into a destination bucket without re-uploading the data. The copy is server-side: only the Xet content hashes are migrated, so even very large files are copied instantly.
+You can copy [Xet](./xet/index)-tracked files from any repository (model, dataset, Space) or bucket into a destination bucket without re-uploading the data. The copy is server-side: only the Xet content hashes are migrated, so even very large files are copied instantly thanks to [chunk-level deduplication](./xet/deduplication).
 
 > [!NOTE]
 > Only Xet-tracked files are copied server-to-server. Small non-Xet files (e.g., config files and READMEs) are automatically downloaded and re-uploaded.

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -154,7 +154,7 @@ hf buckets list julien-c/my-training-bucket --tree -h -R
 
 You can upload and download files directly from the bucket page on the Hub, or use the CLI and Python API for programmatic access. Bucket files are referenced using `hf://buckets/` paths (e.g., `hf://buckets/username/my-bucket/path/to/file`). The `hf buckets cp` command handles individual file transfers while `hf buckets sync` is better suited for directories. All commands work in both directions — local-to-remote and remote-to-local.
 
-If your data already lives in a model, dataset, or Space repository (or another bucket), you can copy it in **server-side** with `hf buckets cp` — no download or re-upload required. See [Copying files between repos and buckets](#copying-files-between-repos-and-buckets).
+If your data already lives in a model, dataset, or Space repository (or another bucket), you can copy it **server-side** with `hf buckets cp` — no download or re-upload required. See [Copying files between repos and buckets](#copying-files-between-repos-and-buckets).
 
 ### Uploading files
 

--- a/docs/hub/xet/deduplication.md
+++ b/docs/hub/xet/deduplication.md
@@ -2,6 +2,9 @@
 
 Xet-enabled repositories utilize [content-defined chunking (CDC)](https://huggingface.co/blog/from-files-to-chunks) to deduplicate on the level of bytes (~64KB of data, also referred to as a "chunk"). Each chunk is identified by a rolling hash that determines chunk boundaries based on the actual file contents, making it resilient to insertions or deletions anywhere in the file. When a file is uploaded to a Xet-backed repository using a Xet-aware client, its contents are broken down into these variable-sized chunks. Only new chunks not already present in Xet storage are kept after chunking, everything else is discarded.
 
+> [!TIP]
+> Chunk-level deduplication is also what makes **server-side copies instant**: `hf buckets cp` between repositories and buckets migrates only content hashes, with no data re-upload. See [Copying files between repos and buckets](../storage-buckets#copying-files-between-repos-and-buckets).
+
 ## How Content-Defined Chunking Works
 
 To understand content-defined chunking, imagine a file as a long passage of text. The system scans the data using a rolling hash — a small mathematical function that slides over the bytes. Whenever the hash hits a special pattern, a chunk boundary is placed at that position. Because the boundaries are determined by the *content itself* (not by fixed positions), identical regions of data always produce the same chunks, even if surrounding content changes.


### PR DESCRIPTION
`hf buckets cp` copies a dataset/model/Space repo into a bucket server-side
(only Xet hashes migrated, no re-upload), but it was documented only at the
bottom of storage-buckets.md and never linked from the datasets docs.

- datasets-ingesting.md: add the copy cross-link + example
- storage-buckets.md: mention it in the Managing Files intro; link "instantly"
  to chunk-level deduplication
- xet/deduplication.md: note dedup is what makes server-side copies instant

No new feature — discoverability only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only discoverability and cross-links; no product or API behavior changes.
> 
> **Overview**
> Improves **discoverability** of server-side **`hf buckets cp`** (and related CLI) for copying Xet-tracked data from datasets/models/Spaces into storage buckets without re-uploading bytes.
> 
> **`datasets-ingesting.md`** now calls out repo→bucket copy in **Ingest raw data**, with a short example and a link to the storage-buckets copy section.
> 
> **`storage-buckets.md`** surfaces the same workflow earlier under **Managing Files**, ties “instant” copies to **chunk-level deduplication**, and expands the NOTE with the **same storage region** requirement for server-side copy (plus minor NOTE formatting cleanup).
> 
> **`xet/deduplication.md`** adds a TIP explaining that deduplication is why hash-only server-side copies are fast, with a link back to the buckets copy docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a760b69314468d3cbc47e466449f972e52e6f97e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->