### PR TITLE
Add oMLX to Hub local cache applications

### DIFF
--- a/docs/hub/local-cache.md
+++ b/docs/hub/local-cache.md
@@ -21,6 +21,7 @@ Here is a partial list of libraries and applications that use this cache layout.
 | [`llama.cpp`](https://github.com/ggml-org/llama.cpp) | C++ | Since [#20775](https://github.com/ggml-org/llama.cpp/pull/20775) |
 | [`LlamaBarn`](https://github.com/ggml-org/LlamaBarn) | Swift | macOS app, built on `llama.cpp` |
 | [`HuggingFaceModelDownloader`](https://github.com/bodaay/HuggingFaceModelDownloader) | Go | |
+| [`oMLX`](https://github.com/jundot/omlx) | Python | macOS MLX inference server, Since [v0.4.0](https://github.com/jundot/omlx/commit/341aebbeaba1ca3452f83dedf03a0d102cef9fd4) |
 
 ## Cache location
 


### PR DESCRIPTION
This adds oMLX to the applications list in the Hub local cache reference.

oMLX is an macOS OpenAI-compatible inference server for MLX and supports the standard Hugging Face Hub cache layout since v0.4.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only table update with no runtime or security impact.
> 
> **Overview**
> Adds **oMLX** to the Applications table in the Hub local cache reference doc, alongside existing entries like `llama.cpp` and `LlamaBarn`.
> 
> The new row links to the project repo, labels it as Python, and notes it is a macOS MLX inference server that follows the standard Hub cache layout since v0.4.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd121a4ff449e3c4b34861fb1b45133c2a8fd6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->