### PR TITLE
Link annotated model card template to the model release checklist

### DIFF
--- a/docs/hub/model-card-annotated.md
+++ b/docs/hub/model-card-annotated.md
@@ -1,5 +1,7 @@
 # Annotated Model Card Template
 
+> [!TIP]
+> Getting ready to publish? See the [Model Release Checklist](./model-release-checklist) for the essential steps to a concise, informative, and user-friendly model release.
 
 ## Template
 


### PR DESCRIPTION

<img width="1040" height="397" alt="image" src="https://github.com/user-attachments/assets/1fdb5a2a-8b23-48a0-9c46-edf85b5f6682" />


Adds an info tile at the top of the [Annotated Model Card Template](https://huggingface.co/docs/hub/model-card-annotated) page pointing readers to the [Model Release Checklist](https://huggingface.co/docs/hub/model-release-checklist).

People (or Claude because it just happened) landing on the annotated template are often in the middle of preparing a release, so surfacing the checklist up front helps them find the broader set of release best practices.

Uses the standard `> [!TIP]` callout (the same style used across the Hub docs, including the checklist page itself) and a relative link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or security impact.
> 
> **Overview**
> Adds a **`> [!TIP]`** callout at the top of **`model-card-annotated.md`** so readers preparing a release are pointed to the **[Model Release Checklist](./model-release-checklist)** for broader publishing best practices.
> 
> The link uses the same Hub docs callout style as other pages and a relative path to the existing checklist doc in the toctree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3de9b75f11b6f652e02797af6cd7620fa7d282b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->