### PR TITLE
[Inference Providers] update extension in Claude Code integration guide

### DIFF
--- a/docs/inference-providers/integrations/claude-code.md
+++ b/docs/inference-providers/integrations/claude-code.md
@@ -15,7 +15,7 @@ Claude Code supports custom API endpoints via environment variables. By setting 
 
 ### Option 1: Using the `hf-claude` Extension (Recommended)
 
-The [`hf-claude`](https://github.com/hanouticelina/hf-claude) extension for the `hf` CLI provides an interactive model and provider picker that launches Claude Code with the right environment variables preconfigured.
+The [`hf-claude`](https://github.com/huggingface/hf-claude) extension for the `hf` CLI provides an interactive model and provider picker that launches Claude Code with the right environment variables preconfigured.
 
 1. Make sure you have `HF_TOKEN` set:
 
@@ -26,7 +26,7 @@ export HF_TOKEN="hf_..."
 2. Install the extension:
 
 ```bash
-hf extensions install hanouticelina/hf-claude
+hf extensions install hf-claude
 ```
 
 3. Launch Claude Code through `hf`:
@@ -73,5 +73,5 @@ Available policies are `:cheapest`, `:fastest`, or `:preferred`; use one of thes
 ## Resources
 
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [`hf-claude` Extension](https://github.com/hanouticelina/hf-claude)
+- [`hf-claude` Extension](https://github.com/huggingface/hf-claude)
 - [Available models on Inference Providers](https://huggingface.co/inference/models)


### PR DESCRIPTION
Related: https://huggingface.slack.com/archives/C089DMDB415/p1782162114840509?thread_ts=1781766018.178629&cid=C089DMDB415

Updates the Claude Code integration page to install the extension via `hf extensions install hf-claude` instead of the personal namespace `hanouticelina/hf-claude`.

- Install command → `hf extensions install hf-claude`
- Repo links now point to the official [huggingface/hf-claude](https://github.com/huggingface/hf-claude)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to install commands and GitHub URLs; no runtime or API behavior changes.
> 
> **Overview**
> The Claude Code integration doc now points users at the **official** `hf-claude` extension under the Hugging Face org instead of a personal GitHub namespace.
> 
> Install instructions use `hf extensions install hf-claude`, and links to the extension repo are updated to `huggingface/hf-claude`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3211ce18621b02b5dec65c9c77a7ec78ec464efc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->