### PR TITLE
docs: surface Transformers Trainer → HF Buckets

### DIFF
--- a/docs/hub/storage-buckets-integrations.md
+++ b/docs/hub/storage-buckets-integrations.md
@@ -51,6 +51,10 @@ from datasets import load_dataset
 ds = load_dataset("buckets/username/my-bucket", data_files=["data.parquet"])
 ```
 
+## 🤗 Transformers
+
+The [`Trainer`](https://huggingface.co/docs/transformers/trainer_recipes) can push and resume training checkpoints directly to a bucket, so a run can resume on a fresh machine without keeping checkpoints in a Git repo. See the [Trainer checkpointing docs](https://huggingface.co/docs/transformers/trainer_recipes) for setup.
+
 ## Filesystem operations
 
 For direct file operations, `huggingface_hub` exposes a pre-instantiated [filesystem object](/docs/huggingface_hub/guides/hf_file_system), `hffs`:

--- a/docs/hub/storage-buckets-integrations.md
+++ b/docs/hub/storage-buckets-integrations.md
@@ -51,7 +51,7 @@ from datasets import load_dataset
 ds = load_dataset("buckets/username/my-bucket", data_files=["data.parquet"])
 ```
 
-## 🤗 Transformers
+## Transformers
 
 The [`Trainer`](https://huggingface.co/docs/transformers/trainer_recipes) can push and resume training checkpoints directly to a bucket, so a run can resume on a fresh machine without keeping checkpoints in a Git repo. See the [Trainer checkpointing docs](https://huggingface.co/docs/transformers/trainer_recipes) for setup.
 

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -335,7 +335,7 @@ hf sync ./checkpoints hf://buckets/my-org/training-run-42/checkpoints
 Because buckets are built on [Xet](./xet/index), successive checkpoints where large parts of the model are frozen benefit from chunk-level deduplication. Only the changed chunks are uploaded.
 
 > [!TIP]
-> 🤗 Transformers' [`Trainer`](https://huggingface.co/docs/transformers/trainer_recipes) can push and resume training checkpoints directly to a bucket — no manual `sync` step needed. See the Trainer docs for setup.
+> Transformers' [`Trainer`](https://huggingface.co/docs/transformers/trainer_recipes) can push and resume training checkpoints directly to a bucket — no manual `sync` step needed. See the Trainer docs for setup.
 
 ### Data processing pipelines
 

--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -334,6 +334,9 @@ hf sync ./checkpoints hf://buckets/my-org/training-run-42/checkpoints
 
 Because buckets are built on [Xet](./xet/index), successive checkpoints where large parts of the model are frozen benefit from chunk-level deduplication. Only the changed chunks are uploaded.
 
+> [!TIP]
+> 🤗 Transformers' [`Trainer`](https://huggingface.co/docs/transformers/trainer_recipes) can push and resume training checkpoints directly to a bucket — no manual `sync` step needed. See the Trainer docs for setup.
+
 ### Data processing pipelines
 
 Buckets serve as staging areas for data processing workflows. Process raw data, write intermediate outputs to a bucket, then promote the final artifact to a versioned [Dataset](./datasets) repository when the pipeline completes. This keeps your versioned repo clean while giving your pipeline fast mutable storage.


### PR DESCRIPTION
Draft — depends on huggingface/transformers#46386 ("HF Buckets integration to Trainer") being merged and its docs deploying.

## What

Surfaces the new `Trainer` → HF Buckets checkpoint support in the Hub buckets docs, so users (and other libraries) see that buckets are a first-class checkpoint store:

- `storage-buckets.md` — Tip in the **Training checkpoints and logs** use case
- `storage-buckets-integrations.md` — new **🤗 Transformers** section

Link-forward and minimal: the canonical `push_to_bucket=` snippet stays in the [transformers Trainer docs](https://huggingface.co/docs/transformers/trainer_recipes) to avoid drift while the upstream API may still change before merge.

## Pre-merge checklist

- [ ] [transformers#46386 ](https://github.com/huggingface/transformers/pull/46386) merged + docs deployed
- [ ] confirm/tighten the Trainer docs link + section anchor
- [ ] mark ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)