### PR TITLE
docs: resource group auto-join scope

### DIFF
--- a/docs/hub/programmatic-user-access-control.md
+++ b/docs/hub/programmatic-user-access-control.md
@@ -422,7 +422,7 @@ For a long list of usernames, chunk them (e.g. 50 per request) and call the API 
 
 ## Configure auto-join via API
 
-[Auto-join](./security-resource-groups#auto-join) automatically adds every org member to a Resource Group at a specified role. You can enable or disable it via the API.
+[Auto-join](./security-resource-groups#auto-join) automatically adds org members to a Resource Group at a specified role. You can enable or disable it via the API, and optionally choose whether to include every org member or only Read+ members.
 
 **Enable auto-join**
 
@@ -434,7 +434,8 @@ Content-Type: application/json
 {
   "autoJoin": {
     "enabled": true,
-    "role": "read"
+    "role": "read",
+    "scope": "read_plus"
   }
 }
 ```
@@ -443,9 +444,10 @@ Content-Type: application/json
   - `org_name`: Organization slug (e.g. `my-org`).
   - `resource_group_id`: The Resource Group's ID (24-character hex string; get IDs from the [list resource groups endpoint](#list-resource-groups)).
 - **Body**
-  - `role`: The role to assign to all org members. One of `"read"`, `"contributor"`, `"write"`, or `"admin"`.
+  - `role`: The role to assign to automatically added members. One of `"read"`, `"contributor"`, `"write"`, or `"admin"`.
+  - `scope` (optional): Which org members to add automatically. Use `"all"` to include every org member. Use `"read_plus"` to exclude members with the `no_access` organization role. Defaults to `"all"` when omitted.
 
-Enabling auto-join on an existing Resource Group immediately adds all current org members (backfill).
+Enabling auto-join on an existing Resource Group immediately adds current org members matching the selected scope (backfill).
 
 **Disable auto-join**
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -54,7 +54,7 @@ Remember that a repository can be part of only one Resource Group. You'll be war
 
 ## Auto-join
 
-Auto-join automatically adds **org member** to a Resource Group at a specified role — both members who are already in the org when auto-join is enabled, and any new members who join in the future.
+Auto-join automatically adds **org members** to a Resource Group at a specified role — both members who are already in the org when auto-join is enabled, and any new members who join in the future.
 
 This is useful for Resource Groups that should be accessible to your entire organization without requiring manual membership management.
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -54,21 +54,30 @@ Remember that a repository can be part of only one Resource Group. You'll be war
 
 ## Auto-join
 
-Auto-join automatically adds **every org member** to a Resource Group at a specified role — both members who are already in the org when auto-join is enabled, and any new members who join in the future.
+Auto-join automatically adds **org member** to a Resource Group at a specified role — both members who are already in the org when auto-join is enabled, and any new members who join in the future.
 
 This is useful for Resource Groups that should be accessible to your entire organization without requiring manual membership management.
 
 ### Enabling auto-join
 
-**Via the UI**: Open the Resource Group's settings page and check the **Include all org members** option, then select the role to assign.
+**Via the UI**: Open the Resource Group's settings page and check the **Auto-include org members** option, then select the role to assign.
 
 **Via the API**: See [Configure auto-join via API](./programmatic-user-access-control#configure-auto-join-via-api).
 
-When auto-join is enabled on an existing Resource Group, all current org members are **immediately added** to the group at the configured role (backfill).
+When auto-join is enabled on an existing Resource Group, current org members matching the selected scope are **immediately added** to the group at the configured role (backfill).
+
+### Auto-join scope
+
+Auto-join can apply to:
+
+- **All org members**: Include every member, including members with the `no_access` organization role.
+- **Read+ members only**: Exclude members with the `no_access` organization role.
+
+Use **Read+ members only** when `no_access` members should keep access only to the specific Resource Groups where they are added manually or through another provisioning flow.
 
 ### Auto-join and SCIM
 
-Auto-join and SCIM management are **mutually exclusive** on the same Resource Group. Auto-join adds every org member automatically; SCIM management means only the IdP controls membership. These two behaviors conflict, so:
+Auto-join and SCIM management are **mutually exclusive** on the same Resource Group. Auto-join adds org members automatically; SCIM management means only the IdP controls membership. These two behaviors conflict, so:
 
 - You cannot enable auto-join on a Resource Group that is linked to a SCIM group.
 - You cannot link a SCIM group to a Resource Group that has auto-join enabled.


### PR DESCRIPTION
This PR document the new resource group auto-join scope option.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime, API, or security behavior changes in this PR.
> 
> **Overview**
> Documents the new **resource group auto-join scope** so admins can limit automatic membership instead of always including every org member.
> 
> **`security-resource-groups.md`** adds an **Auto-join scope** section (`all` vs **Read+ members only**, excluding `no_access`), renames the UI control to **Auto-include org members**, and updates backfill/SCIM wording to refer to scoped members rather than “every” member.
> 
> **`programmatic-user-access-control.md`** documents the optional `autoJoin.scope` field (`"all"` or `"read_plus"`, default `"all"`) in the settings API example and body reference, and aligns backfill language with the chosen scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a85582e28a63ccca999449b6b70af50a0ec4b239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->