### PR TITLE
Docs: Inspect AI → Storage Buckets eval-log integration

### DIFF
--- a/docs/hub/eval-results.md
+++ b/docs/hub/eval-results.md
@@ -70,7 +70,7 @@ Anyone can submit evaluation results to any model via Pull Request:
 3. Add a `.eval_results/*.yaml` file with your results.
 4. The PR will show as "community-provided" on the model page while open.
 
-For help evaluating a model, see the [Evaluating models with Inspect](https://huggingface.co/docs/inference-providers/guides/evaluation-inspect-ai) guide.
+For help evaluating a model, see the [Evaluating models with Inspect](https://huggingface.co/docs/inference-providers/guides/evaluation-inspect-ai) guide. Evaluation logs from Inspect can be written directly to [HF Storage Buckets](./storage-buckets-integrations#inspect-ai).
 
 > [!TIP]
 > Community scores are visible while the PR is open. If a score is disputed, the model author can close the PR to remove it. The goal is to surface existing evaluation data transparently while building toward a fully reproducible standard via verified scores.

--- a/docs/hub/storage-buckets-integrations.md
+++ b/docs/hub/storage-buckets-integrations.md
@@ -53,11 +53,13 @@ ds = load_dataset("buckets/username/my-bucket", data_files=["data.parquet"])
 
 ## Inspect AI
 
-[Inspect AI](https://inspect.aisi.org.uk/) can write evaluation logs directly to a bucket — point its log directory at an `hf://buckets/` path (requires `huggingface_hub>=1.6.0`):
+[Inspect AI](https://inspect.aisi.org.uk/) can write evaluation logs directly to a bucket — point its log directory at an `hf://buckets/` path (requires `huggingface_hub>=1.6.0`). Create the bucket and authenticate first (Inspect won't create it for you):
 
 ```bash
-export INSPECT_LOG_DIR=hf://buckets/username/my-bucket/eval-logs
+hf auth login
+hf buckets create username/my-bucket --private
 
+export INSPECT_LOG_DIR=hf://buckets/username/my-bucket/eval-logs
 inspect eval popularity.py --model openai/gpt-4
 inspect view
 ```

--- a/docs/hub/storage-buckets-integrations.md
+++ b/docs/hub/storage-buckets-integrations.md
@@ -51,6 +51,19 @@ from datasets import load_dataset
 ds = load_dataset("buckets/username/my-bucket", data_files=["data.parquet"])
 ```
 
+## Inspect AI
+
+[Inspect AI](https://inspect.aisi.org.uk/) can write evaluation logs directly to a bucket — point its log directory at an `hf://buckets/` path (requires `huggingface_hub>=1.6.0`):
+
+```bash
+export INSPECT_LOG_DIR=hf://buckets/username/my-bucket/eval-logs
+
+inspect eval popularity.py --model openai/gpt-4
+inspect view
+```
+
+See [Inspect's eval logs guide](https://inspect.aisi.org.uk/eval-logs.html#sec-hugging-face-storage-buckets) for details.
+
 ## Filesystem operations
 
 For direct file operations, `huggingface_hub` exposes a pre-instantiated [filesystem object](/docs/huggingface_hub/guides/hf_file_system), `hffs`:


### PR DESCRIPTION
## What

Documents the new [Inspect AI](https://inspect.aisi.org.uk/) → Hugging Face Storage Buckets integration. Inspect can now write eval logs directly to buckets via `hf://buckets/<owner>/<bucket>/<path>` fsspec paths, added in [`inspect_ai#4155`](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4155) (merged, commit `8165dd20`).

- **`storage-buckets-integrations.md`** — adds a terse `## Inspect AI` section matching the existing per-tool pattern (set `INSPECT_LOG_DIR` to an `hf://buckets/` path; `inspect eval` / `inspect view`).
- **`eval-results.md`** — one-line cross-link so the bucket log target is discoverable from the eval docs.

## Why draft

The "See Inspect's eval logs guide" link deep-links to `eval-logs.html#sec-hugging-face-storage-buckets`. That section is currently in Inspect's `## Unreleased` changelog and not yet on the published docs site — the anchor will resolve once Inspect ships a release including it. Holding as **draft** until then; will mark ready for review once the upstream section is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-handling code.
> 
> **Overview**
> Documents **Inspect AI** writing evaluation logs to Hugging Face Storage Buckets via `hf://buckets/` paths.
> 
> **`storage-buckets-integrations.md`** adds an **Inspect AI** section (same style as pandas/Datasets): auth and bucket setup, set `INSPECT_LOG_DIR`, then `inspect eval` / `inspect view`; notes `huggingface_hub>=1.6.0` and that Inspect does not create buckets.
> 
> **`eval-results.md`** extends the existing Inspect evaluation guide link with a one-line pointer to that bucket integration anchor for community eval workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b1aa58684f191cd1614a5e71b45f1cbc3129782. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->