### PR TITLE
Add Gamut to MCP client examples

### DIFF
--- a/docs/hub/agents-mcp.md
+++ b/docs/hub/agents-mcp.md
@@ -13,7 +13,7 @@ The Hugging Face MCP (Model Context Protocol) Server connects your MCP‑compati
 
 1. Open your [MCP settings](https://huggingface.co/settings/mcp) while logged in.
 
-2. Pick your client: select your MCP‑compatible client (for example Cursor, VS Code, Zed, Claude Desktop). The page shows client‑specific instructions and a ready‑to‑copy configuration snippet.
+2. Pick your client: select your MCP‑compatible client (for example Cursor, VS Code, Zed, Claude Desktop, [Gamut](https://www.gamut.so/mcp/search-ai/hugging-face)). The page shows client‑specific instructions and a ready‑to‑copy configuration snippet.
 
 3. Paste and restart: copy the snippet into your client’s MCP configuration, save, and restart/reload the client. You should see “Hugging Face” (or similar) listed as a connected MCP server in your client.
 


### PR DESCRIPTION
Adds [Gamut](https://www.gamut.so) to the list of MCP-compatible clients in the MCP Server docs.

Gamut is an AI agent platform with native MCP support that can connect to the Hugging Face MCP Server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds **Gamut** to the MCP-compatible client examples in the Hugging Face MCP Server “Get started” step, with a link to Gamut’s Hugging Face MCP integration page (`https://www.gamut.so/mcp/search-ai/hugging-face`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2e409fa23a229cca9e6d1591b8b032f3331c6ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->