### PR TITLE
Update academia-hub with new logo.md

### DIFF
--- a/docs/hub/academia-hub.md
+++ b/docs/hub/academia-hub.md
@@ -16,6 +16,7 @@ With Academia Hub, you get **an all-in-one subscription to the Hugging Face Hub 
 
 <div class="flex flex-wrap justify-center items-center gap-8 my-8">
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/Zurich.png" alt="ETH Zurich logo" class="h-24 object-contain"/>
+  <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/cmu-logo.png" alt="CMU logo" class="h-24 object-contain"/>
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/ESCP_LOGO_CMJN.png" alt="ESCP Business School logo" class="h-24 object-contain"/>
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/The_2025_MBZUAI_logo.png" alt="MBZUAI logo" class="h-24 object-contain"/>
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/academia-hub/epita.png" alt="EPITA logo" class="h-24 object-contain"/>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only markup change with no product, API, or security impact.
> 
> **Overview**
> Adds **Carnegie Mellon University (CMU)** to the partner logo row on the Academia Hub docs page, using the hosted `cmu-logo.png` asset with the same styling as the other university logos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 268a5c126c4dec560525bd2635ab41af5e36c3ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->