### PR TITLE
[Trusted Publishers] Mention bucket resource type

### DIFF
--- a/docs/hub/trusted-publishers.md
+++ b/docs/hub/trusted-publishers.md
@@ -96,7 +96,7 @@ Complete working examples:
 
 | Flavor | Configured on | What you get | Use it to… |
 | --- | --- | --- | --- |
-| **Repo publisher** | A repo's **Settings → Trusted Publishers** | A token with **write access to that one repo** | Publish a model, dataset, Space, or kernel from CI |
+| **Repo publisher** | A repo's **Settings → Trusted Publishers** | A token with **write access to that one repo** | Publish a model, dataset, Space, kernel, or bucket from CI |
 | **User publisher** | Your account's [**Authentication settings → CI/CD Access**](https://huggingface.co/settings/authentication#ci-cd-access) | A read-only token with the `gated-repos` scope | Read **gated repos you have access to** and use your rate limits from CI |
 
 Both tokens expire after 60 minutes. You need the **Write** role on a Hub repo to manage its trusted publishers.
@@ -166,7 +166,7 @@ No client authentication is needed — the OIDC ID token authenticates the reque
 | `grant_type` | yes | `urn:ietf:params:oauth:grant-type:token-exchange` |
 | `subject_token_type` | yes | `urn:ietf:params:oauth:token-type:id_token` |
 | `subject_token` | yes | The raw OIDC ID token (JWT) from your CI provider. Its `aud` claim **must** be `https://huggingface.co`. |
-| `resource` | yes | A Hub repo (`namespace/name`, `datasets/namespace/name`, `spaces/namespace/name`, `kernels/namespace/name`) or a Hub **username** (no slash) for a user-scoped token. |
+| `resource` | yes | A Hub repo (`namespace/name`, `datasets/namespace/name`, `spaces/namespace/name`, `kernels/namespace/name`, `buckets/namespace/name`) or a Hub **username** (no slash) for a user-scoped token. |
 
 **Success response:**
 


### PR DESCRIPTION
Fixing what looks like an omission. On https://huggingface.co/docs/hub/en/trusted-publishers we mention twice models/datasets/spaces/kernels as potential resource types but no buckets.

cc @coyotte508 to confirm it's indeed available (I suppose yes since it's in buckets settings)

<img width="3162" height="864" alt="image" src="https://github.com/user-attachments/assets/ccff0815-8450-4a0a-80c3-2b10d862e5cd" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording updates with no product or API behavior changes.
> 
> **Overview**
> **Trusted Publishers** docs now list **buckets** alongside models, datasets, Spaces, and kernels.
> 
> The repo-publisher table’s “Use it to…” column adds publishing a **bucket** from CI. The token-exchange API table’s `resource` field adds the `buckets/namespace/name` path format next to the other Hub repo prefixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cd70d11025105585c05bac70278ca9a5ae5833f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->