### PR TITLE
Document `hf spaces ssh` in the Spaces Dev Mode guide

### DIFF
--- a/docs/hub/spaces-dev-mode.md
+++ b/docs/hub/spaces-dev-mode.md
@@ -55,6 +55,21 @@ from huggingface_hub import HfApi
 print(HfApi().space_info("namespace/repo").subdomain)
 ```
 
+The Hugging Face CLI can resolve the subdomain and open the session for you:
+
+```shell
+# SSH into the Space's Dev Mode container
+hf spaces ssh username/my-space
+
+# Print the SSH command instead of running it
+hf spaces ssh username/my-space --dry-run
+
+# Use a specific identity file
+hf spaces ssh username/my-space -i ~/.ssh/id_ed25519
+```
+
+Pass `--auto` to enable Dev Mode without prompting if it isn't already running. See the [`hf spaces ssh` CLI reference](https://huggingface.co/docs/huggingface_hub/package_reference/cli#hf-spaces-ssh) for the full list of options.
+
 You will need to add your machine's SSH public key to [your user account](https://huggingface.co/settings/keys) to be able to connect to the Space using SSH.
 Check out the [Git over SSH](./security-git-ssh#add-a-ssh-key-to-your-account) documentation for more detailed instructions.
 


### PR DESCRIPTION
## What

Adds the `hf spaces ssh` CLI command to the SSH section of the Spaces Dev Mode
guide. It resolves the Space subdomain and opens the session for you — a
shortcut to the existing manual `ssh <subdomain>@ssh.hf.space` flow.

Examples added: basic connect, `--dry-run` (print the command instead of
connecting), `-i` (identity file), and an `--auto` note (enable Dev Mode without
prompting), plus a link to the `hf spaces ssh` CLI reference (the page didn't
previously link to the CLI docs). The existing "register your SSH public key at
/settings/keys" line already covers the prerequisite for both the manual and CLI
paths.

Added in huggingface_hub v1.17.0 (huggingface/huggingface_hub#4241).

## Verified against live v1.17.0

- `--dry-run` prints `ssh <namespace>-<repo>@ssh.hf.space` — matches the
  subdomain form already documented above it
- `--auto` enables Dev Mode without prompting
- Dev Mode off → prompts to enable, aborts safely if declined
- nonexistent Space → clean error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> The Spaces Dev Mode guide’s SSH section now documents **`hf spaces ssh`** as a shortcut that resolves the Space subdomain and opens the session, alongside the existing manual `ssh <subdomain>@ssh.hf.space` flow.
> 
> New shell examples cover basic connect, **`--dry-run`**, **`-i`** for an identity file, and a note on **`--auto`** to enable Dev Mode without prompting. A link to the **`hf spaces ssh`** CLI reference was added; prerequisite SSH key setup is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4907909530865652f6558e124cb9b41249ef7733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->