### PR TITLE
docs: add resource group cost attribution

### DIFF
--- a/docs/hub/jobs-pricing.md
+++ b/docs/hub/jobs-pricing.md
@@ -84,11 +84,11 @@ In this case the Job runs under the organization account, and you can see it in 
 ### Bill to a resource group
 
 > [!WARNING]
-> This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
+> This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> plan and above.
 
 If your organization has [Resource Groups](./security-resource-groups) set up, you can attribute job costs to a specific resource group. To do so:
 
-1. Your user token must be a member of the resource group.
+1. You must be a member of the resource group.
 2. Pass the resource group's ID as the `namespace` when running the job.
 
 You can find the resource group's ID in your organization's Resource Groups settings page.

--- a/docs/hub/jobs-pricing.md
+++ b/docs/hub/jobs-pricing.md
@@ -81,6 +81,33 @@ hf jobs run --namespace my-org-name ...
 
 In this case the Job runs under the organization account, and you can see it in your organization Jobs page (organization page > settings > Jobs).
 
+### Bill to a resource group
+
+> [!WARNING]
+> This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
+
+If your organization has [Resource Groups](./security-resource-groups) set up, you can attribute job costs to a specific resource group. To do so:
+
+1. Your user token must be a member of the resource group.
+2. Pass the resource group's ID as the `namespace` when running the job.
+
+You can find the resource group's ID in your organization's Resource Groups settings page.
+
+```bash
+hf jobs run --namespace <resource-group-id> ...
+```
+
+In Python:
+
+```python
+>>> from huggingface_hub import run_job
+>>> run_job(
+...     image="python:3.12",
+...     command=["python", "-c", "print('Hello!')"],
+...     namespace="<resource-group-id>",
+... )
+```
+
 ### View current compute usage
 
 You can look at your current billing information for Jobs in in your [Billing](https://huggingface.co/settings/billing) page, under the "Compute Usage" section:

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -98,12 +98,15 @@ When a non-admin member creates a Resource Group through the UI, they are automa
 
 ## Cost attribution
 
+> [!WARNING]
+> This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> plan and above.
+
 Resource Groups also serve as a cost attribution unit for compute services. When compute is billed to a resource group, costs are tracked separately per group, making it easier to understand spending across teams.
 
 - **Spaces**: cost is automatically attributed to the resource group the Space belongs to.
 - **Jobs**: pass the resource group's ID as the `namespace` when creating a job. See [Bill to a resource group](./jobs-pricing#bill-to-a-resource-group).
-- **Inference Providers**: pass the resource group's ID via the `X-HF-Bill-To` header (or `bill_to` parameter in the SDK). See [Billing for Team and Enterprise organizations](../inference-providers/pricing#billing-for-team-and-enterprise-organizations).
-- **Inference Endpoints**: cost is automatically attributed to the resource group the model repository belongs to.
+- **Inference Providers**: pass the resource group's ID via the `X-HF-Bill-To` header (or `bill_to` parameter in the SDK). See [Billing for Team and Enterprise organizations](/docs/inference-providers/pricing#billing-for-team-and-enterprise-organizations).
+- **Inference Endpoints**: cost is automatically attributed to the resource group the model repository belongs to. Endpoints instantiated directly from the built-in Inference Endpoints catalog aren't supported at this time.
 
 ## Resource Groups API
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -96,6 +96,15 @@ The available options are:
 
 When a non-admin member creates a Resource Group through the UI, they are automatically added as an **admin** of that newly created group. Through the API, this does not happen automatically, since API callers may be creating groups on behalf of others. Non-admin API callers must include at least one user with the admin role in the group's initial member list.
 
+## Cost attribution
+
+Resource Groups also serve as a cost attribution unit for compute services. When compute is billed to a resource group, costs are tracked separately per group, making it easier to understand spending across teams.
+
+- **Spaces**: cost is automatically attributed to the resource group the Space belongs to.
+- **Jobs**: pass the resource group's ID as the `namespace` when creating a job. See [Bill to a resource group](./jobs-pricing#bill-to-a-resource-group).
+- **Inference Providers**: pass the resource group's ID via the `X-HF-Bill-To` header (or `bill_to` parameter in the SDK). See [Billing for Team and Enterprise organizations](../inference-providers/pricing#billing-for-team-and-enterprise-organizations).
+- **Inference Endpoints**: cost is automatically attributed to the resource group the model repository belongs to.
+
 ## Resource Groups API
 
 You can list resource groups and add users to them (or change a member's org role and resource group assignments) via the Hub API. For the full reference, examples, and batch workflows, see the [Programmatic User Access Control Management](./programmatic-user-access-control) guide.

--- a/docs/inference-providers/pricing.md
+++ b/docs/inference-providers/pricing.md
@@ -87,6 +87,8 @@ As of July 2025, hf-inference focuses mostly on CPU inference (e.g. embedding, t
 
 For Team & Enterprise organizations, it is possible to centralize billing for all of your users. Each user still uses their own User Access Token but the requests are billed to your organization. This can be done by passing `"X-HF-Bill-To: my-org-name"` as a header in your HTTP requests.
 
+If your organization has [Resource Groups](../hub/security-resource-groups) set up, you can also attribute inference costs to a specific resource group by passing the resource group's ID instead of the org name: `"X-HF-Bill-To: <resource-group-id>"`. The user's token must be a member of the resource group.
+
 Team & Enterprise organizations receive a pool of free usage credits based on the number of seats in the subscription. Inference Providers usage can be tracked on the organization's billing page. Team & Enterprise organization administrators can also set a spending limit and disable a set of Inference Providers from the organization's settings.
 
 <div class="flex justify-center">

--- a/docs/inference-providers/pricing.md
+++ b/docs/inference-providers/pricing.md
@@ -87,7 +87,7 @@ As of July 2025, hf-inference focuses mostly on CPU inference (e.g. embedding, t
 
 For Team & Enterprise organizations, it is possible to centralize billing for all of your users. Each user still uses their own User Access Token but the requests are billed to your organization. This can be done by passing `"X-HF-Bill-To: my-org-name"` as a header in your HTTP requests.
 
-If your organization has [Resource Groups](../hub/security-resource-groups) set up, you can also attribute inference costs to a specific resource group by passing the resource group's ID instead of the org name: `"X-HF-Bill-To: <resource-group-id>"`. The user's token must be a member of the resource group.
+Enterprise organizations with [Resource Groups](/docs/hub/security-resource-groups) set up can also attribute inference costs to a specific resource group by passing the resource group's ID instead of the org name: `"X-HF-Bill-To: <resource-group-id>"`. The user's token must be a member of the resource group.
 
 Team & Enterprise organizations receive a pool of free usage credits based on the number of seats in the subscription. Inference Providers usage can be tracked on the organization's billing page. Team & Enterprise organization administrators can also set a spending limit and disable a set of Inference Providers from the organization's settings.
 


### PR DESCRIPTION
## Summary

- **`docs/hub/jobs-pricing.md`**: new "Bill to a resource group" subsection — explains how to pass a resource group ID as `namespace` when creating a job
- **`docs/inference-providers/pricing.md`**: note that `X-HF-Bill-To` also accepts a resource group ID (in addition to an org name)
- **`docs/hub/security-resource-groups.md`**: new "Cost attribution" section covering all four compute services (Spaces, Jobs, Inference Providers, Inference Endpoints)

Ref: https://github.com/huggingface-internal/moon-landing/pull/18244 (merged) and https://github.com/huggingface-internal/moon-landing/pull/18333

## Test plan

- [ ] Verify links between the three pages resolve correctly
- [ ] Confirm resource group ID lookup path (org settings > Resource Groups) is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or security code changes.
> 
> **Overview**
> Documents how **Enterprise** customers can attribute compute spend to **Resource Groups**, with cross-links between Hub Jobs, Inference Providers, and the Resource Groups guide.
> 
> **Jobs** (`jobs-pricing.md`): new **Bill to a resource group** section—membership requirement, using the group ID as `namespace` (CLI and `huggingface_hub.run_job`).
> 
> **Resource Groups** (`security-resource-groups.md`): new **Cost attribution** section for Spaces (automatic), Jobs (`namespace`), Inference Providers (`X-HF-Bill-To` / `bill_to`), and Inference Endpoints (automatic from repo; catalog endpoints excluded).
> 
> **Inference Providers** (`pricing.md`): extends org billing to allow `X-HF-Bill-To: <resource-group-id>` when the token user is in that group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d098aa76417fea60835d2ab14e3a6da931765f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->