### PR TITLE
Enterpise service accounts

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -21,6 +21,8 @@
     title: Advanced Security
   - local: enterprise-tokens-management
     title: Tokens Management
+  - local: enterprise-service-accounts
+    title: Service Accounts
   - local: publisher-analytics
     title: Publisher Analytics
   - local: enterprise-gating-group-collections

--- a/docs/hub/enterprise-service-accounts.md
+++ b/docs/hub/enterprise-service-accounts.md
@@ -1,7 +1,7 @@
 # Service Accounts
 
 > [!WARNING]
-> This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
+> This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> and <a href="https://huggingface.co/contact/sales?from=enterprise" target="_blank">Enterprise Plus</a> plans.
 
 Service accounts are organization-owned identities designed for programmatic access to your organization's resources, such as CI/CD pipelines, automation scripts, and backend integrations. Unlike a personal member account, a service account is not tied to an individual person: it belongs to the organization and is managed by its administrators.
 

--- a/docs/hub/enterprise-service-accounts.md
+++ b/docs/hub/enterprise-service-accounts.md
@@ -21,7 +21,7 @@ When creating a service account, you provide:
 - A **name** to identify the service account.
 - An optional **description** to document what the service account is used for.
 
-Service accounts do not have a password and cannot sign in interactively — they are accessed exclusively through the access tokens you issue for them. They are also hidden from the organization's public member list and are managed only from the **Service Accounts** settings, not from the **Members** settings.
+Service accounts do not have a password and cannot sign in interactively — they are accessed exclusively through the access tokens you issue for them. Unlike regular users, they also don't have an HF profile page, aren't part of the organization's member list, and are managed only through the **Service Accounts** settings.
 
 ## Managing Access Tokens
 
@@ -44,4 +44,4 @@ From the service account's page, administrators can:
 
 ## Billing
 
-Service accounts are not counted as billable members of your organization, so creating them does not consume a paid seat in your subscription.
+Service accounts are not counted as billable members of your organization, so creating them does not consume a paid seat in your plan.

--- a/docs/hub/enterprise-service-accounts.md
+++ b/docs/hub/enterprise-service-accounts.md
@@ -11,6 +11,11 @@ Because a service account is decoupled from any individual, it keeps automated w
 
 As an organization administrator, go to the **Service Accounts** section of your organization settings to create and manage service accounts.
 
+<div class="flex justify-center">
+  <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/service-account-create.png" alt="Creating a new service account from the organization settings."/>
+  <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/dark-service-account-create.png" alt="Creating a new service account from the organization settings."/>
+</div>
+
 When creating a service account, you provide:
 
 - A **name** to identify the service account.
@@ -21,6 +26,11 @@ Service accounts do not have a password and cannot sign in interactively — the
 ## Managing Access Tokens
 
 A service account's access to your organization is defined entirely by the fine-grained access tokens you issue to it. For each token, you choose a name and a set of fine-grained permissions, so you can grant only the access a given workflow needs.
+
+<div class="flex justify-center">
+  <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/service-account-create-token.png" alt="Creating a new access token with fine-grained permissions for a service account."/>
+  <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/dark-service-account-create-token.png" alt="Creating a new access token with fine-grained permissions for a service account."/>
+</div>
 
 From the service account's page, administrators can:
 

--- a/docs/hub/enterprise-service-accounts.md
+++ b/docs/hub/enterprise-service-accounts.md
@@ -1,0 +1,37 @@
+# Service Accounts
+
+> [!WARNING]
+> This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
+
+Service accounts are organization-owned identities designed for programmatic access to your organization's resources, such as CI/CD pipelines, automation scripts, and backend integrations. Unlike a personal member account, a service account is not tied to an individual person: it belongs to the organization and is managed by its administrators.
+
+Because a service account is decoupled from any individual, it keeps automated workflows running even as people join or leave the organization, and it lets you scope and rotate credentials without affecting any member's personal tokens.
+
+## Creating a Service Account
+
+As an organization administrator, go to the **Service Accounts** section of your organization settings to create and manage service accounts.
+
+When creating a service account, you provide:
+
+- A **name** to identify the service account.
+- An optional **description** to document what the service account is used for.
+
+Service accounts do not have a password and cannot sign in interactively — they are accessed exclusively through the access tokens you issue for them. They are also hidden from the organization's public member list and are managed only from the **Service Accounts** settings, not from the **Members** settings.
+
+## Managing Access Tokens
+
+A service account's access to your organization is defined entirely by the fine-grained access tokens you issue to it. For each token, you choose a name and a set of fine-grained permissions, so you can grant only the access a given workflow needs.
+
+From the service account's page, administrators can:
+
+- **Create** a new access token with a chosen name and fine-grained permissions.
+- **Update** an existing token's name or permissions.
+- **Rotate** a token to replace it with a new value. The previous token stops working immediately, which is useful if a credential may have been exposed.
+- **Delete** a token to permanently revoke its access.
+
+> [!WARNING]
+> An access token is only displayed once, at the time it is created or rotated. Store it securely — it cannot be retrieved later. If you lose it, rotate the token to generate a new value.
+
+## Billing
+
+Service accounts are not counted as billable members of your organization, so creating them does not consume a paid seat in your subscription.

--- a/docs/hub/enterprise-tokens-management.md
+++ b/docs/hub/enterprise-tokens-management.md
@@ -121,3 +121,7 @@ An administrator cannot revoke their own token (`LEAKED_HF_TOKEN` cannot have th
 ## Programmatic Token Issuance
 
 For organizations that need to programmatically issue access tokens for their members (e.g., for internal platforms, CI/CD pipelines, or custom integrations), see [OAuth Token Exchange](./oauth#token-exchange-for-organizations-rfc-8693). This Enterprise plan feature allows your backend services to issue scoped tokens for organization members without requiring interactive user consent.
+
+## Service Accounts
+
+For automated access that is owned by the organization rather than an individual member, administrators can create [Service Accounts](./enterprise-service-accounts) and issue fine-grained tokens scoped to your organization's resources.

--- a/docs/hub/enterprise-tokens-management.md
+++ b/docs/hub/enterprise-tokens-management.md
@@ -120,8 +120,14 @@ An administrator cannot revoke their own token (`LEAKED_HF_TOKEN` cannot have th
 
 ## Programmatic Token Issuance
 
+> [!WARNING]
+> This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> plan and above.
+
 For organizations that need to programmatically issue access tokens for their members (e.g., for internal platforms, CI/CD pipelines, or custom integrations), see [OAuth Token Exchange](./oauth#token-exchange-for-organizations-rfc-8693). This Enterprise plan feature allows your backend services to issue scoped tokens for organization members without requiring interactive user consent.
 
 ## Service Accounts
+
+> [!WARNING]
+> This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> plan and above.
 
 For automated access that is owned by the organization rather than an individual member, administrators can create [Service Accounts](./enterprise-service-accounts) and issue fine-grained tokens scoped to your organization's resources.


### PR DESCRIPTION
Adds a docs page for organization-owned service accounts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application or API code.
> 
> **Overview**
> Adds **Enterprise Service Accounts** documentation to the Hub docs: a new page under Team & Enterprise, plus cross-links from **Tokens Management**.
> 
> The new `enterprise-service-accounts` page explains org-owned identities for CI/CD and automation (not tied to a person), how admins create them in org settings, and that access is only via fine-grained tokens (create/update/rotate/delete). It notes service accounts are not billable seats and includes light/dark screenshots.
> 
> `_toctree.yml` registers **Service Accounts** after Tokens Management. `enterprise-tokens-management.md` adds an Enterprise plan callout on **Programmatic Token Issuance** and a **Service Accounts** section pointing to the dedicated page for org-owned automated access vs member tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ac6b28ac3f51618f90ada48d7b3dd8e0022d955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->