### PR TITLE
Note S3-compatible API covers the 'Coming soon' libraries

### DIFF
--- a/docs/hub/storage-buckets-integrations.md
+++ b/docs/hub/storage-buckets-integrations.md
@@ -88,4 +88,4 @@ text_files = hffs.glob("buckets/username/my-bucket/*.txt")
 
 ## Coming soon
 
-Support for more libraries is on the way — including Polars, DuckDB (native `hf://` URL support), Daft, and webdataset.
+Native `hf://` URL support is on the way for more libraries — including Polars, DuckDB, Daft, and webdataset. In the meantime, all of these already work today through the [S3-compatible API](./storage-buckets-s3).


### PR DESCRIPTION
## What
The "Coming soon" note on the Bucket Integrations page lists Polars, DuckDB, Daft, and webdataset as pending native `hf://` URL support. With the S3-compatible API now GA, all four already work today via S3 — this points readers there in the meantime.

## Verification
Checked each against the live gateway: Polars (`read_parquet` over `s3://`), DuckDB (`httpfs`), Daft (`S3Config(endpoint_url=…)`), and webdataset (TAR streaming via the AWS CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with a link to existing S3 compatibility docs; no product or code behavior changes.
> 
> **Overview**
> Updates the **Coming soon** blurb on the Bucket Integrations page so it no longer reads as if Polars, DuckDB, Daft, and webdataset are unavailable.
> 
> The text now states that **native `hf://` URL support** is still planned for those libraries, and adds that they **already work today** through the **[S3-compatible API](./storage-buckets-s3)** doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7262ea3b26770f52cdb76163f114271912864a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->