### PR TITLE
docs(sso): note OIDC client_secret_post token endpoint auth method

### DIFF
--- a/docs/hub/security-sso-configuration-guides.md
+++ b/docs/hub/security-sso-configuration-guides.md
@@ -8,6 +8,9 @@ These guides help you configure SAML 2.0 and OpenID Connect (OIDC) with your Ide
 > [!NOTE]
 > If you are looking to set up [Managed SSO](./enterprise-advanced-sso), the configuration is done in collaboration with the Hugging Face team. Please <a href="https://huggingface.co/contact/sales?from=enterprise" target="_blank">contact us</a> to get started.
 
+> [!TIP]
+> **OIDC token endpoint authentication method.** When exchanging the authorization code, Hugging Face authenticates to your Identity Provider's token endpoint using the `client_secret_post` method. If your IdP application is configured to expect a different method (such as `client_secret_basic`), the login will fail with an `invalid_client` error. To resolve this, set your IdP application's token endpoint authentication method to `client_secret_post`.
+
 ## Okta
 
 - [How to configure OIDC with Okta](./security-sso-okta-oidc)


### PR DESCRIPTION
Document that Hugging Face authenticates to the IdP token endpoint using client_secret_post by default, and that IdP apps expecting a different method fail with invalid_client. Helps customers resolve OIDC SSO login failures on the IdP side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security logic impact.
> 
> **Overview**
> Adds a **TIP** callout to the SSO configuration guides index explaining that Hugging Face uses **`client_secret_post`** when calling the IdP token endpoint during the authorization code exchange.
> 
> It notes that IdP apps set to another method (e.g. **`client_secret_basic`**) can fail with **`invalid_client`**, and directs admins to set token endpoint authentication to **`client_secret_post`** on the IdP side.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a9c4d8532630bd1162fb69e167f74896b7a3100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->