### PR TITLE
[Docs] how to register an agent harness

### DIFF
--- a/docs/hub/agents-overview.md
+++ b/docs/hub/agents-overview.md
@@ -182,6 +182,23 @@ Agent: [Fetches documentation]
        result = classifier("I love this product!")
 ```
 
+## Register your agent harness
+
+Hugging Face maintains a public registry of agent harnesses, the coding agents and tools that interact with the Hub (Claude Code, Codex, Cursor, and more). When `huggingface_hub` detects it is running inside a registered harness, it reports it via the user agent on Hub requests. Registering your harness makes this agentic usage visible and gives your project a friendly display label, links back to your docs and repository, and inclusion in upcoming agent leaderboards.
+
+To register a harness, open a Pull Request adding an entry to [`agent-harnesses.ts`](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/agent-harnesses.ts) in the `@huggingface/tasks` package:
+
+- The harness id (the entry key) should be lowercased and hyphen-separated (example: `"claude-code"`).
+- set `prettyLabel` with user-friendly casing (example: `Claude Code`).
+- (optional) set `repoUrl` with a link to the harness source code (usually a GitHub repository).
+- (optional) set `docsUrl` with a link to the harness documentation or website.
+- (optional) set `description` with a short, one-line explanation of the harness.
+- define how your harness is detected from the environment:
+  - If your harness sets one of the standard environment variables (`AI_AGENT` or `AGENT`), its value is used directly as the identifier and no extra config is needed.
+  - Otherwise, set `envVars` to map environment variable names to value patterns. Use `"*"` to match any non-empty value, an exact string for an exact match, or `"<prefix>*"` for prefix matching.
+
+And that's it! Once PR is merged, we will start tracking usage of the `hf` CLI by your agent harness.
+
 ## Next Steps
 
 - [CLI](./agents-cli) - Command-line interface for Hub operations

--- a/docs/hub/agents-overview.md
+++ b/docs/hub/agents-overview.md
@@ -184,11 +184,11 @@ Agent: [Fetches documentation]
 
 ## Register your agent harness
 
-Hugging Face maintains a public registry of agent harnesses, the coding agents and tools that interact with the Hub (Claude Code, Codex, Cursor, and more). When `huggingface_hub` detects it is running inside a registered harness, it reports it via the user agent on Hub requests. Registering your harness makes this agentic usage visible and gives your project a friendly display label, links back to your docs and repository, and inclusion in upcoming agent leaderboards.
+Hugging Face maintains a public registry of agent harnesses, the coding agents and tools that interact with the Hub (Claude Code, Codex, Cursor, and more). When `huggingface_hub` detects it is running inside a registered harness, it reports it via the user agent on Hub requests. Registering your harness means this activity is attributed to your tool by name and gives your project a friendly display label, links back to your docs and repository, and a place in upcoming agent leaderboards.
 
 To register a harness, open a Pull Request adding an entry to [`agent-harnesses.ts`](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/agent-harnesses.ts) in the `@huggingface/tasks` package:
 
-- The harness id (the entry key) should be lowercased and hyphen-separated (example: `"claude-code"`).
+- the harness id (the entry key) should be lowercased and hyphen-separated (example: `"claude-code"`).
 - set `prettyLabel` with user-friendly casing (example: `Claude Code`).
 - (optional) set `repoUrl` with a link to the harness source code (usually a GitHub repository).
 - (optional) set `docsUrl` with a link to the harness documentation or website.
@@ -197,7 +197,7 @@ To register a harness, open a Pull Request adding an entry to [`agent-harnesses.
   - If your harness sets one of the standard environment variables (`AI_AGENT` or `AGENT`), its value is used directly as the identifier and no extra config is needed.
   - Otherwise, set `envVars` to map environment variable names to value patterns. Use `"*"` to match any non-empty value, an exact string for an exact match, or `"<prefix>*"` for prefix matching.
 
-And that's it! Once PR is merged, we will start tracking usage of the `hf` CLI by your agent harness.
+And that's it! Once the PR is merged, we will start tracking usage of the `hf` CLI by your agent harness.
 
 ## Next Steps
 


### PR DESCRIPTION
Adds a brief "Register your agent harness" how-to section to the Agents Overview page, covering the harness registry introduced in https://github.com/huggingface/huggingface.js/pull/2209 (fields + env-var detection).

Will merge only once js PR gets merged.

Didn't really knew where to put this section. I placed it on `agents-overview.md` because that page already enumerates coding agents/harnesses, and it's the landing page of the Agents section. Happy to start a new page but I feel that it's too little content to justify it. 

Docs: https://moon-ci-docs.huggingface.co/docs/hub/pr_2521/en/agents-overview#register-your-agent-harness


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `agents-overview.md` with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds a **Register your agent harness** section to the Agents Overview page, placed before **Next Steps**.
> 
> The new content explains why to register (Hub user-agent attribution, display metadata, docs/repo links, future leaderboards) and walks contributors through opening a PR against `agent-harnesses.ts` in `@huggingface/tasks`: required `prettyLabel` and id format, optional `repoUrl` / `docsUrl` / `description`, and environment detection via `AI_AGENT` / `AGENT` or custom `envVars` patterns.
> 
> No application or Hub runtime code is changed in this PR—documentation only, dependent on the related `huggingface.js` registry work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a881cc9d92e01699194e4e0148ea45c1064602f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


