### PR TITLE
Add pricing information for exposed ports in Jobs

### DIFF
--- a/docs/hub/jobs-pricing.md
+++ b/docs/hub/jobs-pricing.md
@@ -59,6 +59,16 @@ You can also retrieve available hardware and pricing programmatically via the AP
 >>> hf jobs hardware
 ```
 
+### Exposed ports
+
+A Job can expose a port to make it reachable from the outside while it is running. Exposing a port is billed at a flat rate per Job, in addition to the hardware price:
+
+| **Product**            | **Hourly Price**  |
+|----------------------- | ----------------- |
+| Exposed port           | $0.01             |
+
+Like hardware, it is billed by the minute, only while the Job is Starting or Running.
+
 ## Manage billing
 
 ### Bill to your organization

--- a/docs/hub/jobs-pricing.md
+++ b/docs/hub/jobs-pricing.md
@@ -61,11 +61,11 @@ You can also retrieve available hardware and pricing programmatically via the AP
 
 ### Exposed ports
 
-A Job can expose a port to make it reachable from the outside while it is running. Exposing a port is billed at a flat rate per Job, in addition to the hardware price:
+A Job can [expose one or more ports](./jobs-configuration#docker-jobs) to make them reachable from the outside while the Job is running. Exposing one or more ports is billed at a flat rate per Job, in addition to the hardware price:
 
-| **Product**            | **Hourly Price**  |
-|----------------------- | ----------------- |
-| Exposed port           | $0.01             |
+| **Product**   | **Hourly Price**  |
+|---------------| ----------------- |
+| Exposed ports | $0.01             |
 
 Like hardware, it is billed by the minute, only while the Job is Starting or Running.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only update to jobs pricing; no code or billing logic changes.
> 
> **Overview**
> Documents **exposed ports** billing for Hugging Face Jobs in the pricing guide.
> 
> Adds an **Exposed ports** subsection: port exposure is a **flat $0.01/hour per Job** on top of hardware, billed **by the minute** only while the Job is **Starting** or **Running**, with a link to Docker Jobs configuration for how ports are exposed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee08a02f5cc80a7e475c61ebfe23a911c77815c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->