### PR TITLE
ci(inference-providers): bump doc-builder pin to InferenceSnippet prerender fix

### DIFF
--- a/.github/workflows/api_inference_build_documentation.yml
+++ b/.github/workflows/api_inference_build_documentation.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@6a5a6d1ecfa094768def72858d14d14e37853449  # huggingface/doc-builder#791 (InferenceSnippet prerender fix; main + 1)
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@bcff59fca682130d2e7271ca8589911b7ac0b8bf  # main
     with:
       commit_sha: ${{ github.sha }}
       package: hub-docs

--- a/.github/workflows/api_inference_build_documentation.yml
+++ b/.github/workflows/api_inference_build_documentation.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@6a5a6d1ecfa094768def72858d14d14e37853449  # huggingface/doc-builder#791 (InferenceSnippet prerender fix; main + 1)
     with:
       commit_sha: ${{ github.sha }}
       package: hub-docs

--- a/.github/workflows/api_inference_build_pr_documentation.yml
+++ b/.github/workflows/api_inference_build_pr_documentation.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@6a5a6d1ecfa094768def72858d14d14e37853449  # huggingface/doc-builder#791 (InferenceSnippet prerender fix; main + 1)
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@bcff59fca682130d2e7271ca8589911b7ac0b8bf  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/api_inference_build_pr_documentation.yml
+++ b/.github/workflows/api_inference_build_pr_documentation.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@6a5a6d1ecfa094768def72858d14d14e37853449  # huggingface/doc-builder#791 (InferenceSnippet prerender fix; main + 1)
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/api_inference_upload_pr_documentation.yml
+++ b/.github/workflows/api_inference_upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@bcff59fca682130d2e7271ca8589911b7ac0b8bf  # main
     with:
       package_name: inference-providers
     secrets:


### PR DESCRIPTION
## Why

The inference-providers doc build has been red on `main` and every PR. Root cause is a `@huggingface/inference` **version skew** between the two halves of the pipeline:

- **Generator** (CI runs `@latest` = `4.13.18`) → `together` + `automatic-speech-recognition` is supported (added in `4.13.16`), so it emits that section.
- **doc-builder kit** (lockfile-pinned `4.13.15`) → that combo is *not* supported → `getInferenceSnippets` returns `[]` → `InferenceSnippet.svelte` dereferences `clients.length` on `undefined` → `TypeError` → SvelteKit `500` → build fails on `/providers/together`.

The hub-docs generator guard (#2527) can't fix this: the generator is *ahead* of the renderer, so it correctly keeps the section while the renderer crashes. The fix had to be in doc-builder.

## What

Bump the pinned `doc-builder` ref to **`bcff59f`** (doc-builder `main`, including huggingface/doc-builder#791), which defaults `clients` to `[]` so the prerender renders an unsupported combo as empty instead of crashing the build. All three inference-providers workflows are moved together to stay in sync:

- `api_inference_build_documentation.yml` (main build)
- `api_inference_build_pr_documentation.yml` (PR build)
- `api_inference_upload_pr_documentation.yml` (upload step)

## Verification

Reproduced the exact CI crash locally (docs with the `together`/ASR section + kit resolving `@huggingface/inference@4.13.15`):

- **Before** the doc-builder fix: `TypeError: Cannot read properties of undefined (reading 'length')` → `Error: 500 /providers/together` → exit 1.
- **After**: build exit **0**, `providers/together` prerenders, no `TypeError`.

## Notes / follow-ups

- **huggingface/doc-builder#791 is merged**; all three workflows pin the resulting `main` commit `bcff59fca682130d2e7271ca8589911b7ac0b8bf`.
- With the fix but the kit still on `4.13.15`, the `together`/ASR section renders as an **empty** snippet widget. Bumping the kit's `@huggingface/inference` to a current release (which also moves `@huggingface/tasks` `^0.20.12` → `^0.21.x`) would make it render the actual snippet — a separate maintainer decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)