### PR TITLE
Document is_free field in router /v1/models API response

### DIFF
--- a/docs/inference-providers/hub-api.md
+++ b/docs/inference-providers/hub-api.md
@@ -216,6 +216,7 @@ Each provider entry may include the following fields:
 | `status` | string | `live` or `error` |
 | `context_length` | number | Maximum context length supported by this provider for the model, when available |
 | `pricing` | object | `input` and `output` prices in USD per million tokens, when available |
+| `is_free` | boolean | Whether the model is currently free of charge on this provider (temporary promo), when applicable |
 | `supports_tools` | boolean | Whether the provider supports tool calling, when available |
 | `supports_structured_output` | boolean | Whether the provider supports structured output, when available |
 | `first_token_latency_ms` | number | Time to first token in milliseconds from the latest validation probe, when available |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Documents the optional **`is_free`** boolean on each provider object returned by the router’s OpenAI-compatible **`GET /v1/models`** listing (and single-model lookup).
> 
> The field indicates when a model is temporarily free on that provider (e.g. promos), and is added to the provider fields table in `hub-api.md` alongside `pricing` and other routing metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb55893f7dedc8371010fa73a34fc4bce45f9132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->