### PR TITLE
Use `llama serve` in Jobs serving guide (llama.cpp unified CLI)

### DIFF
--- a/docs/hub/jobs-serving.md
+++ b/docs/hub/jobs-serving.md
@@ -68,7 +68,7 @@ The same pattern works with any server that speaks HTTP. llama.cpp's `llama serv
 
 ```bash
 >>> hf jobs run --detach --expose 8080 --flavor a10g-small -s HF_TOKEN \
-...   ghcr.io/ggml-org/llama.cpp:full-cuda -- \
+...   ghcr.io/ggml-org/llama.cpp:server-cuda -- \
 ...   /app/llama serve -hf ggml-org/gemma-4-E4B-it-GGUF \
 ...   --host 0.0.0.0 --port 8080 -ngl 99 \
 ...   --temp 1.0 --top-p 0.95 --top-k 64
@@ -82,7 +82,7 @@ The `--` separates the job's command from `hf jobs run`'s own options — needed
 > ```bash
 > >>> hf jobs run --detach --expose 8080 --flavor a10g-small -s HF_TOKEN \
 > ...   -v hf://ggml-org/gemma-4-E4B-it-GGUF:/model:ro \
-> ...   ghcr.io/ggml-org/llama.cpp:full-cuda -- \
+> ...   ghcr.io/ggml-org/llama.cpp:server-cuda -- \
 > ...   /app/llama serve --model /model/gemma-4-E4B-it-Q4_K_M.gguf \
 > ...   --host 0.0.0.0 --port 8080 -ngl 99
 > ```

--- a/docs/hub/jobs-serving.md
+++ b/docs/hub/jobs-serving.md
@@ -64,17 +64,17 @@ Because the token travels in the `Authorization` header, these URLs work from sc
 
 ## Serve GGUF models with llama.cpp
 
-The same pattern works with any server that speaks HTTP. llama.cpp's `llama-server` pulls GGUF files straight from the Hub with the `-hf` flag and serves the same OpenAI-compatible API. For example, to serve [Gemma 4 E4B](https://huggingface.co/ggml-org/gemma-4-E4B-it-GGUF) with Gemma's recommended sampling settings:
+The same pattern works with any server that speaks HTTP. llama.cpp's `llama serve` pulls GGUF files straight from the Hub with the `-hf` flag and serves the same OpenAI-compatible API. For example, to serve [Gemma 4 E4B](https://huggingface.co/ggml-org/gemma-4-E4B-it-GGUF) with Gemma's recommended sampling settings:
 
 ```bash
 >>> hf jobs run --detach --expose 8080 --flavor a10g-small -s HF_TOKEN \
-...   ghcr.io/ggml-org/llama.cpp:server-cuda -- \
-...   /app/llama-server -hf ggml-org/gemma-4-E4B-it-GGUF \
+...   ghcr.io/ggml-org/llama.cpp:full-cuda -- \
+...   /app/llama serve -hf ggml-org/gemma-4-E4B-it-GGUF \
 ...   --host 0.0.0.0 --port 8080 -ngl 99 \
 ...   --temp 1.0 --top-p 0.95 --top-k 64
 ```
 
-The `--` separates the job's command from `hf jobs run`'s own options — needed here because `llama-server`'s flags would otherwise be parsed by the CLI itself.
+The `--` separates the job's command from `hf jobs run`'s own options — needed here because `llama serve`'s flags would otherwise be parsed by the CLI itself.
 
 > [!TIP]
 > You can skip the model download entirely by mounting the model repo as a read-only volume and pointing the server at the file directly:
@@ -82,15 +82,15 @@ The `--` separates the job's command from `hf jobs run`'s own options — needed
 > ```bash
 > >>> hf jobs run --detach --expose 8080 --flavor a10g-small -s HF_TOKEN \
 > ...   -v hf://ggml-org/gemma-4-E4B-it-GGUF:/model:ro \
-> ...   ghcr.io/ggml-org/llama.cpp:server-cuda -- \
-> ...   /app/llama-server --model /model/gemma-4-E4B-it-Q4_K_M.gguf \
+> ...   ghcr.io/ggml-org/llama.cpp:full-cuda -- \
+> ...   /app/llama serve --model /model/gemma-4-E4B-it-Q4_K_M.gguf \
 > ...   --host 0.0.0.0 --port 8080 -ngl 99
 > ```
 >
 > The server starts much faster since there is nothing to download — the model streams from the mounted repo as it loads.
 
 > [!WARNING]
-> Your server must listen on `0.0.0.0`. `llama-server` binds to `127.0.0.1` by default, which the jobs proxy can't reach — pass `--host 0.0.0.0` explicitly.
+> Your server must listen on `0.0.0.0`. `llama serve` binds to `127.0.0.1` by default, which the jobs proxy can't reach — pass `--host 0.0.0.0` explicitly.
 
 The same applies to any other OpenAI-compatible server (SGLang, ...): start the server on an exposed port, listen on `0.0.0.0`, and connect with your HF token as the API key.
 


### PR DESCRIPTION
Follow-up to #2554 addressing @julien-c's review feedback: push the new unified `llama serve` command instead of the standalone `llama-server`.

## What changed
The llama.cpp section now uses `llama serve` on the `full-cuda` image (both the `-hf` example and the volume-mount tip), with the surrounding prose and warning updated to match.

## Why the image also changed
`llama serve` and `llama-server` are the same server — the unified `llama` CLI ([ggml-org/llama.cpp#23875](https://github.com/ggml-org/llama.cpp/discussions/23875), "`git commit` vs `git-commit`"). But the unified `llama` binary only ships in the **`full-cuda`** image; **`server-cuda`** contains only `/app/llama-server`. So using `llama serve` requires `full-cuda` — a ~1 GB larger pull (3.6 GB vs 2.6 GB compressed). Startup is dominated by the model download/load, which is unchanged, so the "a few minutes" framing still holds.

## Tested
Ran on live Jobs (`full-cuda` + `a10g-small`):
- `llama serve -hf ggml-org/gemma-4-E4B-it-GGUF --host 0.0.0.0 --port 8080 -ngl 99` → server reached ready, returned a completion through the exposed-port proxy with a Bearer token.
- The volume-mounted `--model /model/...gguf` variant → ready in ~40s (nothing to download), completion returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and example command updates with no runtime or security impact.
> 
> **Overview**
> Updates the **Serve GGUF models with llama.cpp** section in `jobs-serving.md` to document llama.cpp’s unified **`llama serve`** entry point instead of the standalone **`llama-server`**.
> 
> Prose, the main `-hf` job example, the volume-mount tip, and the `0.0.0.0` warning now refer to **`llama serve`** and use **`/app/llama serve`** in the sample commands; server flags and the `ghcr.io/ggml-org/llama.cpp:server-cuda` image tag in the snippets are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f9c7ace83c5dee41da5a444ac9e8268bd862eaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->