### PR TITLE
Lead integrations page with HF-native coding agents, friendlier copy

### DIFF
--- a/docs/inference-providers/integrations/index.md
+++ b/docs/inference-providers/integrations/index.md
@@ -1,8 +1,6 @@
 # Integrations Overview
 
-Hugging Face Inference Providers works with a growing ecosystem of developer tools, frameworks, and platforms. These integrations let you use state-of-the-art models in your existing workflows and development environments.
-
-If a tool doesn't have explicit support for Inference Providers, it is often still compatible via its OpenAI-compatible API support. Check the documentation for your tool to see if it can be configured to use custom endpoints.
+Hugging Face Inference Providers plugs into the tools you already use, from coding agents like Claude Code, Codex, and OpenCode to LLM frameworks, evaluation suites, and IDEs. Bring your own HF token and run state-of-the-art open models across dozens of providers, without changing your workflow.
 
 ## Why Use Integrations?
 
@@ -15,27 +13,27 @@ If a tool doesn't have explicit support for Inference Providers, it is often sti
 
 This table lists _some_ tools, libraries, and applications that work with Hugging Face Inference Providers. For detailed setup instructions, follow the links in the Resources column.
 
-| Integration                                                                                                         | Description                                                    | Resources                                                                                                             |
-| ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code)                                                       | Agentic coding tool for the terminal                           | [HF docs](./claude-code)                                                                                               |
-| [Codex](https://developers.openai.com/codex)                                                                        | OpenAI's agentic coding CLI for the terminal                   | [HF docs](./codex)                                                                                                     |
-| [CrewAI](https://www.crewai.com/)                                                                                   | Framework for orchestrating AI agent teams                     | [Official docs](https://docs.crewai.com/en/concepts/llms#hugging-face)                                                 |
-| [NeMo Data Designer](https://github.com/NVIDIA-NeMo/DataDesigner)                                                         | Synthetic dataset generation framework                         | [HF docs](./datadesigner)                                                                                              |
-| [GitHub Copilot Chat](https://docs.github.com/en/copilot)                                                           | AI pair programmer in VS Code                                  | [HF docs](./vscode)                                                                                                    |
-| [fast-agent](https://fast-agent.ai/)                                                                                | Flexible framework building MCP/ACP powered Agents, Workflows and evals | [Official docs](https://fast-agent.ai/models/llm_providers/#hugging-face)                                     |
-| [Hermes Agent](https://github.com/NousResearch/hermes-agent)                                                       | Open-source AI agent CLI for coding and development            | [Official docs](https://hermes-agent.nousresearch.com/docs/user-guide/configuration/#hugging-face-inference-providers) / [HF docs](./hermes-agent) |
-| [Haystack](https://haystack.deepset.ai/)                                                                            | Open-source LLM framework for building production applications | [Official docs](https://docs.haystack.deepset.ai/docs/huggingfaceapichatgenerator)                                     |
-| [Inspect](https://inspect.aisi.org.uk/)                                                                             | AI safety and evaluation framework                             | [Official docs](https://inspect.aisi.org.uk/providers.html#hugging-face)                                               |
-| [LangChain](https://www.langchain.com/)                                                                             | LLM application framework                                      | [Official docs](https://docs.langchain.com/oss/python/integrations/providers/huggingface#huggingfaceendpoint)          |
-| [LiteLLM](https://www.litellm.ai/)                                                       | Unified interface for 100+ LLMs                                | [Official docs](https://docs.litellm.ai/docs/providers/huggingface)                                                    |
-| [LlamaIndex](https://www.llamaindex.ai/) | Data framework for LLM applications                            | [Official docs](https://developers.llamaindex.ai/python/examples/llm/huggingface/#use-a-model-via-inference-providers) |
-| [MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper)                                                           | Speech-to-text application for macOS                           | [HF docs](./macwhisper)                                                                                                     |
-| [OpenCode](https://opencode.ai/)                                                                                             | AI coding agent built for the terminal                         | [Official docs](https://opencode.ai/docs/providers#hugging-face) / [HF docs](./opencode)                             |
-| [Pi](https://github.com/badlogic/pi-mono)                                                                                    | Minimalist terminal-based coding assistant                     | [Official docs](https://github.com/badlogic/pi-mono) / [HF docs](./pi)                                               |
-| [PydanticAI](https://ai.pydantic.dev/)                                                                         | Framework for building AI agents with Python                   | [Official docs](https://ai.pydantic.dev/models/huggingface/)                                                           |
-| [Roo Code](https://roocode.com/)                                                                               | AI-powered code generation and refactoring                     | [Official docs](https://docs.roocode.com/providers/huggingface)                                                        |
-| [smolagents](https://huggingface.co/docs/smolagents)                                                           | Framework for building LLM agents with tool integration        | [Official docs](https://huggingface.co/docs/smolagents/reference/models#smolagents.InferenceClientModel)               |
-| [Vision Agents](https://visionagents.ai/)                                                                      | SDK for real-time AI with text and vision language models      | [Official docs](https://visionagents.ai/integrations/huggingface) / [HF docs](./visionagents)                          |
+| Integration                                                        | Description                                                              | Resources                                                                                                                                          |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Pi](https://github.com/badlogic/pi-mono)                          | Minimalist terminal-based coding assistant                              | [Official docs](https://github.com/badlogic/pi-mono) / [Getting started](./pi)                                                                     |
+| [OpenCode](https://opencode.ai/)                                   | AI coding agent built for the terminal                                  | [Official docs](https://opencode.ai/docs/providers#hugging-face) / [Getting started](./opencode)                                                   |
+| [Codex](https://developers.openai.com/codex)                       | OpenAI's agentic coding CLI for the terminal                            | [Getting started](./codex)                                                                                                                         |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code)      | Agentic coding tool for the terminal                                    | [Getting started](./claude-code)                                                                                                                   |
+| [Hermes Agent](https://github.com/NousResearch/hermes-agent)       | Open-source AI agent CLI for coding and development                     | [Official docs](https://hermes-agent.nousresearch.com/docs/user-guide/configuration/#hugging-face-inference-providers) / [Getting started](./hermes-agent) |
+| [CrewAI](https://www.crewai.com/)                                  | Framework for orchestrating AI agent teams                              | [Official docs](https://docs.crewai.com/en/concepts/llms#hugging-face)                                                                             |
+| [NeMo Data Designer](https://github.com/NVIDIA-NeMo/DataDesigner)  | Synthetic dataset generation framework                                  | [Getting started](./datadesigner)                                                                                                                  |
+| [GitHub Copilot Chat](https://docs.github.com/en/copilot)          | AI pair programmer in VS Code                                           | [Getting started](./vscode)                                                                                                                        |
+| [fast-agent](https://fast-agent.ai/)                               | Flexible framework building MCP/ACP powered Agents, Workflows and evals | [Official docs](https://fast-agent.ai/models/llm_providers/#hugging-face)                                                                          |
+| [Haystack](https://haystack.deepset.ai/)                           | Open-source LLM framework for building production applications          | [Official docs](https://docs.haystack.deepset.ai/docs/huggingfaceapichatgenerator)                                                                |
+| [Inspect](https://inspect.aisi.org.uk/)                            | AI safety and evaluation framework                                      | [Official docs](https://inspect.aisi.org.uk/providers.html#hugging-face)                                                                           |
+| [LangChain](https://www.langchain.com/)                            | LLM application framework                                               | [Official docs](https://docs.langchain.com/oss/python/integrations/providers/huggingface#huggingfaceendpoint)                                      |
+| [LiteLLM](https://www.litellm.ai/)                                 | Unified interface for 100+ LLMs                                         | [Official docs](https://docs.litellm.ai/docs/providers/huggingface)                                                                               |
+| [LlamaIndex](https://www.llamaindex.ai/)                           | Data framework for LLM applications                                     | [Official docs](https://developers.llamaindex.ai/python/examples/llm/huggingface/#use-a-model-via-inference-providers)                            |
+| [MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper)          | Speech-to-text application for macOS                                    | [Getting started](./macwhisper)                                                                                                                    |
+| [PydanticAI](https://ai.pydantic.dev/)                             | Framework for building AI agents with Python                            | [Official docs](https://ai.pydantic.dev/models/huggingface/)                                                                                       |
+| [Roo Code](https://roocode.com/)                                   | AI-powered code generation and refactoring                              | [Official docs](https://docs.roocode.com/providers/huggingface)                                                                                    |
+| [smolagents](https://huggingface.co/docs/smolagents)               | Framework for building LLM agents with tool integration                 | [Official docs](https://huggingface.co/docs/smolagents/reference/models#smolagents.InferenceClientModel)                                          |
+| [Vision Agents](https://visionagents.ai/)                          | SDK for real-time AI with text and vision language models               | [Official docs](https://visionagents.ai/integrations/huggingface) / [Getting started](./visionagents)                                              |
 
 ## Integrations by Category
 
@@ -49,18 +47,18 @@ Client libraries and gateways for simplified LLM access.
 
 End-user applications and interfaces powered by LLMs.
 
-- [MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper) - Speech-to-text application for macOS ([HF docs](./macwhisper))
+- [MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper) - Speech-to-text application for macOS ([Getting started](./macwhisper))
 
 ### Developer Tools
 
 AI-powered coding assistants and development environments.
 
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) - Agentic coding tool for the terminal ([HF docs](./claude-code))
-- [Codex](https://developers.openai.com/codex) - OpenAI's agentic coding CLI for the terminal ([HF docs](./codex))
-- [GitHub Copilot Chat](https://docs.github.com/en/copilot) - AI pair programmer in VS Code ([HF docs](./vscode))
-- [Hermes Agent](https://github.com/NousResearch/hermes-agent) - Open-source AI agent CLI for coding and development ([Official docs](https://hermes-agent.nousresearch.com/docs/user-guide/configuration/#hugging-face-inference-providers) / [HF docs](./hermes-agent))
-- [OpenCode](https://opencode.ai/) - AI coding agent built for the terminal ([Official docs](https://opencode.ai/docs/providers#hugging-face) / [HF docs](./opencode))
-- [Pi](https://github.com/badlogic/pi-mono) - Minimalist terminal-based coding assistant ([Official docs](https://github.com/badlogic/pi-mono) / [HF docs](./pi))
+- [Pi](https://github.com/badlogic/pi-mono) - Minimalist terminal-based coding assistant ([Official docs](https://github.com/badlogic/pi-mono) / [Getting started](./pi))
+- [OpenCode](https://opencode.ai/) - AI coding agent built for the terminal ([Official docs](https://opencode.ai/docs/providers#hugging-face) / [Getting started](./opencode))
+- [Codex](https://developers.openai.com/codex) - OpenAI's agentic coding CLI for the terminal ([Getting started](./codex))
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) - Agentic coding tool for the terminal ([Getting started](./claude-code))
+- [Hermes Agent](https://github.com/NousResearch/hermes-agent) - Open-source AI agent CLI for coding and development ([Official docs](https://hermes-agent.nousresearch.com/docs/user-guide/configuration/#hugging-face-inference-providers) / [Getting started](./hermes-agent))
+- [GitHub Copilot Chat](https://docs.github.com/en/copilot) - AI pair programmer in VS Code ([Getting started](./vscode))
 - [Roo Code](https://roocode.com/) - AI-powered code generation and refactoring ([Official docs](https://docs.roocode.com/providers/huggingface))
 
 ### Evaluation Frameworks
@@ -80,13 +78,17 @@ LLM application frameworks and orchestration platforms.
 - [LlamaIndex](https://www.llamaindex.ai/) - Data framework for connecting custom data to LLMs ([Official docs](https://developers.llamaindex.ai/python/examples/llm/huggingface/#use-a-model-via-inference-providers))
 - [PydanticAI](https://ai.pydantic.dev/) - Framework for building AI agents with Python ([Official docs](https://ai.pydantic.dev/models/huggingface/))
 - [smolagents](https://huggingface.co/docs/smolagents) - Framework for building LLM agents with tool integration ([Official docs](https://huggingface.co/docs/smolagents/reference/models#smolagents.InferenceClientModel))
-- [Vision Agents](https://visionagents.ai/) - SDK for real-time AI with text and vision language models ([Official docs](https://visionagents.ai/integrations/huggingface) / [HF docs](./visionagents))
+- [Vision Agents](https://visionagents.ai/) - SDK for real-time AI with text and vision language models ([Official docs](https://visionagents.ai/integrations/huggingface) / [Getting started](./visionagents))
 
 ### Synthetic Data
 
 Tools for creating synthetic datasets.
 
-- [NeMo Data Designer](https://github.com/NVIDIA-NeMo/DataDesigner) - NVIDIA NeMo framework for synthetic data generation ([HF docs](./datadesigner))
+- [NeMo Data Designer](https://github.com/NVIDIA-NeMo/DataDesigner) - NVIDIA NeMo framework for synthetic data generation ([Getting started](./datadesigner))
+
+## Don't See Your Tool?
+
+If a tool doesn't have explicit support for Inference Providers, it's often still compatible via its OpenAI-compatible API. Check your tool's documentation to see if it can be pointed at a custom endpoint.
 
 <!-- ## Add Your Integration
 

--- a/docs/inference-providers/integrations/index.md
+++ b/docs/inference-providers/integrations/index.md
@@ -15,11 +15,11 @@ This table lists _some_ tools, libraries, and applications that work with Huggin
 
 | Integration                                                        | Description                                                              | Resources                                                                                                                                          |
 | ------------------------------------------------------------------ | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Pi](https://github.com/badlogic/pi-mono)                          | Minimalist terminal-based coding assistant                              | [Official docs](https://github.com/badlogic/pi-mono) / [Getting started](./pi)                                                                     |
-| [OpenCode](https://opencode.ai/)                                   | AI coding agent built for the terminal                                  | [Official docs](https://opencode.ai/docs/providers#hugging-face) / [Getting started](./opencode)                                                   |
+| [Pi](https://github.com/badlogic/pi-mono)                          | Minimalist terminal-based coding assistant                              | [Getting started](./pi)                                                                     |
+| [OpenCode](https://opencode.ai/)                                   | AI coding agent built for the terminal                                  | [Getting started](./opencode)                                                   |
 | [Codex](https://developers.openai.com/codex)                       | OpenAI's agentic coding CLI for the terminal                            | [Getting started](./codex)                                                                                                                         |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code)      | Agentic coding tool for the terminal                                    | [Getting started](./claude-code)                                                                                                                   |
-| [Hermes Agent](https://github.com/NousResearch/hermes-agent)       | Open-source AI agent CLI for coding and development                     | [Official docs](https://hermes-agent.nousresearch.com/docs/user-guide/configuration/#hugging-face-inference-providers) / [Getting started](./hermes-agent) |
+| [Hermes Agent](https://github.com/NousResearch/hermes-agent)       | Open-source AI agent CLI for coding and development                     | [Getting started](./hermes-agent) |
 | [CrewAI](https://www.crewai.com/)                                  | Framework for orchestrating AI agent teams                              | [Official docs](https://docs.crewai.com/en/concepts/llms#hugging-face)                                                                             |
 | [NeMo Data Designer](https://github.com/NVIDIA-NeMo/DataDesigner)  | Synthetic dataset generation framework                                  | [Getting started](./datadesigner)                                                                                                                  |
 | [GitHub Copilot Chat](https://docs.github.com/en/copilot)          | AI pair programmer in VS Code                                           | [Getting started](./vscode)                                                                                                                        |
@@ -33,7 +33,7 @@ This table lists _some_ tools, libraries, and applications that work with Huggin
 | [PydanticAI](https://ai.pydantic.dev/)                             | Framework for building AI agents with Python                            | [Official docs](https://ai.pydantic.dev/models/huggingface/)                                                                                       |
 | [Roo Code](https://roocode.com/)                                   | AI-powered code generation and refactoring                              | [Official docs](https://docs.roocode.com/providers/huggingface)                                                                                    |
 | [smolagents](https://huggingface.co/docs/smolagents)               | Framework for building LLM agents with tool integration                 | [Official docs](https://huggingface.co/docs/smolagents/reference/models#smolagents.InferenceClientModel)                                          |
-| [Vision Agents](https://visionagents.ai/)                          | SDK for real-time AI with text and vision language models               | [Official docs](https://visionagents.ai/integrations/huggingface) / [Getting started](./visionagents)                                              |
+| [Vision Agents](https://visionagents.ai/)                          | SDK for real-time AI with text and vision language models               | [Getting started](./visionagents)                                              |
 
 ## Integrations by Category
 
@@ -53,11 +53,11 @@ End-user applications and interfaces powered by LLMs.
 
 AI-powered coding assistants and development environments.
 
-- [Pi](https://github.com/badlogic/pi-mono) - Minimalist terminal-based coding assistant ([Official docs](https://github.com/badlogic/pi-mono) / [Getting started](./pi))
-- [OpenCode](https://opencode.ai/) - AI coding agent built for the terminal ([Official docs](https://opencode.ai/docs/providers#hugging-face) / [Getting started](./opencode))
+- [Pi](https://github.com/badlogic/pi-mono) - Minimalist terminal-based coding assistant ([Getting started](./pi))
+- [OpenCode](https://opencode.ai/) - AI coding agent built for the terminal ([Getting started](./opencode))
 - [Codex](https://developers.openai.com/codex) - OpenAI's agentic coding CLI for the terminal ([Getting started](./codex))
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) - Agentic coding tool for the terminal ([Getting started](./claude-code))
-- [Hermes Agent](https://github.com/NousResearch/hermes-agent) - Open-source AI agent CLI for coding and development ([Official docs](https://hermes-agent.nousresearch.com/docs/user-guide/configuration/#hugging-face-inference-providers) / [Getting started](./hermes-agent))
+- [Hermes Agent](https://github.com/NousResearch/hermes-agent) - Open-source AI agent CLI for coding and development ([Getting started](./hermes-agent))
 - [GitHub Copilot Chat](https://docs.github.com/en/copilot) - AI pair programmer in VS Code ([Getting started](./vscode))
 - [Roo Code](https://roocode.com/) - AI-powered code generation and refactoring ([Official docs](https://docs.roocode.com/providers/huggingface))
 
@@ -78,7 +78,7 @@ LLM application frameworks and orchestration platforms.
 - [LlamaIndex](https://www.llamaindex.ai/) - Data framework for connecting custom data to LLMs ([Official docs](https://developers.llamaindex.ai/python/examples/llm/huggingface/#use-a-model-via-inference-providers))
 - [PydanticAI](https://ai.pydantic.dev/) - Framework for building AI agents with Python ([Official docs](https://ai.pydantic.dev/models/huggingface/))
 - [smolagents](https://huggingface.co/docs/smolagents) - Framework for building LLM agents with tool integration ([Official docs](https://huggingface.co/docs/smolagents/reference/models#smolagents.InferenceClientModel))
-- [Vision Agents](https://visionagents.ai/) - SDK for real-time AI with text and vision language models ([Official docs](https://visionagents.ai/integrations/huggingface) / [Getting started](./visionagents))
+- [Vision Agents](https://visionagents.ai/) - SDK for real-time AI with text and vision language models ([Getting started](./visionagents))
 
 ### Synthetic Data
 


### PR DESCRIPTION
didn't like the onboarding from [the current one](https://huggingface.co/docs/inference-providers/integrations/index).

<img width="1013" height="820" alt="image" src="https://github.com/user-attachments/assets/f216fafb-bd02-4b67-b8b6-7c6beba05aec" />


Refreshes the Inference Providers **Integrations Overview** page (`/docs/inference-providers/integrations`) to make it friendlier and lead with our coding agents.

### Changes
- **Reorder the overview table** so the five HF-native coding agents come first, matching the sidebar order: Pi, OpenCode, Codex, Claude Code, Hermes Agent. The rest follow.
- **Rename `HF docs` resource links to `Getting started`** so it's obvious they're setup guides, not generic docs. External `Official docs` links are unchanged.
- **Rewrite the intro** for the agent era (leads with coding agents like Claude Code, Codex, OpenCode).
- **Move the OpenAI-compatibility note** off the top into a closing "Don't See Your Tool?" section, where people look after scanning the list.

Also mirrors the new lead order at the top of the Developer Tools category list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to link labels, ordering, and prose with no runtime or API impact.
> 
> **Overview**
> Refreshes the **Integrations Overview** page so it reads for the coding-agent workflow and surfaces HF setup guides more clearly.
> 
> The **intro** now leads with coding agents (Claude Code, Codex, OpenCode) and BYO HF token, instead of generic ecosystem copy plus an upfront OpenAI-compat note. That compat guidance moves to a new **Don't See Your Tool?** section at the bottom.
> 
> The **overview table** and **Developer Tools** list are **reordered** so Pi, OpenCode, Codex, Claude Code, and Hermes Agent appear first (aligned with sidebar). Internal resource links labeled **HF docs** are renamed to **Getting started**; third-party **Official docs** links are unchanged. Several entries drop dual Official/HF link pairs in favor of a single Getting started link where HF owns the guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29dea060c8ac728576a8eb66b06f87889b468398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->