### PR TITLE
docs: document SSH access for Jobs

### DIFF
--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -250,12 +250,9 @@ Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
 
 ## SSH
 
-You can open an interactive SSH session into a running Job to debug, inspect, or work directly inside the container. Enable it with `--ssh` (CLI) or `ssh=True` (Python API), then connect with `hf jobs ssh <job_id>`.
+You can open an interactive SSH session into a running Job to debug, inspect, or work directly inside the container. Enable it at job creation with `--ssh` (CLI) or `ssh=True` (Python API), then connect with `hf jobs ssh <job_id>`.
 
-Only users with write access to the Job's namespace are allowed in (the Job creator, or members of the owner organization), authenticated by an SSH public key registered at [https://huggingface.co/settings/keys](https://huggingface.co/settings/keys).
-
-> [!NOTE]
-> SSH access is **not billed** on top of the Job's hardware price.
+Only users with write access to the Job's namespace are allowed in (i.e. the Job creator, or members of the owner organization), authenticated by an SSH public key registered at [https://huggingface.co/settings/keys](https://huggingface.co/settings/keys).
 
 SSH is available on `hf jobs run` and `hf jobs uv run`. It is not supported for scheduled jobs.
 

--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -290,6 +290,26 @@ ssh 6a2bd1f1871c005b5352ad31@ssh.hf.jobs
 
 Then connect from a terminal with `hf jobs ssh <job_id>`, or directly with `ssh <job_id>@ssh.hf.jobs`.
 
+### Port forwarding
+
+Since this is a regular SSH connection, you can use SSH's `-L` and `-R` flags to forward ports between your machine and the Job. Connect directly with `ssh` (use `hf jobs ssh <job_id> --dry-run` to get the exact destination) and add the forwarding flags.
+
+Use `-L` (local forwarding) to access a service running inside the Job from your machine. For example, to reach a TensorBoard started in a training Job:
+
+```bash
+# Forward local port 6006 to the Job's TensorBoard on port 6006
+>>> ssh -L 6006:localhost:6006 6a2bd1f1871c005b5352ad31@ssh.hf.jobs
+```
+
+Then open [http://localhost:6006](http://localhost:6006) in your browser.
+
+Use `-R` (remote forwarding) to let the Job access a service running on your machine. For example, to expose a local database or API to the Job:
+
+```bash
+# Make your local port 8080 reachable from inside the Job on port 8080
+>>> ssh -R 8080:localhost:8080 6a2bd1f1871c005b5352ad31@ssh.hf.jobs
+```
+
 ## Timeout
 
 Jobs have a default timeout (30 minutes), after which they will automatically stop. This is important to know when running long-running tasks like model training.

--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -252,7 +252,7 @@ Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
 
 You can open an interactive SSH session into a running Job to debug, inspect, or work directly inside the container. Enable it at job creation with `--ssh` (CLI) or `ssh=True` (Python API), then connect with `hf jobs ssh <job_id>`.
 
-Only users with write access to the Job's namespace are allowed in (i.e. the Job creator, or members of the owner organization), authenticated by an SSH public key registered at [https://huggingface.co/settings/keys](https://huggingface.co/settings/keys).
+Only users with Write access to the Job's namespace are allowed (i.e. the Job creator, or members of the owner organization with Write permissions). Authentication is performed via SSH public keys registered at [https://huggingface.co/settings/keys](https://huggingface.co/settings/keys).
 
 SSH is available on `hf jobs run` and `hf jobs uv run`. It is not supported for scheduled jobs.
 

--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -248,6 +248,51 @@ Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
 ['https://6a2ab384c4f53f9fc5aa4d4f--8000.hf.jobs']
 ```
 
+## SSH
+
+You can open an interactive SSH session into a running Job to debug, inspect, or work directly inside the container. Enable it with `--ssh` (CLI) or `ssh=True` (Python API), then connect with `hf jobs ssh <job_id>`.
+
+Only users with write access to the Job's namespace are allowed in (the Job creator, or members of the owner organization), authenticated by an SSH public key registered at [https://huggingface.co/settings/keys](https://huggingface.co/settings/keys).
+
+> [!NOTE]
+> SSH access is **not billed** on top of the Job's hardware price.
+
+SSH is available on `hf jobs run` and `hf jobs uv run`. It is not supported for scheduled jobs.
+
+### CLI
+
+```bash
+# Start a job with SSH enabled
+>>> hf jobs run --ssh --detach --timeout 10m python:3.12 sleep infinity
+✓ Job started
+  id: 6a2bd1f1871c005b5352ad31
+  url: https://huggingface.co/jobs/Wauplin/6a2bd1f1871c005b5352ad31
+Hint: Use `hf jobs ssh 6a2bd1f1871c005b5352ad31` to open an SSH session into the job.
+
+# Open an SSH session into the job
+>>> hf jobs ssh 6a2bd1f1871c005b5352ad31
+```
+
+You can also print the SSH command without running it (`--dry-run`), or pass a specific identity file (`-i`/`--identity-file`):
+
+```bash
+>>> hf jobs ssh 6a2bd1f1871c005b5352ad31 --dry-run
+ssh 6a2bd1f1871c005b5352ad31@ssh.hf.jobs
+
+>>> hf jobs ssh 6a2bd1f1871c005b5352ad31 -i ~/.ssh/id_ed25519
+```
+
+### Python
+
+```python
+>>> from huggingface_hub import run_job
+>>> job = run_job(image="python:3.12", command=["sleep", "infinity"], ssh=True)
+>>> job.status.ssh_url
+'ssh://6a2bd1f1871c005b5352ad31@ssh.hf.jobs'
+```
+
+Then connect from a terminal with `hf jobs ssh <job_id>`, or directly with `ssh <job_id>@ssh.hf.jobs`.
+
 ## Timeout
 
 Jobs have a default timeout (30 minutes), after which they will automatically stop. This is important to know when running long-running tasks like model training.


### PR DESCRIPTION
Document `hf jobs ssh ...`

Depends on:
- huggingface-internal/moon-landing#18500
- huggingface/huggingface_hub#4352

:warning: Wait for `huggingface_hub` 1.20 to be released first.

## Details

Adds an **SSH** section to `docs/hub/jobs-configuration.md` with:
- `--ssh` flag (CLI) / `ssh=True` (Python API) to make a Job's container reachable over SSH
- `hf jobs ssh <job_id>` command
- `ssh://<job_id>@ssh.hf.jobs` endpoint
- `job.status.ssh_url` attribute
- access requirements: write access to the Job's namespace + an SSH public key registered at https://huggingface.co/settings/keys
- **port forwarding** with `ssh -L` / `-R` (e.g. access a TensorBoard running in a training Job, or let the Job reach a local resource)

SSH is not billed. 
SSH not supported for scheduled jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security logic modifications in this repo.
> 
> **Overview**
> Adds a new **SSH** section to `docs/hub/jobs-configuration.md` (after **Expose Ports**, before **Timeout**) describing how to enable and use interactive SSH into running Jobs.
> 
> The docs cover enabling SSH at create time (`--ssh` / `ssh=True`), connecting with `hf jobs ssh <job_id>` or `ssh <job_id>@ssh.hf.jobs`, and `job.status.ssh_url`. They state **Write** access to the job namespace and SSH keys from [huggingface.co/settings/keys](https://huggingface.co/settings/keys), and that SSH applies to `hf jobs run` and `hf jobs uv run` but **not** scheduled jobs.
> 
> CLI extras documented include `--dry-run` and `-i`/`--identity-file`. A **Port forwarding** subsection explains `-L` (e.g. TensorBoard on 6006) and `-R` (expose a local service to the container).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cedb5fc48d458a3daf4f50416b9d643fc278c516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->