### PR TITLE
add buckets to storage regions repo types

### DIFF
--- a/docs/hub/storage-regions.md
+++ b/docs/hub/storage-regions.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
 
-Regions allow you to specify where your organization's models, datasets and Spaces are stored. For non-Team or Enterprise users, repositories are always stored in the US.
+Regions allow you to specify where your organization's models, datasets, Spaces, and buckets are stored. For non-Team or Enterprise users, repositories are always stored in the US.
 
 This offers two key benefits:
 

--- a/docs/hub/storage-regions.md
+++ b/docs/hub/storage-regions.md
@@ -62,7 +62,7 @@ Any repository (model or dataset) stored in a non-default location displays its 
 
 Regulated industries often require data storage in specific regions.
 
-For EU companies, you can use the Hub for ML development in a GDPR-compliant manner, with datasets, models and inference endpoints stored in EU data centers.
+For EU companies, you can use the Hub for ML development in a GDPR-compliant manner, with datasets, models, buckets and inference endpoints all stored in EU data centers.
 
 ## Performance
 


### PR DESCRIPTION
buckets are now covered by storage regions alongside models datasets and Spaces

disclaimer: my julien-cto agent helped me write this

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no product or code impact.
> 
> **Overview**
> Updates **Storage Regions** docs so **buckets** are listed alongside models, datasets, and Spaces as org resources whose region can be chosen.
> 
> The intro paragraph and the EU GDPR compliance example now mention buckets (and inference endpoints in the compliance line) as stored in the selected region.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e4eb96b1232d22faee520d86f84ece75463642d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->