### PR TITLE
Add Jobs guide: Process Large Datasets

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -452,6 +452,8 @@
     title: Popular Images
   - local: jobs-examples
     title: Examples & Tutorials
+  - local: jobs-large-datasets
+    title: Process Large Datasets
   - local: jobs-schedule
     title: Schedule Jobs
   - local: jobs-webhooks

--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -105,6 +105,9 @@ You can pass environment variables to your job using
 
 Mount Hugging Face repositories (models, datasets) or [Storage Buckets](./storage-buckets) as volumes in your job container using `-v` or `--volume`. The syntax uses the `hf://` URL scheme: `hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]`.
 
+> [!TIP]
+> Because mounted files are fetched lazily, mounting lets a Job work with datasets far larger than its local disk. See [Process Large Datasets](./jobs-large-datasets) for mounting, streaming, and processing big data on Jobs.
+
 Volume types:
 
 | Type | Example |

--- a/docs/hub/jobs-large-datasets.md
+++ b/docs/hub/jobs-large-datasets.md
@@ -125,7 +125,7 @@ WET = (
 )
 
 rows = []
-with HfFileSystem().open(WET, "rb") as f:
+with hffs.open(WET, "rb") as f:
     for rec in ArchiveIterator(f, record_types=WarcRecordType.conversion):
         lang = (rec.headers.get("WARC-Identified-Content-Language", "") or "und").split(",")[0]
         rows.append((rec.headers.get("WARC-Target-URI", ""), lang, len(rec.reader.read())))

--- a/docs/hub/jobs-large-datasets.md
+++ b/docs/hub/jobs-large-datasets.md
@@ -5,7 +5,7 @@ Every Job comes with a fixed amount of local disk, set by its [hardware flavor](
 ## Which approach?
 
 - **Fits on disk** → a plain `load_dataset(...)` works as-is (or just pick a bigger flavor — up to 1 TB of ephemeral disk).
-- **Iterating over rows, or training** → [stream](#stream-the-dataset) it.
+- **Iterating over rows, processing or training** → [stream](#stream-the-dataset) it.
 - **Filtered or column-pruned scans** → query it [directly over `hf://`](#read-and-filter-over-hf) with Polars or DuckDB.
 - **Tools that expect local file paths** → [mount](#mount-a-dataset-model-or-bucket) the repo and read it lazily.
 - **Persisting results** → write them to a [Storage Bucket](#save-results) so they survive the Job.

--- a/docs/hub/jobs-large-datasets.md
+++ b/docs/hub/jobs-large-datasets.md
@@ -1,6 +1,6 @@
 # Process Large Datasets
 
-Every Job comes with a fixed amount of local disk, set by its [hardware flavor](./jobs-pricing#pricing) (the **Ephemeral Storage** column, also shown by `hf jobs hardware`). That's plenty for many tasks — but you don't need to fit a dataset on disk to work with it. To use datasets larger than the disk, read them directly from the Hub.
+Every Job comes with a fixed amount of local disk, set by its [hardware flavor](./jobs-pricing#pricing) (the **Ephemeral Storage** column, also shown by `hf jobs hardware`). You don't need to fit a whole dataset on that disk to work with it: datasets and [Storage Buckets](./storage-buckets) can be read directly from the Hub — streamed, queried, or mounted — so a single Job can process data far larger than its disk. This page covers the options and when to reach for each.
 
 **Which approach?**
 
@@ -77,7 +77,7 @@ Datasets and models mount read-only; buckets are read-write, which makes them a 
 
 ## Save results
 
-Ephemeral disk doesn't survive the Job, so write anything you want to keep to a [Storage Bucket](./storage-buckets) mounted read-write, or push it to the Hub as a dataset. DuckDB can filter the source over `hf://` and persist the matches to a mounted bucket in one query — and because it writes out-of-core, the result doesn't need to fit in memory. A filter like this reads the full `text` column, so expect it to take a while (it transfers most of the ~28 GB):
+Ephemeral disk doesn't survive the Job, so write anything you want to keep to a [Storage Bucket](./storage-buckets) mounted read-write, or push it to the Hub as a dataset. DuckDB can filter the source over `hf://` and write the matches straight to a mounted bucket in one out-of-core query, so the result never has to fit in memory:
 
 ```bash
 hf jobs uv run --flavor cpu-upgrade --timeout 1h \
@@ -149,12 +149,7 @@ Run it with `hf jobs uv run cc_wet.py` — it completes in about a minute on the
 │ zho     │   586 │
 │ rus     │   434 │
 │ jpn     │   244 │
-│ spa     │   239 │
-│ fra     │   194 │
-│ deu     │   179 │
-│ por     │   145 │
-│ pol     │    98 │
-│ ita     │    79 │
+│ …       │    …  │
 └─────────┴───────┘
 ```
 

--- a/docs/hub/jobs-large-datasets.md
+++ b/docs/hub/jobs-large-datasets.md
@@ -2,7 +2,7 @@
 
 Every Job comes with a fixed amount of local disk, set by its [hardware flavor](./jobs-pricing#pricing) (the **Ephemeral Storage** column, also shown by `hf jobs hardware`). You don't need to fit a whole dataset on that disk to work with it: datasets and [Storage Buckets](./storage-buckets) can be read directly from the Hub — streamed, queried, or mounted — so a single Job can process data far larger than its disk. This page covers the options and when to reach for each.
 
-**Which approach?**
+## Which approach?
 
 - **Fits on disk** → a plain `load_dataset(...)` works as-is (or just pick a bigger flavor — up to 1 TB of ephemeral disk).
 - **Iterating over rows, or training** → [stream](#stream-the-dataset) it.

--- a/docs/hub/jobs-large-datasets.md
+++ b/docs/hub/jobs-large-datasets.md
@@ -1,0 +1,127 @@
+# Process large datasets
+
+Every Job comes with a fixed amount of local disk, set by its [hardware flavor](./jobs-pricing#pricing) (the **Ephemeral Storage** column). That's plenty for many tasks — but you don't need to fit a dataset on disk to work with it. To use datasets larger than the disk, read them directly from the Hub.
+
+**Which approach?**
+
+- **Fits on disk** → a plain `load_dataset(...)` works as-is.
+- **Iterating over rows, or training** → [stream](#stream-the-dataset) it — no download.
+- **Filtered or column-pruned scans** → [mount](#mount-a-dataset-model-or-bucket) the repo and read it lazily, or query it [directly over `hf://`](#read-and-filter-over-hf) with Polars or DuckDB.
+- **Persisting results** → write them to a [Storage Bucket](#saving-results) so they survive the Job.
+
+## Stream the dataset
+
+Streaming reads examples from the Hub as your code consumes them — no download, no local copy, and it scales to multi-TB datasets. Recent releases made it [up to 100× more efficient](https://huggingface.co/blog/streaming-datasets), reaching performance on par with local SSDs when training across many workers:
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("HuggingFaceFW/fineweb-edu", "sample-10BT", split="train", streaming=True)
+for example in ds.take(1000):
+    ...  # streams in as you iterate, nothing hits disk
+```
+
+A streamed dataset is an `IterableDataset` supporting lazy `.filter()`, `.map()`, `.shuffle(buffer_size=...)`, and `.batch()`, and can be passed straight to a PyTorch `DataLoader` or a `Trainer` to train on data larger than disk. See the [Stream guide](/docs/datasets/stream) for the full API, and [Examples & Tutorials](./jobs-examples) for end-to-end training walkthroughs.
+
+## Mount a dataset, model, or bucket
+
+Mount a repository or bucket into the Job as a local path with `-v` / `--volume`; files are fetched lazily over the network as your code reads them, so any tool that reads local files just works:
+
+```bash
+hf jobs uv run --flavor cpu-upgrade \
+  -v hf://datasets/HuggingFaceFW/fineweb-edu:/mnt/data \
+  filter.py
+```
+
+```python
+# filter.py — lazy scan: reads Parquet metadata first, then only the columns/rows the query needs
+import polars as pl
+
+df = (
+    pl.scan_parquet("/mnt/data/sample/10BT/*.parquet")
+    .filter(pl.col("int_score") >= 4)
+    .select("text", "url", "token_count")
+    .collect()
+)
+```
+
+Datasets and models mount read-only; buckets are read-write, which makes them a good place to [save results](#saving-results). See [Configuration](./jobs-configuration#volumes) for the full `-v` syntax and [bucket access patterns](./storage-buckets-access#volume-mounts-in-jobs-and-spaces) for details.
+
+> [!TIP]
+> Files read through a mount are cached on the Job's ephemeral disk, so reading lazily (a `scan_parquet`, or one file at a time) keeps the footprint small. When running a local script with `hf jobs uv run`, the script directory is mounted at `/data`, so mount your data elsewhere (e.g. `/mnt/data`).
+
+## Read and filter over `hf://`
+
+Many data libraries read datasets and buckets straight from the Hub over `hf://` (via [`HfFileSystem`](/docs/huggingface_hub/guides/hf_file_system)/fsspec) — no mount needed. **Polars**, **DuckDB**, and **pandas** all read Hub Parquet directly, pushing filters and column selection down into the scan, so a single Job can process far more data than fits in memory. For example, DuckDB can filter the source and write the result to a mounted bucket in one query:
+
+```python
+import duckdb
+from huggingface_hub import HfFileSystem
+
+duckdb.register_filesystem(HfFileSystem())
+duckdb.sql(
+    """
+    COPY (
+        SELECT text, url, token_count
+        FROM 'hf://datasets/HuggingFaceFW/fineweb-edu/sample/100BT/*.parquet'
+        WHERE int_score >= 4 AND token_count >= 4000
+    ) TO '/mnt/out/result.parquet' (FORMAT parquet)
+    """
+)
+```
+
+See [Python data tools](./storage-buckets-access#python-data-tools) and [bucket integrations](./storage-buckets-integrations) for per-library examples. A large scan is network-bound rather than memory-bound, so to go faster you can split the work across several Jobs running in parallel.
+
+## Saving results
+
+Ephemeral disk doesn't survive the Job, so write anything you want to keep to a [Storage Bucket](./storage-buckets) mounted read-write, or push it to the Hub as a dataset:
+
+```bash
+hf jobs uv run --flavor cpu-performance \
+  -v hf://datasets/HuggingFaceFW/fineweb-edu:/mnt/data \
+  -v hf://buckets/username/my-output:/mnt/out \
+  filter.py
+```
+
+Files written under the bucket mount path persist after the Job ends. To publish a processed dataset instead, use [`Dataset.push_to_hub`](/docs/datasets/upload_dataset).
+
+## Worked example: query Common Crawl without downloading it
+
+Common Crawl mirrors its archive to the bucket [`commoncrawl/commoncrawl`](https://huggingface.co/datasets/commoncrawl/commoncrawl) — hundreds of TB. Stream one WET (plaintext) shard straight from `hf://`, parse it, and query it with DuckDB; only a few MB transit because the gzip is read sequentially and stopped early:
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["huggingface_hub>=1.0", "fastwarc>=0.15", "duckdb>=1.0"]
+# ///
+import duckdb
+from fastwarc.warc import ArchiveIterator, WarcRecordType
+from huggingface_hub import HfFileSystem
+
+WET = (
+    "buckets/commoncrawl/commoncrawl/crawl-data/CC-MAIN-2026-17/"
+    "segments/1775805908305.14/wet/"
+    "CC-MAIN-20260410081153-20260410111153-00000.warc.wet.gz"
+)
+
+rows = []
+with HfFileSystem().open(WET, "rb") as f:
+    for rec in ArchiveIterator(f, record_types=WarcRecordType.conversion):
+        lang = (rec.headers.get("WARC-Identified-Content-Language", "") or "und").split(",")[0]
+        rows.append((rec.headers.get("WARC-Target-URI", ""), lang, len(rec.reader.read())))
+        if len(rows) >= 5000:
+            break
+
+con = duckdb.connect()
+con.execute("CREATE TABLE wet(url VARCHAR, lang VARCHAR, n_chars BIGINT)")
+con.executemany("INSERT INTO wet VALUES (?,?,?)", rows)
+con.sql("SELECT lang, count(*) AS docs FROM wet GROUP BY lang ORDER BY docs DESC LIMIT 10").show()
+```
+
+Run it with `hf jobs uv run cc_wet.py`.
+
+## See also
+
+- [Stream](/docs/datasets/stream) · [Streaming datasets: 100× more efficient](https://huggingface.co/blog/streaming-datasets)
+- [Pricing & hardware](./jobs-pricing#pricing) — ephemeral disk per flavor · [Configuration](./jobs-configuration#volumes) — volumes
+- [Storage Buckets](./storage-buckets) · [access patterns](./storage-buckets-access) · [integrations](./storage-buckets-integrations)

--- a/docs/hub/jobs-large-datasets.md
+++ b/docs/hub/jobs-large-datasets.md
@@ -1,13 +1,14 @@
-# Process large datasets
+# Process Large Datasets
 
-Every Job comes with a fixed amount of local disk, set by its [hardware flavor](./jobs-pricing#pricing) (the **Ephemeral Storage** column). That's plenty for many tasks — but you don't need to fit a dataset on disk to work with it. To use datasets larger than the disk, read them directly from the Hub.
+Every Job comes with a fixed amount of local disk, set by its [hardware flavor](./jobs-pricing#pricing) (the **Ephemeral Storage** column, also shown by `hf jobs hardware`). That's plenty for many tasks — but you don't need to fit a dataset on disk to work with it. To use datasets larger than the disk, read them directly from the Hub.
 
 **Which approach?**
 
-- **Fits on disk** → a plain `load_dataset(...)` works as-is.
+- **Fits on disk** → a plain `load_dataset(...)` works as-is (or just pick a bigger flavor — up to 1 TB of ephemeral disk).
 - **Iterating over rows, or training** → [stream](#stream-the-dataset) it.
-- **Filtered or column-pruned scans** → [mount](#mount-a-dataset-model-or-bucket) the repo and read it lazily, or query it [directly over `hf://`](#read-and-filter-over-hf) with Polars or DuckDB.
-- **Persisting results** → write them to a [Storage Bucket](#saving-results) so they survive the Job.
+- **Filtered or column-pruned scans** → query it [directly over `hf://`](#read-and-filter-over-hf) with Polars or DuckDB.
+- **Tools that expect local file paths** → [mount](#mount-a-dataset-model-or-bucket) the repo and read it lazily.
+- **Persisting results** → write them to a [Storage Bucket](#save-results) so they survive the Job.
 
 ## Stream the dataset
 
@@ -23,6 +24,26 @@ for example in ds.take(1000):
 
 A streamed dataset is an `IterableDataset` supporting lazy `.filter()`, `.map()`, `.shuffle(buffer_size=...)`, and `.batch()`, and can be passed straight to a PyTorch `DataLoader` or a `Trainer` to train on data larger than disk. See the [Stream guide](/docs/datasets/stream) for the full API, and [Examples & Tutorials](./jobs-examples) for end-to-end training walkthroughs.
 
+## Read and filter over `hf://`
+
+Many data libraries read Hub datasets directly over `hf://` paths — **Polars**, **DuckDB**, and **pandas** all scan Hub Parquet natively, pushing filters and column selection down into the scan, so a single Job can process far more data than fits in memory or on disk. This query summarizes ~28 GB of Parquet in about four minutes on the default CPU flavor:
+
+```python
+import polars as pl
+
+agg = (
+    pl.scan_parquet("hf://datasets/HuggingFaceFW/fineweb-edu/sample/10BT/*.parquet")
+    .filter(pl.col("int_score") >= 4)
+    .group_by("int_score")
+    .agg(pl.len().alias("docs"), pl.col("token_count").sum().alias("tokens"))
+    .sort("int_score")
+    .collect()
+)
+print(agg)
+```
+
+Scans like this are network-bound rather than memory-bound, and engines differ in how aggressively they parallelize remote reads, so timings vary by library. Two practical consequences: set `--timeout` above the default 30 minutes for long scans, and split the work across several Jobs running in parallel to go faster. See [Polars](./datasets-polars), [DuckDB](./datasets-duckdb), and [pandas](./datasets-pandas) for per-library examples, and [Python data tools](./storage-buckets-access#python-data-tools) for reading **buckets** over `hf://` (which goes through [`HfFileSystem`](/docs/huggingface_hub/guides/hf_file_system)).
+
 ## Mount a dataset, model, or bucket
 
 Mount a repository or bucket into the Job as a local path with `-v` / `--volume`; files are fetched lazily over the network as your code reads them, so any tool that reads local files just works:
@@ -30,57 +51,56 @@ Mount a repository or bucket into the Job as a local path with `-v` / `--volume`
 ```bash
 hf jobs uv run --flavor cpu-upgrade \
   -v hf://datasets/HuggingFaceFW/fineweb-edu:/mnt/data \
+  process.py
+```
+
+```python
+# /// script
+# dependencies = ["polars"]
+# ///
+# process.py — the mounted repo is just a directory of files
+from pathlib import Path
+
+import polars as pl
+
+for path in Path("/mnt/data/sample/10BT").glob("*.parquet"):
+    shard = pl.read_parquet(path)
+    ...  # process one shard at a time, write results out
+```
+
+Mounting is the natural fit when files are consumed whole — model weights, audio or image files, archives — or when a tool only accepts file paths. For large multi-file Parquet scans, querying [directly over `hf://`](#read-and-filter-over-hf) is typically several times faster than scanning through a mount.
+
+Datasets and models mount read-only; buckets are read-write, which makes them a good place to [save results](#save-results). See [Configuration](./jobs-configuration#volumes) for the full `-v` syntax and [bucket access patterns](./storage-buckets-access#volume-mounts-in-jobs-and-spaces) for details.
+
+> [!TIP]
+> Files read through a mount are cached on the Job's ephemeral disk, so reading lazily (one file at a time) keeps the footprint small. When running a local script with `hf jobs uv run`, the script directory is mounted at `/data`, so mount your data elsewhere (e.g. `/mnt/data`).
+
+## Save results
+
+Ephemeral disk doesn't survive the Job, so write anything you want to keep to a [Storage Bucket](./storage-buckets) mounted read-write, or push it to the Hub as a dataset. DuckDB can filter the source over `hf://` and persist the matches to a mounted bucket in one query — and because it writes out-of-core, the result doesn't need to fit in memory. A filter like this reads the full `text` column, so expect it to take a while (it transfers most of the ~28 GB):
+
+```bash
+hf jobs uv run --flavor cpu-upgrade --timeout 1h \
+  -v hf://buckets/username/my-output:/mnt/out \
   filter.py
 ```
 
 ```python
-# filter.py — lazy scan: reads Parquet metadata first, then only the columns/rows the query needs
-import polars as pl
-
-df = (
-    pl.scan_parquet("/mnt/data/sample/10BT/*.parquet")
-    .filter(pl.col("int_score") >= 4)
-    .select("text", "url", "token_count")
-    .collect()
-)
-```
-
-Datasets and models mount read-only; buckets are read-write, which makes them a good place to [save results](#saving-results). See [Configuration](./jobs-configuration#volumes) for the full `-v` syntax and [bucket access patterns](./storage-buckets-access#volume-mounts-in-jobs-and-spaces) for details.
-
-> [!TIP]
-> Files read through a mount are cached on the Job's ephemeral disk, so reading lazily (a `scan_parquet`, or one file at a time) keeps the footprint small. When running a local script with `hf jobs uv run`, the script directory is mounted at `/data`, so mount your data elsewhere (e.g. `/mnt/data`).
-
-## Read and filter over `hf://`
-
-Many data libraries read datasets and buckets straight from the Hub over `hf://` (via [`HfFileSystem`](/docs/huggingface_hub/guides/hf_file_system)/fsspec) with no mount needed. **Polars**, **DuckDB**, and **pandas** all read Hub Parquet directly, pushing filters and column selection down into the scan, so a single Job can process far more data than fits in memory. For example, DuckDB can filter the source and write the result to a mounted bucket in one query:
-
-```python
+# /// script
+# dependencies = ["duckdb"]
+# ///
+# filter.py — scan ~28 GB of Parquet, keep only the matching rows
 import duckdb
-from huggingface_hub import HfFileSystem
 
-duckdb.register_filesystem(HfFileSystem())
 duckdb.sql(
     """
     COPY (
         SELECT text, url, token_count
-        FROM 'hf://datasets/HuggingFaceFW/fineweb-edu/sample/100BT/*.parquet'
+        FROM 'hf://datasets/HuggingFaceFW/fineweb-edu/sample/10BT/*.parquet'
         WHERE int_score >= 4 AND token_count >= 4000
     ) TO '/mnt/out/result.parquet' (FORMAT parquet)
     """
 )
-```
-
-See [Python data tools](./storage-buckets-access#python-data-tools) and [bucket integrations](./storage-buckets-integrations) for per-library examples. A large scan is network-bound rather than memory-bound, so to go faster you can split the work across several Jobs running in parallel.
-
-## Saving results
-
-Ephemeral disk doesn't survive the Job, so write anything you want to keep to a [Storage Bucket](./storage-buckets) mounted read-write, or push it to the Hub as a dataset:
-
-```bash
-hf jobs uv run --flavor cpu-performance \
-  -v hf://datasets/HuggingFaceFW/fineweb-edu:/mnt/data \
-  -v hf://buckets/username/my-output:/mnt/out \
-  filter.py
 ```
 
 Files written under the bucket mount path persist after the Job ends. To publish a processed dataset instead, use [`Dataset.push_to_hub`](/docs/datasets/upload_dataset).
@@ -118,7 +138,25 @@ con.executemany("INSERT INTO wet VALUES (?,?,?)", rows)
 con.sql("SELECT lang, count(*) AS docs FROM wet GROUP BY lang ORDER BY docs DESC LIMIT 10").show()
 ```
 
-Run it with `hf jobs uv run cc_wet.py`.
+Run it with `hf jobs uv run cc_wet.py` — it completes in about a minute on the default CPU flavor and prints:
+
+```
+┌─────────┬───────┐
+│  lang   │ docs  │
+│ varchar │ int64 │
+├─────────┼───────┤
+│ eng     │  1974 │
+│ zho     │   586 │
+│ rus     │   434 │
+│ jpn     │   244 │
+│ spa     │   239 │
+│ fra     │   194 │
+│ deu     │   179 │
+│ por     │   145 │
+│ pol     │    98 │
+│ ita     │    79 │
+└─────────┴───────┘
+```
 
 ## See also
 

--- a/docs/hub/jobs-large-datasets.md
+++ b/docs/hub/jobs-large-datasets.md
@@ -22,7 +22,17 @@ for example in ds.take(1000):
     ...  # streams in as you iterate, nothing hits disk
 ```
 
-A streamed dataset is an `IterableDataset` supporting lazy `.filter()`, `.map()`, `.shuffle(buffer_size=...)`, and `.batch()`, and can be passed straight to a PyTorch `DataLoader` or a `Trainer` to train on data larger than disk. See the [Stream guide](/docs/datasets/stream) for the full API, and [Examples & Tutorials](./jobs-examples) for end-to-end training walkthroughs.
+A streamed dataset is an `IterableDataset` supporting lazy `.filter()`, `.map()`, `.shuffle(buffer_size=...)`, and `.batch()`, and can be passed straight to a PyTorch `DataLoader` or a `Trainer` to train on data larger than disk. See the [Stream guide](/docs/datasets/stream) for the full API, and [Examples & Tutorials](./jobs-examples) for end-to-end training walkthroughs for single-node or distributed setups.
+
+Streaming also works in distributed setups, using Spark:
+
+```python
+import pyspark_huggingface
+
+df = spark.read.format("huggingface").option("config", "sample-10BT").load("HuggingFaceFW/fineweb-edu")
+```
+
+The resulting Spark dataframe is distributed: each worker streams from its own subset of files. See the [Spark documentation](./datasets-spark) for examples of reading, writing, and efficiently filtering rows and columns.
 
 ## Read and filter over `hf://`
 
@@ -112,7 +122,7 @@ Common Crawl mirrors its archive to the bucket [`commoncrawl/commoncrawl`](https
 ```python
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["huggingface_hub>=1.0", "fastwarc>=0.15", "duckdb>=1.0"]
+# dependencies = ["huggingface_hub>=1.9", "fastwarc>=0.15", "duckdb>=1.0"]
 # ///
 import duckdb
 from fastwarc.warc import ArchiveIterator, WarcRecordType

--- a/docs/hub/jobs-large-datasets.md
+++ b/docs/hub/jobs-large-datasets.md
@@ -5,7 +5,7 @@ Every Job comes with a fixed amount of local disk, set by its [hardware flavor](
 **Which approach?**
 
 - **Fits on disk** → a plain `load_dataset(...)` works as-is.
-- **Iterating over rows, or training** → [stream](#stream-the-dataset) it — no download.
+- **Iterating over rows, or training** → [stream](#stream-the-dataset) it.
 - **Filtered or column-pruned scans** → [mount](#mount-a-dataset-model-or-bucket) the repo and read it lazily, or query it [directly over `hf://`](#read-and-filter-over-hf) with Polars or DuckDB.
 - **Persisting results** → write them to a [Storage Bucket](#saving-results) so they survive the Job.
 
@@ -52,7 +52,7 @@ Datasets and models mount read-only; buckets are read-write, which makes them a 
 
 ## Read and filter over `hf://`
 
-Many data libraries read datasets and buckets straight from the Hub over `hf://` (via [`HfFileSystem`](/docs/huggingface_hub/guides/hf_file_system)/fsspec) — no mount needed. **Polars**, **DuckDB**, and **pandas** all read Hub Parquet directly, pushing filters and column selection down into the scan, so a single Job can process far more data than fits in memory. For example, DuckDB can filter the source and write the result to a mounted bucket in one query:
+Many data libraries read datasets and buckets straight from the Hub over `hf://` (via [`HfFileSystem`](/docs/huggingface_hub/guides/hf_file_system)/fsspec) with no mount needed. **Polars**, **DuckDB**, and **pandas** all read Hub Parquet directly, pushing filters and column selection down into the scan, so a single Job can process far more data than fits in memory. For example, DuckDB can filter the source and write the result to a mounted bucket in one query:
 
 ```python
 import duckdb

--- a/docs/hub/jobs-large-datasets.md
+++ b/docs/hub/jobs-large-datasets.md
@@ -116,7 +116,7 @@ Common Crawl mirrors its archive to the bucket [`commoncrawl/commoncrawl`](https
 # ///
 import duckdb
 from fastwarc.warc import ArchiveIterator, WarcRecordType
-from huggingface_hub import HfFileSystem
+from huggingface_hub import hffs
 
 WET = (
     "buckets/commoncrawl/commoncrawl/crawl-data/CC-MAIN-2026-17/"

--- a/docs/hub/jobs-large-datasets.md
+++ b/docs/hub/jobs-large-datasets.md
@@ -107,7 +107,7 @@ Files written under the bucket mount path persist after the Job ends. To publish
 
 ## Worked example: query Common Crawl without downloading it
 
-Common Crawl mirrors its archive to the bucket [`commoncrawl/commoncrawl`](https://huggingface.co/datasets/commoncrawl/commoncrawl) — hundreds of TB. Stream one WET (plaintext) shard straight from `hf://`, parse it, and query it with DuckDB; only a few MB transit because the gzip is read sequentially and stopped early:
+Common Crawl mirrors its archive to the bucket [`commoncrawl/commoncrawl`](https://huggingface.co/buckets/commoncrawl/commoncrawl) — hundreds of TB. Stream one WET (plaintext) shard straight from `hf://`, parse it, and query it with DuckDB; only a few MB transit because the gzip is read sequentially and stopped early:
 
 ```python
 # /// script


### PR DESCRIPTION
## What

Adds a new Jobs documentation page — **Process Large Datasets** (`docs/hub/jobs-large-datasets.md`) — under the Jobs section of the nav, plus an inbound pointer from `jobs-configuration`'s Volumes section.

It's a task-oriented guide for working with datasets **larger than a Job's ephemeral disk**, opening with a short decision rule and then covering each approach:

- **Stream** with `datasets` (`streaming=True`) — links the [Stream guide](https://huggingface.co/docs/datasets/stream) and the [100× more efficient](https://huggingface.co/blog/streaming-datasets) blog
- **Read & filter over `hf://`** directly with Polars/DuckDB/pandas (native readers, no mount)
- **Mount** a dataset/model/bucket for tools that expect local file paths
- **Save results** to a Storage Bucket (DuckDB `COPY` straight from `hf://` to the mount) or `push_to_hub`
- A **Common Crawl** worked example: stream a WET shard straight from `hf://` → DuckDB, no download

It links the canonical reference pages (`jobs-pricing`, `jobs-configuration#volumes`, `storage-buckets-access`, `datasets/stream`, per-library dataset pages) rather than restating them.

## Verification

Every snippet was run against live Jobs. Timings that shaped the page (same aggregate query, same ~28 GB / 14-file Parquet glob):

| Read path | Time |
|---|---|
| Polars native `hf://` scan | **~4 min** (in the doc) |
| DuckDB native `hf://` | ~18 min |
| DuckDB via `register_filesystem(HfFileSystem())` | did not finish (killed at 30-min default timeout) |
| Polars over a `-v` repo mount | ~6 min *per file* (~85 min extrapolated) |

Hence the page's structure: `hf://` native readers for scans, mounts for whole-file/local-path access, explicit `--timeout` guidance for network-bound scans. The Common Crawl example runs verbatim in ~1 min on the default CPU flavor with no token; its printed output is included on the page.

## Notes

- #2554 (jobs-serving) touched the same `_toctree.yml` region and has since merged; this branch is mergeable and rebases cleanly on `main` (no conflicts).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact.
> 
> **Overview**
> Adds a new Jobs doc page **Process Large Datasets** and registers it in the Hub nav (after Examples & Tutorials).
> 
> The guide explains how to work with data bigger than a Job’s ephemeral disk: a short “which approach?” decision tree, then sections on **streaming** (`datasets` + Spark), **native `hf://` scans** (Polars/DuckDB/pandas) with `--timeout` and parallel-job guidance, **volume mounts** for path-based tools, **persisting output** to Storage Buckets or `push_to_hub`, and a **Common Crawl WET** end-to-end example. It points to existing pricing, configuration, bucket, and per-library docs instead of duplicating them.
> 
> **Configuration** gains a Volumes tip that lazy mounts enable oversized datasets and links to this page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cd203e257e683523c46a6419a7069b723b61b62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->