### PR TITLE
Docs: free accounts in good standing can host ZeroGPU Spaces

### DIFF
--- a/docs/hub/billing.md
+++ b/docs/hub/billing.md
@@ -29,7 +29,7 @@ The PRO subscription unlocks essential features for serious users, including:
 - Higher bandwidth and API [rate limits](./rate-limits)
 - Included credits for [Inference Providers](/docs/inference-providers/)
 - Higher tier for ZeroGPU Spaces usage, and pay-as-you-go quota extension
-- Ability to create ZeroGPU Spaces and use Dev Mode
+- Ability to host more ZeroGPU Spaces and use Dev Mode
 - Ability to publish Social Posts and Community Blogs
 - Leverage the [Data Studio](./data-studio) on private datasets
 

--- a/docs/hub/pro.md
+++ b/docs/hub/pro.md
@@ -6,7 +6,7 @@ The PRO subscription unlocks essential features for serious users, including:
 - Higher bandwidth and API [rate limits](./rate-limits)
 - Included credits for [Inference Providers](/docs/inference-providers/)
 - Higher tier for [ZeroGPU Spaces](./spaces-zerogpu) usage, and pay-as-you-go quota extension
-- Ability to create ZeroGPU Spaces and use [Dev Mode](./spaces-dev-mode)
+- Ability to host more ZeroGPU Spaces and use [Dev Mode](./spaces-dev-mode)
 - Ability to publish Social Posts and Community Blogs
 - Leverage the [Data Studio](./data-studio) on private datasets
 

--- a/docs/hub/spaces-zerogpu.md
+++ b/docs/hub/spaces-zerogpu.md
@@ -15,7 +15,7 @@ Unlike traditional single-GPU allocations, ZeroGPU's efficient system lowers bar
   - ZeroGPU Spaces are available to use for free to all users. (Visit [the curated list](https://huggingface.co/spaces/enzostvs/zero-gpu-spaces)).
   - [PRO users](https://huggingface.co/subscribe/pro) get x8 more daily usage quota, highest priority in GPU queues, and can go beyond their daily quota using pre-paid credits when using any ZeroGPU Spaces.
 - **Hosting your own ZeroGPU Spaces**
-  - Personal accounts: [Subscribe to PRO](https://huggingface.co/settings/billing/subscription) to access ZeroGPU in the hardware options when creating a new Gradio SDK Space.
+  - Personal accounts: Established free accounts in good standing can host a limited number of ZeroGPU Spaces, selectable under the **Free tier** hardware option when creating a new Gradio SDK Space. [Subscribe to PRO](https://huggingface.co/settings/billing/subscription) to host more ZeroGPU Spaces and unlock higher usage quotas and queue priority.
   - Organizations: [Subscribe to a Team or Enterprise plan](https://huggingface.co/enterprise) to enable ZeroGPU Spaces for all organization members.
 
 ## Technical Specifications
@@ -175,6 +175,7 @@ You can add credits from your [billing settings](https://huggingface.co/settings
 
 ## Hosting Limitations
 
+- **Free personal accounts**: Established accounts in good standing can host a limited number of ZeroGPU Spaces on the Free tier.
 - **Personal accounts ([PRO subscribers](https://huggingface.co/subscribe/pro))**: Maximum of 10 ZeroGPU Spaces.
 - **Organization accounts ([Team & Enterprise](https://huggingface.co/enterprise))**: Maximum of 50 ZeroGPU Spaces.
 


### PR DESCRIPTION
ZeroGPU Spaces are no longer PRO-only for personal accounts: established free accounts in good standing can now host a limited number on the new Free tier. Update the ZeroGPU hosting section/limitations and reword the PRO benefit accordingly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and policy clarification with no application or billing code changes.
> 
> **Overview**
> Hub docs now reflect that **personal free accounts in good standing** can host a **limited** number of ZeroGPU Spaces via the **Free tier** hardware option when creating Gradio Spaces, instead of treating hosting as PRO-only.
> 
> `spaces-zerogpu.md` updates the hosting guidance and adds a **Hosting Limitations** bullet for free personal accounts; PRO (10) and org (50) caps are unchanged. **`billing.md`** and **`pro.md`** reword the PRO benefit from creating ZeroGPU Spaces to **hosting more** ZeroGPU Spaces (plus Dev Mode).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 944f47af57add8ea4aa5654ad616998c4b362c01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->