### PR TITLE
[Inference Providers] Fix missing commands in Claude Code billing section

### DIFF
--- a/docs/inference-providers/integrations/claude-code.md
+++ b/docs/inference-providers/integrations/claude-code.md
@@ -77,6 +77,7 @@ To bill inference usage to a Hugging Face organization instead of your personal 
 **With the `hf-claude` extension**, pass the `--bill-to` flag:
 
 ```bash
+hf extensions install hf-claude --force # reinstall to get the latest version of the extension
 hf claude --bill-to your-org-name
 ```
 
@@ -84,12 +85,14 @@ You can also set the `HF_BILL_TO` environment variable instead:
 
 ```bash
 export HF_BILL_TO="your-org-name"
+hf claude
 ```
 
 **With manual environment variables**, set `ANTHROPIC_CUSTOM_HEADERS` to include the `X-HF-Bill-To` header:
 
 ```bash
 export ANTHROPIC_CUSTOM_HEADERS="X-HF-Bill-To: your-org-name"
+claude
 ```
 
 Replace `your-org-name` with the name of the organization you want to bill to. The org must be a Team or Enterprise org that you're a member of.

--- a/docs/inference-providers/integrations/claude-code.md
+++ b/docs/inference-providers/integrations/claude-code.md
@@ -76,13 +76,20 @@ To bill inference usage to a Hugging Face organization instead of your personal 
 
 **With the `hf-claude` extension**, pass the `--bill-to` flag:
 
+```bash
+hf claude --bill-to your-org-name
+```
 
 You can also set the `HF_BILL_TO` environment variable instead:
 
+```bash
+export HF_BILL_TO="your-org-name"
 ```
 
 **With manual environment variables**, set `ANTHROPIC_CUSTOM_HEADERS` to include the `X-HF-Bill-To` header:
 
+```bash
+export ANTHROPIC_CUSTOM_HEADERS="X-HF-Bill-To: your-org-name"
 ```
 
 Replace `your-org-name` with the name of the organization you want to bill to. The org must be a Team or Enterprise org that you're a member of.


### PR DESCRIPTION
#2588 added a "Billing to an Organization" section to the [Claude Code integration page](https://huggingface.co/docs/inference-providers/integrations/claude-code), but it merged with **empty/malformed code blocks** — the actual commands were missing and the markdown fences were unbalanced.

This restores the three intended command snippets (as described in #2588's own description):

- **`hf-claude` extension** — `hf claude --bill-to your-org-name`
- **`HF_BILL_TO` env var** — `export HF_BILL_TO="your-org-name"`
- **Manual setup via `ANTHROPIC_CUSTOM_HEADERS`** — `export ANTHROPIC_CUSTOM_HEADERS="X-HF-Bill-To: your-org-name"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only fix with no runtime, API, or security behavior changes.
> 
> **Overview**
> Fixes **broken markdown** in the Claude Code integration doc’s **Billing to an Organization** section: the three billing options were described in text but their fenced `bash` blocks were empty or malformed, so readers couldn’t copy the commands.
> 
> Restores the intended snippets: `hf claude --bill-to your-org-name`, `export HF_BILL_TO="your-org-name"`, and `export ANTHROPIC_CUSTOM_HEADERS="X-HF-Bill-To: your-org-name"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f656001a83c01117d95c2dc16744375a44470526. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->