### PR TITLE
Skip provider/task combos with no @huggingface/inference snippet helper

### DIFF
--- a/scripts/inference-providers/scripts/generate.ts
+++ b/scripts/inference-providers/scripts/generate.ts
@@ -1,5 +1,5 @@
 import { PipelineType } from "@huggingface/tasks";
-import { PROVIDERS_HUB_ORGS } from "@huggingface/inference";
+import { PROVIDERS_HUB_ORGS, getProviderHelper } from "@huggingface/inference";
 import Handlebars from "handlebars";
 import * as fs from "node:fs/promises";
 import * as path from "node:path/posix";
@@ -478,6 +478,19 @@ await Promise.all(
   }),
 );
 
+/// A provider may serve a live model for a task that `@huggingface/inference`
+/// has no snippet helper for. Emitting an `<InferenceSnippet>` for such a combo
+/// crashes the doc-builder prerender (`getProviderHelper` throws), so we mirror
+/// that lookup here and skip any (provider, task) combo it can't handle.
+function isSnippetSupported(provider: string, task: string): boolean {
+  try {
+    getProviderHelper(provider, task);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function fetchWarmModels(
   task: PipelineType,
   conversational: boolean = false,
@@ -498,9 +511,18 @@ async function fetchWarmModels(
         ]
       : ["hf-inference", ...(PER_TASK_SUPPORTED_PROVIDERS[task] ?? [])]
   ).sort();
+  // The doc-builder resolves conversational text-generation / image-text-to-text
+  // snippets to the "conversational" helper task; mirror that here.
+  const helperTask = conversational ? "conversational" : task;
   return (
     await Promise.all(
       providers.map(async (provider) => {
+        if (!isSnippetSupported(provider, helperTask)) {
+          console.warn(
+            `   ⏭️  Skipping ${provider} for ${task}: @huggingface/inference has no snippet helper for this (provider, task) combo`,
+          );
+          return;
+        }
         console.log(
           `   ⚡ Fetching most popular warm model for ${task} from ${provider}`,
         );


### PR DESCRIPTION
## Problem

The inference-providers doc build prerenders an `<InferenceSnippet>` for every `(provider, task)` section. The doc-builder generates those snippets via `@huggingface/inference`'s `getProviderHelper(provider, task)`, which throws an `InferenceClientInputError` when the provider has no helper for that task. The uncaught error surfaces as a SvelteKit `500` and fails the whole build:

```
Failed to get provider helper for together (automatic-speech-recognition)
  InferenceClientInputError: Task 'automatic-speech-recognition' not supported for provider 'together'.
  Available tasks: text-to-image, conversational, text-generation
TypeError: Cannot read properties of undefined (reading 'length')
Error: 500 /docs/inference-providers/.../providers/together
```

This happens whenever a provider's partner API (`/api/partners/<provider>/models`) advertises a *live* model for a task that `@huggingface/inference` doesn't (yet) expose as a snippet. The generator happily emits the section, and the build crashes on it.

Concretely, the **Automatic Speech Recognition** section for `together` (model `nvidia/parakeet-tdt-0.6b-v3`) was added by the automated generator in #2507 (2026-05-28), and the **Build Inference Providers Documentation** workflow has been red on `main` every day since 2026-05-29 — and on every PR (e.g. #2526) since.

## Fix

Guard `generate.ts` so it never emits a section the doc-builder can't render. We mirror the doc-builder's exact lookup — resolving conversational `text-generation` / `image-text-to-text` to the `"conversational"` task — and skip any `(provider, task)` combo `getProviderHelper` rejects, logging each skip so the bot's CI output stays transparent.

The check lives at the single chokepoint `fetchWarmModels()`, through which all `perProviderWarmModels` (and therefore both provider pages and task pages) flow.

## Verification

Ran `npm run generate` locally — exits 0, and the guard skips exactly the unsupported combos:

```
⏭️  Skipping together for automatic-speech-recognition: ...
⏭️  Skipping together for feature-extraction / image-to-image / text-to-video: ...
⏭️  Skipping hyperbolic for image-text-to-text: ...
⏭️  Skipping hf-inference for text-to-video / image-text-to-text: ...
```

The regenerated `together.md` no longer contains the ASR section. (`hf-inference` + non-conversational `image-text-to-text` is dropped harmlessly — that snippet variant is never rendered; the task page uses the conversational one.)

## Note

This PR is **code-only**. The committed provider/task docs are owned by the automated **Update Inference Providers documentation** job — once this guard lands, the next regeneration will drop the broken sections and turn the build green. (A one-off regeneration could be committed to unblock immediately if desired.)

Split out of #2526, which is unaffected by its own changes but inherits this pre-existing breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time generator guard only; no runtime product, auth, or data-path changes.
> 
> **Overview**
> The inference-providers doc generator now **filters out** `(provider, task)` pairs that `@huggingface/inference` cannot render as snippets, using the same `getProviderHelper` lookup the doc-builder uses at prerender time.
> 
> In `fetchWarmModels()` (the chokepoint for all warm-model / snippet sections), each provider is checked via a new `isSnippetSupported()` helper before any Hub API fetch. Unsupported combos are skipped with a console warning. For conversational flows, the helper task is **`conversational`**, matching how doc-builder treats `text-generation` and `image-text-to-text` chat snippets.
> 
> This stops generated pages from including `<InferenceSnippet>` sections that would throw `InferenceClientInputError` and break the inference-providers build (e.g. `together` + automatic speech recognition).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b840cfe6d98676556ceffc02960df097607f1a93. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->