### PR TITLE
Sync Jobs hardware docs with huggingface_hub v1.17.0 (add rtx-pro-6000, refresh `hf jobs hardware` example)

### DIFF
--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -184,24 +184,33 @@ See the list of available `--flavor` options using the `hf jobs hardware` comman
 
 ```bash
 >>> hf jobs hardware
-NAME         PRETTY NAME            CPU      RAM     ACCELERATOR      COST/MIN COST/HOUR 
------------- ---------------------- -------- ------- ---------------- -------- --------- 
-cpu-basic    CPU Basic              2 vCPU   16 GB   N/A              $0.0002  $0.01     
-cpu-upgrade  CPU Upgrade            8 vCPU   32 GB   N/A              $0.0005  $0.03     
-t4-small     Nvidia T4 - small      4 vCPU   15 GB   1x T4 (16 GB)    $0.0067  $0.40     
-t4-medium    Nvidia T4 - medium     8 vCPU   30 GB   1x T4 (16 GB)    $0.0100  $0.60     
-a10g-small   Nvidia A10G - small    4 vCPU   15 GB   1x A10G (24 GB)  $0.0167  $1.00     
-a10g-large   Nvidia A10G - large    12 vCPU  46 GB   1x A10G (24 GB)  $0.0250  $1.50     
-a10g-largex2 2x Nvidia A10G - large 24 vCPU  92 GB   2x A10G (48 GB)  $0.0500  $3.00     
-a10g-largex4 4x Nvidia A10G - large 48 vCPU  184 GB  4x A10G (96 GB)  $0.0833  $5.00     
-a100-large   Nvidia A100 - large    12 vCPU  142 GB  1x A100 (80 GB)  $0.0417  $2.50     
-a100x4       4x Nvidia A100         48 vCPU  568 GB  4x A100 (320 GB) $0.1667  $10.00    
-a100x8       8x Nvidia A100         96 vCPU  1136 GB 8x A100 (640 GB) $0.3333  $20.00    
-l4x1         1x Nvidia L4           8 vCPU   30 GB   1x L4 (24 GB)    $0.0133  $0.80     
-l4x4         4x Nvidia L4           48 vCPU  186 GB  4x L4 (96 GB)    $0.0633  $3.80     
-l40sx1       1x Nvidia L40S         8 vCPU   62 GB   1x L40S (48 GB)  $0.0300  $1.80     
-l40sx4       4x Nvidia L40S         48 vCPU  382 GB  4x L40S (192 GB) $0.1383  $8.30     
-l40sx8       8x Nvidia L40S         192 vCPU 1534 GB 8x L40S (384 GB) $0.3917  $23.50
+name             pretty name             cpu       ram      storage   accelerator               cost/min  cost/hour
+cpu-basic        CPU Basic               2 vCPU    16 GB    50 GB                               $0.0002   $0.01
+cpu-upgrade      CPU Upgrade             8 vCPU    32 GB    50 GB                               $0.0005   $0.03
+cpu-performance  CPU Performance         32 vCPU   256 GB   1024 GB                             $0.0317   $1.90
+cpu-xl           CPU XL                  16 vCPU   124 GB   1000 GB                             $0.0167   $1.00
+t4-small         Nvidia T4 - small       4 vCPU    15 GB    50 GB     1x T4 (16 GB)             $0.0067   $0.40
+t4-medium        Nvidia T4 - medium      8 vCPU    30 GB    100 GB    1x T4 (16 GB)             $0.0100   $0.60
+a10g-small       Nvidia A10G - small     4 vCPU    15 GB    110 GB    1x A10G (24 GB)           $0.0167   $1.00
+a10g-large       Nvidia A10G - large     12 vCPU   46 GB    200 GB    1x A10G (24 GB)           $0.0250   $1.50
+a10g-largex2     2x Nvidia A10G - large  24 vCPU   92 GB    1000 GB   2x A10G (48 GB)           $0.0500   $3.00
+a10g-largex4     4x Nvidia A10G - large  48 vCPU   184 GB   2000 GB   4x A10G (96 GB)           $0.0833   $5.00
+a100-large       Nvidia A100 - large     12 vCPU   142 GB   1000 GB   1x A100 (80 GB)           $0.0417   $2.50
+a100x4           4x Nvidia A100          48 vCPU   568 GB   4000 GB   4x A100 (320 GB)          $0.1667   $10.00
+a100x8           8x Nvidia A100          96 vCPU   1136 GB  8000 GB   8x A100 (640 GB)          $0.3333   $20.00
+h200             Nvidia H200             23 vCPU   256 GB   3000 GB   1x H200 (141 GB)          $0.0833   $5.00
+h200x2           Nvidia H200             46 vCPU   512 GB   6000 GB   2x H200 (282 GB)          $0.1667   $10.00
+h200x4           Nvidia H200             92 vCPU   1024 GB  12000 GB  4x H200 (564 GB)          $0.3333   $20.00
+h200x8           Nvidia H200             184 vCPU  2048 GB  24000 GB  8x H200 (1128 GB)         $0.6667   $40.00
+rtx-pro-6000     Nvidia RTX PRO 6000     23 vCPU   256 GB   475 GB    1x RTX PRO 6000 (96 GB)   $0.0458   $2.75
+rtx-pro-6000x2   Nvidia RTX PRO 6000     46 vCPU   512 GB   950 GB    2x RTX PRO 6000 (192 GB)  $0.0917   $5.50
+rtx-pro-6000x4   Nvidia RTX PRO 6000     92 vCPU   1024 GB  1900 GB   4x RTX PRO 6000 (384 GB)  $0.1833   $11.00
+rtx-pro-6000x8   Nvidia RTX PRO 6000     184 vCPU  2048 GB  3800 GB   8x RTX PRO 6000 (768 GB)  $0.3667   $22.00
+l4x1             1x Nvidia L4            8 vCPU    30 GB    400 GB    1x L4 (24 GB)             $0.0133   $0.80
+l4x4             4x Nvidia L4            48 vCPU   186 GB   3200 GB   4x L4 (96 GB)             $0.0633   $3.80
+l40sx1           1x Nvidia L40S          8 vCPU    62 GB    380 GB    1x L40S (48 GB)           $0.0300   $1.80
+l40sx4           4x Nvidia L40S          48 vCPU   382 GB   3200 GB   4x L40S (192 GB)          $0.1383   $8.30
+l40sx8           8x Nvidia L40S          192 vCPU  1534 GB  6500 GB   8x L40S (384 GB)          $0.3917   $23.50
 ```
 
 ## Timeout

--- a/docs/hub/jobs-pricing.md
+++ b/docs/hub/jobs-pricing.md
@@ -48,6 +48,10 @@ Jobs are billed per minute based on the hardware used. Below are the available h
 | 2x Nvidia H200         | 46 vCPU       | 512 GB       | 282 GB          | 6000 GB               | $10.00            |
 | 4x Nvidia H200         | 92 vCPU       | 1024 GB      | 564 GB          | 12000 GB              | $20.00            |
 | 8x Nvidia H200         | 184 vCPU      | 2048 GB      | 1128 GB         | 24000 GB              | $40.00            |
+| Nvidia RTX PRO 6000    | 23 vCPU       | 256 GB       | 96 GB           | 475 GB                | $2.75             |
+| 2x Nvidia RTX PRO 6000 | 46 vCPU       | 512 GB       | 192 GB          | 950 GB                | $5.50             |
+| 4x Nvidia RTX PRO 6000 | 92 vCPU       | 1024 GB      | 384 GB          | 1900 GB               | $11.00            |
+| 8x Nvidia RTX PRO 6000 | 184 vCPU      | 2048 GB      | 768 GB          | 3800 GB               | $22.00            |
 
 You can also retrieve available hardware and pricing programmatically via the API at `GET /api/jobs/hardware` or via the CLI:
 


### PR DESCRIPTION
## What

Two Jobs hardware doc fixes to match huggingface_hub **v1.17.0**:

- **`jobs-pricing.md`** — add the new **RTX PRO 6000** flavors (`rtx-pro-6000`,
  `x2`, `x4`, `x8`) to the GPU pricing table. These landed in v1.17.0
  (huggingface/huggingface_hub#4259) and weren't yet documented here.
- **`jobs-configuration.md`** — regenerate the `hf jobs hardware` example, which
  had drifted from the real CLI output.

## Why the example block looks different

The `hf jobs hardware` example hadn't been refreshed in a while and the CLI
output format has since changed. The new block reflects what the command prints
today:

- **lowercase** column headers (`name  pretty name  cpu  ram  storage  accelerator  cost/min  cost/hour`)
- a new **`storage`** column (ephemeral disk per flavor)
- a **blank** accelerator cell for CPU flavors (was `N/A`)

It also adds flavors that were missing from the old paste: `cpu-xl`,
`cpu-performance`, the `h200` family, and the new `rtx-pro-6000` family.

> I went with the verbatim CLI output here, but I could just as easily keep the
> previous uppercase heading style if that reads better. Matching the real output
> (and the auto-generated table in the huggingface_hub guide) should be a bit
> easier to keep in sync as flavors change — happy to switch if reviewers prefer
> the old look.

## Verification

All specs/prices come from `GET /api/jobs/hardware`. I confirmed the
**unauthenticated** response is identical to the authenticated CLI (same 26
flavors), so this documents only publicly-available hardware — no internal/beta
flavors. This also brings hub-docs in line with the auto-generated table in the
huggingface_hub guide (`docs/source/en/guides/jobs.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to pricing tables and a CLI example; no runtime, auth, or billing code changes.
> 
> **Overview**
> Updates Hub Jobs documentation to match **huggingface_hub v1.17.0** hardware and current `hf jobs hardware` CLI output.
> 
> **`jobs-pricing.md`** adds four **Nvidia RTX PRO 6000** GPU tiers (`rtx-pro-6000` through `x8`) with CPU, memory, GPU memory, ephemeral storage, and hourly pricing.
> 
> **`jobs-configuration.md`** replaces the stale `hf jobs hardware` example with verbatim CLI output: lowercase headers, a **`storage`** column, blank accelerator cells for CPU flavors (instead of `N/A`), and flavors that were missing before (`cpu-xl`, `cpu-performance`, **H200** family, **RTX PRO 6000** family), plus refreshed specs/storage for existing rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 952a9f503f1699eee654d796398ffe4317f1549a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->