### PR TITLE
Fix skill name in agents-skills.md

### DIFF
--- a/docs/hub/agents-skills.md
+++ b/docs/hub/agents-skills.md
@@ -18,7 +18,7 @@ Skills work with all major coding agents: Claude Code, OpenAI Codex, Google Gemi
 /plugin marketplace add huggingface/skills
 
 # install a specific Skill
-/plugin install <skill-name>@huggingface/skills
+/plugin install <skill-name>@huggingface-skills
 ```
 
 </hfoption>
@@ -60,7 +60,7 @@ Install via the Cursor plugin flow using the [repository URL](https://github.com
 | [`huggingface-papers`](https://github.com/huggingface/skills/tree/main/skills/huggingface-papers) | Look up and read Hugging Face paper pages in markdown |
 | [`huggingface-paper-publisher`](https://github.com/huggingface/skills/tree/main/skills/huggingface-paper-publisher) | Publish and manage research papers on the Hub |
 | [`huggingface-tool-builder`](https://github.com/huggingface/skills/tree/main/skills/huggingface-tool-builder) | Build reusable scripts for HF API operations |
-| [`gradio`](https://github.com/huggingface/skills/tree/main/skills/huggingface-gradio) | Build Gradio web UIs and demos |
+| [`huggingface-gradio`](https://github.com/huggingface/skills/tree/main/skills/huggingface-gradio) | Build Gradio web UIs and demos |
 | [`transformers-js`](https://github.com/huggingface/skills/tree/main/skills/transformers-js) | Run ML models in JavaScript/TypeScript with WebGPU/WASM |
 
 ## Using Skills


### PR DESCRIPTION
This PR updates the documentation to fix the naming of the `huggingface-gradio` plugin and installation process for Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or security impact.
> 
> **Overview**
> Updates **`docs/hub/agents-skills.md`** so Claude Code install examples use `/plugin install <skill-name>@huggingface-skills` instead of `@huggingface/skills`.
> 
> In the Available Skills table, the Gradio skill is labeled **`huggingface-gradio`** (matching its repo path) rather than **`gradio`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9d119f722b38fcf880f2bd13ecf079c802c81d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->