### PR TITLE
Add `boto3` and DuckDB examples to the S3 docs

### DIFF
--- a/docs/hub/storage-buckets-s3.md
+++ b/docs/hub/storage-buckets-s3.md
@@ -3,6 +3,8 @@
 Storage Buckets can be accessed through an **S3-compatible API**, letting you use existing S3 tooling — the AWS CLI, `boto3`, `s5cmd`, and most other S3 SDKs — against your buckets without changing your code. 
 Requests go through a gateway service at `https://s3.hf.co`.
 
+The S3 API is one of several ways to reach bucket data — for Hugging Face-native access (the `hf` CLI, `hf://` paths, and filesystem mounts) without separate S3 credentials, see [Access Patterns](./storage-buckets-access).
+
 > [!NOTE]
 > The S3 API works only with [Storage Buckets](./storage-buckets). It does not expose other Hugging Face repository types (models, datasets, Spaces).
 
@@ -133,6 +135,54 @@ Bucket object keys are more restricted than S3. A key must **not**:
 ## Examples
 
 Real-world recipes for common tasks. Each builds on the [client configuration](#configuring-a-client) above.
+
+### Read and write with `boto3`
+
+[`boto3`](https://docs.aws.amazon.com/boto3/latest/) works against the gateway with the [client settings](#configuring-a-client) above. Replace `<namespace>` with your username or organization:
+
+```python
+import boto3
+from botocore.config import Config
+
+s3 = boto3.client(
+    "s3",
+    endpoint_url="https://s3.hf.co/<namespace>",
+    aws_access_key_id="HFAK...",
+    aws_secret_access_key="...",
+    config=Config(
+        region_name="us-east-1",
+        s3={"addressing_style": "path"},
+        request_checksum_calculation="when_required",
+        response_checksum_validation="when_required",
+    ),
+)
+
+s3.upload_file("model.safetensors", "my-bucket", "models/model.safetensors")
+s3.download_file("my-bucket", "models/model.safetensors", "model.safetensors")
+```
+
+### Query a bucket with DuckDB
+
+With the `httpfs` extension, [DuckDB](https://duckdb.org/) can read Parquet (and other formats) straight from a bucket:
+
+```sql
+INSTALL httpfs;
+LOAD httpfs;
+
+CREATE SECRET hf (
+    TYPE s3,
+    KEY_ID 'HFAK...',
+    SECRET '...',
+    ENDPOINT 's3.hf.co/<namespace>',
+    URL_STYLE 'path',
+    REGION 'us-east-1'
+);
+
+SELECT * FROM read_parquet('s3://my-bucket/data.parquet');
+```
+
+> [!NOTE]
+> `URL_STYLE 'path'` is required. Without it, DuckDB uses virtual-hosted-style addressing (`my-bucket.s3.hf.co`), which the gateway does not serve — you will see a "Could not resolve hostname" error.
 
 ### Import data using `rclone`
 


### PR DESCRIPTION
## What
Adds two examples to the `## Examples` section of the Storage Buckets S3 page (currently only rclone):
- **`boto3`** — read/write against the gateway
- **DuckDB** — query a bucket, with a note on the required `URL_STYLE 'path'` setting

Plus a one-line pointer near the top to [Access Patterns](./storage-buckets-access), so the S3 API reads as one of several ways to reach bucket data rather than the only one.

## Verification
Both run against the live gateway:
- boto3: `put` / `get` / `list` / `upload_file` / `download_file`
- DuckDB: `CREATE SECRET … URL_STYLE 'path'` + `read_parquet` / `read_csv` from `s3://`

The DuckDB `URL_STYLE 'path'` note documents a real failure mode — without it, DuckDB uses virtual-hosted-style addressing (`bucket.s3.hf.co`), which the gateway doesn't serve, so you get a confusing "could not resolve hostname" error.

_(As the Examples section grows, these per-tool recipes might eventually be worth a dedicated page — just noting it for the future, nothing to act on now.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to `storage-buckets-s3.md`; no runtime, auth, or application code changes.
> 
> **Overview**
> Expands **Storage Buckets S3** documentation with two new **Examples** recipes and clearer navigation to non-S3 access.
> 
> Near the top, a short line links to **[Access Patterns](./storage-buckets-access)** so readers see the S3 gateway as one option alongside `hf` CLI, `hf://`, and mounts.
> 
> Under **Examples**, new sections show **`boto3`** upload/download with the same gateway client settings as the rest of the page (path addressing, checksum options), and **DuckDB** querying Parquet via `httpfs` with an `CREATE SECRET` block. A note calls out that **`URL_STYLE 'path'`** is required to avoid virtual-hosted-style hostnames the gateway does not serve. The existing **rclone** import recipe is unchanged aside from ordering after the new examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff4a9734cff24a5cf42bd6b0c0ba34413cce6072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->