### PR TITLE
trace docs: add hermes and droid

### DIFF
--- a/docs/hub/agent-traces.md
+++ b/docs/hub/agent-traces.md
@@ -5,19 +5,27 @@
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/agent-traces-preview-dark.webp" alt="Agent trace preview on a dataset page in dark mode."/>
 </div>
 
-Agent traces from Claude Code, Codex, and Pi Agent are natively supported on the Hugging Face Hub. Upload the raw JSONL sessions to a [Dataset](https://huggingface.co/datasets?format=format%3Aagent-traces) or a [Storage Bucket](./storage-buckets) to open them in a dedicated trace viewer. Datasets show traces in Data Studio; buckets let you open individual `.jsonl` files directly.
+Agent traces from Claude Code, Codex, Pi, Hermes Agent, and Factory Droid are natively supported on the Hugging Face Hub. Upload the raw JSONL sessions to a [Dataset](https://huggingface.co/datasets?format=format%3Aagent-traces) or a [Storage Bucket](./storage-buckets) to open them in a dedicated trace viewer. Datasets show traces in Data Studio; buckets let you open individual `.jsonl` files directly.
 
 ## Find your traces
 
-Each supported agent writes JSONL sessions to the following directories:
+Most supported agents write JSONL sessions to local directories:
 
-| Agent       | Local session directory |
-| ----------- | ----------------------- |
-| Claude Code | `~/.claude/projects`    |
-| Codex       | `~/.codex/sessions`     |
-| Pi          | `~/.pi/agent/sessions`  |
+| Agent         | Local session directory      |
+| ------------- | ---------------------------- |
+| Claude Code   | `~/.claude/projects`         |
+| Codex         | `~/.codex/sessions`          |
+| Codex archive | `~/.codex/archived_sessions` |
+| Factory/Droid | `~/.factory/sessions`        |
+| Pi            | `~/.pi/agent/sessions`       |
 
 These trace files are supported out of the box, so you can upload them without modifying or converting them first.
+
+Hermes Agent stores current sessions in its session database. Export the sessions you want to share as JSONL before uploading:
+
+```bash
+hermes sessions export session.jsonl --session-id <session_id>
+```
 
 Trace files can include prompts, tool inputs, command output, local paths, screenshots, secrets, private code, and personal data. Review and redact traces before publishing them publicly, or keep the dataset or bucket private if you are not sure what is inside.
 
@@ -25,7 +33,7 @@ For Pi Agent sessions, [`pi-share-hf`](https://github.com/badlogic/pi-share-hf) 
 
 <Tip>
 
-The easiest way to upload is to ask your agent itself: point it at the directory above and tell it to upload the `.jsonl` files to a Hub dataset or bucket.
+The easiest way to upload is to ask your agent itself: point it at the directory or exported JSONL file above and tell it to upload the `.jsonl` files to a Hub dataset or bucket.
 
 Buckets are especially useful if you want to keep syncing traces as new sessions land.
 
@@ -44,11 +52,11 @@ hf upload <username>/<dataset-name> ~/.codex/sessions . --repo-type dataset
 hf buckets sync ~/.codex/sessions hf://buckets/<username>/<bucket-name>/codex
 ```
 
-Replace `~/.codex/sessions` with the matching session directory for your agent. Use `hf upload` for datasets and `hf buckets sync` for buckets you want to update as new traces are written. The shorter `hf sync` command is an alias for `hf buckets sync`.
+Replace `~/.codex/sessions` with the matching session directory for your agent, or with a directory containing JSONL files exported from Hermes Agent. Use `hf upload` for datasets and `hf buckets sync` for buckets you want to update as new traces are written. The shorter `hf sync` command is an alias for `hf buckets sync`.
 
 ## View your traces
 
-Once you have traces in a dataset, open Data Studio and click a row. For traces in a Storage Bucket, navigate to the `.jsonl` file you want to inspect and open it. The trace viewer shows the session timeline, prompts, assistant messages, tool calls, and results.
+Once you have traces in a dataset, open Data Studio and click a row. For traces in a Storage Bucket, navigate to the `.jsonl` file you want to inspect and open it. The trace viewer shows the session timeline, prompts, assistant messages, tool calls, shell output, reasoning blocks, and results.
 
 <div class="flex justify-center">
 <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/agent-traces-session.webp" alt="Agent trace session viewer showing user and assistant turns with expanded tool calls."/>


### PR DESCRIPTION
We recently added Factory Droid Support and Hermes Agent Session Files. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security impact.
> 
> **Overview**
> Updates **`docs/hub/agent-traces.md`** so the Hub Agent Traces page matches newly supported trace formats and viewer behavior.
> 
> **Supported agents** now include **Hermes Agent** and **Factory Droid** alongside Claude Code, Codex, and Pi. The session-directory table adds **Codex archived** (`~/.codex/archived_sessions`) and **Factory/Droid** (`~/.factory/sessions`), and the intro clarifies that most agents write JSONL locally.
> 
> **Hermes** is documented separately: sessions live in a database and must be exported with `hermes sessions export` before upload. Upload/tip copy now mentions exported Hermes JSONL, not only on-disk session folders.
> 
> The **viewing** section notes the trace viewer can show **shell output** and **reasoning blocks** in addition to the existing timeline, messages, tool calls, and results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52ce10e28d050161685b0d30d49f00dae39e9556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->