### PR TITLE
docs(billing): document self-serve invoicing details on card update

### DIFF
--- a/docs/hub/billing.md
+++ b/docs/hub/billing.md
@@ -140,7 +140,7 @@ A. Please ensure the card supports 3D-secure authentication and is properly co
 
 **Q. How can I add my tax ID or update the billing details?**
 
-A. Email billing@huggingface.co and we can help!
+A. When adding or updating a card at https://huggingface.co/settings/billing/payment, check the **Additional invoicing information (optional)** box. You can then provide a **Business name** and **Invoicing details** (e.g. tax ID, PO number, or company registration number), which will appear on your invoices. If you need further help, email billing@huggingface.co.
 
 **Q. I was just billed for the PRO/Team subscription a few days ago. Why did you charge me again?**
 


### PR DESCRIPTION
Users can now optionally provide a business name and invoicing details (e.g. tax ID, PO number) when adding or updating a card, which appear on their invoices. Updated the billing FAQ accordingly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the billing FAQ with no product or security impact.
> 
> **Overview**
> Updates the billing FAQ so users can add a tax ID and invoicing details without emailing support first.
> 
> The answer for **How can I add my tax ID or update the billing details?** now points to https://huggingface.co/settings/billing/payment and the **Additional invoicing information (optional)** section, where users can enter a **Business name** and **Invoicing details** (tax ID, PO number, company registration number) that show on invoices. Support email remains as a fallback for extra help.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aa0b10822ab0d1a0c066f5dfab170f6f13dc88d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->