### PR TITLE
Fix plugin install command in agents-cli.md

### DIFF
--- a/docs/hub/agents-cli.md
+++ b/docs/hub/agents-cli.md
@@ -37,7 +37,7 @@ Alternatively, you can install via the Claude Code plugin system:
 ```bash
 claude
 /plugin marketplace add huggingface/skills
-/plugin install hf-cli@huggingface/skills
+/plugin install hf-cli@huggingface-skills
 ```
 
 ## Resources


### PR DESCRIPTION
The Claude Code install instructions have a typo in the marketplace name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only one-line fix with no runtime or security impact.
> 
> **Overview**
> Corrects the Claude Code **plugin install** example in `agents-cli.md` so the `hf-cli` skill is installed from **`huggingface-skills`** instead of **`huggingface/skills`**.
> 
> The marketplace add step (`huggingface/skills`) is unchanged; only the install line’s plugin identifier is fixed so copy-paste install instructions work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d10bdb789f90d468d20cc9c15d06a07d5f97f4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->