### PR TITLE
Add OpenMDW 1.1 license

### DIFF
--- a/docs/hub/repositories-licenses.md
+++ b/docs/hub/repositories-licenses.md
@@ -70,7 +70,8 @@ A full list of the available licenses is available here:
 | Mozilla Public License 2.0                                     | `mpl-2.0`                                |
 | Open Data Commons License Attribution family                   | `odc-by`                                 |
 | Open Database License family                                   | `odbl`                                   |
-| Open Model, Data & Weights License Agreement                   | `openmdw-1.0`                            | <!-- license: https://openmdw.ai/license -->
+| Open Model, Data & Weights License Agreement                   | `openmdw-1.0`                            | <!-- license: https://openmdw.ai/license/1-0/ -->
+| Open Model, Data & Weights License Agreement v1.1              | `openmdw-1.1`                            | <!-- license: https://openmdw.ai/license/1-1/ -->
 | Open Rail++-M License                                          | `openrail++`                             | <!-- license: https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md -->
 | Open Software License 3.0                                      | `osl-3.0`                                |
 | PostgreSQL License                                             | `postgresql`                             |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to the license reference table; no runtime or security impact.
> 
> **Overview**
> Documents **Open Model, Data & Weights License Agreement v1.1** on the Hub license list with repo-card identifier `openmdw-1.1` and link to the v1.1 license text.
> 
> Also updates the existing **OpenMDW 1.0** entry so its reference URL points to the versioned `1-0` path instead of the generic license URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ed530b6f141a0409765a42042fab3df6cdcaf05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->