### PR TITLE
quickfix: removing cells that hardcoded role in notebook

### DIFF
--- a/docs/sagemaker/notebooks/sagemaker-sdk/deploy-embedding-models/sagemaker-notebook.ipynb
+++ b/docs/sagemaker/notebooks/sagemaker-sdk/deploy-embedding-models/sagemaker-notebook.ipynb
@@ -142,15 +142,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "role = \"arn:aws:iam::754289655784:role/sagemaker_execution_role\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from sagemaker.serve import ModelBuilder, ModelServer\n",
     "from sagemaker.serve.builder.schema_builder import SchemaBuilder\n",
     "\n",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only notebook edit with no runtime or security logic changes in application code.
> 
> **Overview**
> Removes a code cell in the SageMaker embedding deployment notebook that **hardcoded** `role` to a specific AWS account IAM ARN (`754289655784`).
> 
> Readers now rely on the existing setup cell that resolves the role via `get_execution_role()` (or the `sagemaker_execution_role` fallback), so the notebook works in their own account without copying a foreign role ARN.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64366ce574cdd1c9eafff690fecdc4ea7842b822. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->