### PR TITLE
docs: you can block a user without reporting them

### DIFF
--- a/docs/hub/moderation.md
+++ b/docs/hub/moderation.md
@@ -29,8 +29,8 @@ Blocking a user prevents them from interacting with your repositories and other 
 
 There are two ways to block a user from a discussion comment:
 
-- **Directly from the comment menu** — click the three dots at the top right of a comment written by someone else and select **"Block @username"**. You will be asked to confirm before the block is applied.
 - **From the report modal** — select "Report" from the comment's menu, fill in your reason, and check **"Yes, block this user"** before submitting. Use this option if you also want to report the comment to the Hugging Face moderation team. 
+- **Directly from the comment menu** — click the three dots at the top right of a comment written by someone else and select **"Block @username"**. You will be asked to confirm before the block is applied.
 
 > [!NOTE]
 > You must have a confirmed email address on your account to block users.

--- a/docs/hub/moderation.md
+++ b/docs/hub/moderation.md
@@ -16,7 +16,7 @@ To report a repository, you can click the three dots at the top right of a repos
 
 To report a comment, click the three dots at the top right of a comment and select "Report". A modal will appear where you can describe the reason for your report — this will be reviewed by the Hugging Face moderation team.
 
-While submitting the report, you also have the option to **block the comment author** at the same time (see [Blocking a user](#blocking-a-user) below).
+While submitting the report, you also have the option to **block the comment author** at the same time. You can also block a user directly from the comment menu without filing a report — see [Blocking a user](#blocking-a-user) below.
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/comment-report.png"/>
@@ -27,7 +27,10 @@ While submitting the report, you also have the option to **block the comment aut
 
 Blocking a user prevents them from interacting with your repositories and other Hub content. When you block someone, any existing follow relationship between you and that user is also removed.
 
-You can block a user from the [comment report modal](#reporting-a-comment). Select "Report" from the comment's menu, fill in your reason, and check **"Yes, block this user"** before submitting.
+There are two ways to block a user from a discussion comment:
+
+- **Directly from the comment menu** — click the three dots at the top right of a comment written by someone else and select **"Block @username"**. You will be asked to confirm before the block is applied.
+- **From the report modal** — select "Report" from the comment's menu, fill in your reason, and check **"Yes, block this user"** before submitting. Use this option if you also want to report the comment to the Hugging Face moderation team. 
 
 > [!NOTE]
 > You must have a confirmed email address on your account to block users.


### PR DESCRIPTION
Change was merged a few weeks ago but forgot to update the docs. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates Hub **moderation** docs to match shipped behavior: users can **block someone from a discussion comment without filing a report**.
> 
> The **Reporting a comment** section now notes that blocking can happen during a report or on its own via the comment menu. **Blocking a user** is rewritten as two paths—block while reporting through the modal, or use **Block @username** from another user’s comment menu (with confirmation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8483fbccdac6049ffd6e87d745a2fa7104c1f078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->