### PR TITLE
docs: surface cost attribution a bit more + link to api

### DIFF
--- a/docs/hub/enterprise-resource-groups.md
+++ b/docs/hub/enterprise-resource-groups.md
@@ -26,6 +26,7 @@ This feature allows organization administrators to:
 - Keep private repositories visible only to authorized group members
 - Enable multiple teams to work independently within the same organization
 - Configure which member roles are allowed to create new resource groups
+- Attribute costs to specific resource groups for better budget management
 
 This Team & Enterprise feature helps organizations manage complex team structures and maintain proper access control over their repositories.
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -108,7 +108,7 @@ Resource Groups also serve as a cost attribution unit for compute services. When
 - **Inference Providers**: pass the resource group's ID via the `X-HF-Bill-To` header (or `bill_to` parameter in the SDK). See [Billing for Team and Enterprise organizations](/docs/inference-providers/pricing#billing-for-team-and-enterprise-organizations).
 - **Inference Endpoints**: cost is automatically attributed to the resource group the model repository belongs to. Endpoints instantiated directly from the built-in Inference Endpoints catalog aren't supported at this time.
 
-You can use the <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/{name}/billing/usage-by-resource-group">dedicated API endpoint</a> to retrieve cost attribution data for resource groups.
+You can use the <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/&#123;name&#125;/billing/usage-by-resource-group">dedicated API endpoint</a> to retrieve cost attribution data for resource groups.
 
 ## Resource Groups API
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -108,7 +108,7 @@ Resource Groups also serve as a cost attribution unit for compute services. When
 - **Inference Providers**: pass the resource group's ID via the `X-HF-Bill-To` header (or `bill_to` parameter in the SDK). See [Billing for Team and Enterprise organizations](/docs/inference-providers/pricing#billing-for-team-and-enterprise-organizations).
 - **Inference Endpoints**: cost is automatically attributed to the resource group the model repository belongs to. Endpoints instantiated directly from the built-in Inference Endpoints catalog aren't supported at this time.
 
-You can use the [dedicated API endpoint](https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/%7Bname%7D/billing/usage-by-resource-group) to retrieve cost attribution data for resource groups.
+You can use the <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/&#123;name&#125;/billing/usage-by-resource-group" rel="nofollow">dedicated API endpoint</a> to retrieve cost attribution data for resource groups.
 
 ## Resource Groups API
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -108,7 +108,7 @@ Resource Groups also serve as a cost attribution unit for compute services. When
 - **Inference Providers**: pass the resource group's ID via the `X-HF-Bill-To` header (or `bill_to` parameter in the SDK). See [Billing for Team and Enterprise organizations](/docs/inference-providers/pricing#billing-for-team-and-enterprise-organizations).
 - **Inference Endpoints**: cost is automatically attributed to the resource group the model repository belongs to. Endpoints instantiated directly from the built-in Inference Endpoints catalog aren't supported at this time.
 
-You can use the <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/&#123;name&#125;/billing/usage-by-resource-group" rel="nofollow">dedicated API endpoint</a> to retrieve cost attribution data for resource groups.
+You can use the <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/{name}/billing/usage-by-resource-group">dedicated API endpoint</a> to retrieve cost attribution data for resource groups.
 
 ## Resource Groups API
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -108,6 +108,8 @@ Resource Groups also serve as a cost attribution unit for compute services. When
 - **Inference Providers**: pass the resource group's ID via the `X-HF-Bill-To` header (or `bill_to` parameter in the SDK). See [Billing for Team and Enterprise organizations](/docs/inference-providers/pricing#billing-for-team-and-enterprise-organizations).
 - **Inference Endpoints**: cost is automatically attributed to the resource group the model repository belongs to. Endpoints instantiated directly from the built-in Inference Endpoints catalog aren't supported at this time.
 
+You can use the [dedicated API endpoint](https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/{name}/billing/usage-by-resource-group) to retrieve cost attribution data for resource groups.
+
 ## Resource Groups API
 
 You can list resource groups and add users to them (or change a member's org role and resource group assignments) via the Hub API. For the full reference, examples, and batch workflows, see the [Programmatic User Access Control Management](./programmatic-user-access-control) guide.

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -108,7 +108,7 @@ Resource Groups also serve as a cost attribution unit for compute services. When
 - **Inference Providers**: pass the resource group's ID via the `X-HF-Bill-To` header (or `bill_to` parameter in the SDK). See [Billing for Team and Enterprise organizations](/docs/inference-providers/pricing#billing-for-team-and-enterprise-organizations).
 - **Inference Endpoints**: cost is automatically attributed to the resource group the model repository belongs to. Endpoints instantiated directly from the built-in Inference Endpoints catalog aren't supported at this time.
 
-You can use the [dedicated API endpoint](https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/{name}/billing/usage-by-resource-group) to retrieve cost attribution data for resource groups.
+You can use the [dedicated API endpoint](https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/%7Bname%7D/billing/usage-by-resource-group) to retrieve cost attribution data for resource groups.
 
 ## Resource Groups API
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Markdown-only documentation changes with no runtime or security impact.
> 
> **Overview**
> Documentation-only updates to make **resource group cost attribution** easier to discover.
> 
> The enterprise resource groups overview now lists **attributing costs to specific resource groups** among admin capabilities. The security resource groups **Cost attribution** section adds a link to the OpenAPI docs for `GET /api/organizations/{name}/billing/usage-by-resource-group` so teams can pull per-group usage data programmatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44966b330e37b9e069eef9a92652344c4bce47c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->