### PR TITLE
add service account consideration

### DIFF
--- a/docs/hub/enterprise-scim.md
+++ b/docs/hub/enterprise-scim.md
@@ -67,7 +67,7 @@ Once a SCIM group is linked to a Resource Group:
 
 ### SCIM-managed Resource Groups
 
-A Resource Group linked to a SCIM group is considered **SCIM-managed**. The IdP is the sole source of truth for its regular members. As a result:
+A Resource Group linked to a SCIM group is considered **SCIM-managed**. The IdP is the sole source of truth for its regular users. As a result:
 
 - Manual membership changes via the Hub UI or API are **blocked** for regular users — any attempt to add, remove, or change the role of a regular user on a SCIM-managed Resource Group will return a `403` error.
 - [Service accounts](./enterprise-service-accounts) are the exception: since they are never provisioned through SCIM, you can still add, remove, or change the role of a service account manually on a SCIM-managed Resource Group.

--- a/docs/hub/enterprise-scim.md
+++ b/docs/hub/enterprise-scim.md
@@ -67,10 +67,13 @@ Once a SCIM group is linked to a Resource Group:
 
 ### SCIM-managed Resource Groups
 
-A Resource Group linked to a SCIM group is considered **SCIM-managed**. The IdP is the sole source of truth for its membership. As a result:
+A Resource Group linked to a SCIM group is considered **SCIM-managed**. The IdP is the sole source of truth for its regular members. As a result:
 
-- Manual membership changes via the Hub UI or API are **blocked** — any attempt to add, remove, or change a member's role on a SCIM-managed Resource Group will return a `403` error.
+- Manual membership changes via the Hub UI or API are **blocked** for regular users — any attempt to add, remove, or change the role of a regular user on a SCIM-managed Resource Group will return a `403` error.
+- [Service accounts](./enterprise-service-accounts) are the exception: since they are never provisioned through SCIM, you can still add, remove, or change the role of a service account manually on a SCIM-managed Resource Group.
 - Auto-join **cannot be enabled** on a SCIM-managed Resource Group. To re-enable auto-join, first remove the SCIM link.
+
+In the Resource Group settings, a SCIM-managed Resource Group displays a **SCIM synced** badge, and the membership form notes that only service accounts can be added or removed manually.
 
 Group provisioning works the same way for both Basic SSO and Managed SSO.
 


### PR DESCRIPTION
Documents that service accounts are exempt from the manual membership block on SCIM-managed Resource Groups, and adds a note about the SCIM synced badge in Resource Group settings.

Suggested by https://github.com/huggingface-internal/moon-landing/pull/18605.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to enterprise SCIM guidance; no product or security behavior changes in this diff.
> 
> **Overview**
> **SCIM-managed Resource Groups** documentation now states that the IdP is the source of truth for **regular users** only, not all membership.
> 
> Manual add/remove/role changes via Hub UI or API remain forbidden for regular users (`403`), but **[service accounts](./enterprise-service-accounts)** can still be managed manually because they are not SCIM-provisioned.
> 
> A new note describes Resource Group settings: **SCIM synced** badge and copy on the membership form that only service accounts can be changed by hand.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22d88db64c77787c8ce93eee9e8b0a4db5ca975e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->