### PR TITLE
[Docs] Add `hf jobs scheduled trigger` to the scheduled jobs page

### DIFF
--- a/docs/hub/jobs-schedule.md
+++ b/docs/hub/jobs-schedule.md
@@ -23,7 +23,7 @@ Use `hf jobs uv run ` or `hf jobs run` with a schedule of `@annually`, `@yearly`
 
 Use the same parameters as `hf jobs uv run` and `hf jobs run` to pass environment variables, secrets, timeout, labels, etc.
 
-Manage scheduled jobs using `hf jobs scheduled ps`, `hf jobs scheduled inspect`, `hf jobs scheduled suspend`, `hf jobs scheduled resume`, and `hf jobs scheduled delete`:
+Manage scheduled jobs using `hf jobs scheduled ps`, `hf jobs scheduled inspect`, `hf jobs scheduled suspend`, `hf jobs scheduled resume`, `hf jobs scheduled trigger`, and `hf jobs scheduled delete`:
 
 ```python
 # List your active scheduled jobs
@@ -40,6 +40,9 @@ Manage scheduled jobs using `hf jobs scheduled ps`, `hf jobs scheduled inspect`,
 
 # Resume a scheduled job
 >>> hf jobs scheduled resume <scheduled-job-id>
+
+# Trigger a scheduled job to run right now (does not change the schedule)
+>>> hf jobs scheduled trigger <scheduled-job-id>
 
 # Delete a scheduled job
 >>> hf jobs scheduled delete <scheduled-job-id>


### PR DESCRIPTION
Adds the new "run now" command for scheduled jobs to the Hub product docs — `trigger` in the "Manage scheduled jobs" command list plus an example on the [scheduled jobs page](https://huggingface.co/docs/hub/jobs-schedule).

Mirrors huggingface/huggingface_hub#4459, which adds the `hf jobs scheduled trigger` CLI command (the server endpoint + UI are already live).

> [!NOTE]
> Draft — depends on huggingface/huggingface_hub#4459. Keep as draft until that command ships in a `huggingface_hub` release, otherwise readers on a released CLI can’t run it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to jobs-schedule.md; no runtime, API, or security impact.
> 
> **Overview**
> Documents **`hf jobs scheduled trigger`** on the Hub scheduled jobs page so readers can discover the “run now” flow alongside existing manage commands.
> 
> The **Manage scheduled jobs** intro line now lists `trigger`, and a new example shows how to fire a run immediately **without** changing the cron schedule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a3470de5b792e734140d0a83dc33d2143b39b68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->