### PR TITLE
[Inference Providers] Add "Billing to an Organization" section to Claude Code integration page

### DIFF
--- a/docs/inference-providers/integrations/claude-code.md
+++ b/docs/inference-providers/integrations/claude-code.md
@@ -76,20 +76,13 @@ To bill inference usage to a Hugging Face organization instead of your personal 
 
 **With the `hf-claude` extension**, pass the `--bill-to` flag:
 
-```bash
-hf claude --bill-to your-org-name
-```
 
 You can also set the `HF_BILL_TO` environment variable instead:
 
-```bash
-export HF_BILL_TO="your-org-name"
 ```
 
 **With manual environment variables**, set `ANTHROPIC_CUSTOM_HEADERS` to include the `X-HF-Bill-To` header:
 
-```bash
-export ANTHROPIC_CUSTOM_HEADERS="X-HF-Bill-To: your-org-name"
 ```
 
 Replace `your-org-name` with the name of the organization you want to bill to. You must have Write privileges in the org.

--- a/docs/inference-providers/integrations/claude-code.md
+++ b/docs/inference-providers/integrations/claude-code.md
@@ -85,7 +85,7 @@ You can also set the `HF_BILL_TO` environment variable instead:
 
 ```
 
-Replace `your-org-name` with the name of the organization you want to bill to. You must have Write privileges in the org.
+Replace `your-org-name` with the name of the organization you want to bill to. The org must be a Team or Enterprise org that you're a member of.
 
 ## Resources
 

--- a/docs/inference-providers/integrations/claude-code.md
+++ b/docs/inference-providers/integrations/claude-code.md
@@ -70,6 +70,30 @@ Available policies are `:cheapest`, `:fastest`, or `:preferred`; use one of thes
 > [!TIP]
 > The `ANTHROPIC_DEFAULT_*_MODEL` variables map to Claude Code's internal model slots (Opus, Sonnet, Haiku), from the most powerful to the quickest. You can assign different models to each slot to balance capability and speed e.g. `zai-org/GLM-5.1` for Opus, `google/gemma-4-31B-it:together` for Sonnet, and `openai/gpt-oss-120b:cerebras` for Haiku. `CLAUDE_CODE_SUBAGENT_MODEL` controls which model is used for sub-agents.
 
+### Billing to an Organization
+
+To bill inference usage to a Hugging Face organization instead of your personal account, you have several options depending on your setup.
+
+**With the `hf-claude` extension**, pass the `--bill-to` flag:
+
+```bash
+hf claude --bill-to your-org-name
+```
+
+You can also set the `HF_BILL_TO` environment variable instead:
+
+```bash
+export HF_BILL_TO="your-org-name"
+```
+
+**With manual environment variables**, set `ANTHROPIC_CUSTOM_HEADERS` to include the `X-HF-Bill-To` header:
+
+```bash
+export ANTHROPIC_CUSTOM_HEADERS="X-HF-Bill-To: your-org-name"
+```
+
+Replace `your-org-name` with the name of the organization you want to bill to. You must have Write privileges in the org.
+
 ## Resources
 
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a "Billing to an Organization" subsection to the [Claude Code integration page](https://huggingface.co/docs/inference-providers/integrations/claude-code), mirroring the existing section on the [Codex page](https://huggingface.co/docs/inference-providers/integrations/codex#billing-to-an-organization).

The new section documents three ways to bill inference usage to an HF organization:

1. **`hf-claude` extension** — `hf claude --bill-to your-org-name`
2. **`HF_BILL_TO` env var** — `export HF_BILL_TO="your-org-name"`
3. **Manual setup via `ANTHROPIC_CUSTOM_HEADERS`** — `export ANTHROPIC_CUSTOM_HEADERS="X-HF-Bill-To: your-org-name"`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/C089DMDB415/p1782269876602269?thread_ts=1782269876.602269&cid=C089DMDB415)

<div><a href="https://cursor.com/agents/bc-c6f5bb63-a0e4-52f2-8262-92c29727fc47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6f5bb63-a0e4-52f2-8262-92c29727fc47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

