### PR TITLE
docs(billing): remove stale threshold billing section

### DIFF
--- a/docs/hub/billing.md
+++ b/docs/hub/billing.md
@@ -80,31 +80,6 @@ You can add a credit card to your account from your billing settings.
 	<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/billing/payment-method-dark.png"/>
 </div>
 
-
-### Billing thresholds & Invoicing
-
-When using credit cards as a payment method, you'll be billed for the Hugging Face compute usage each time the accrued usage goes above a billing threshold for your user or organization.
-
-On the 1st of every month, Hugging Face edits an invoice for usage accrued during the prior month. Any usage that has yet to be charged will be charged at that time.
-
-For example, if your billing threshold is set at $100.00, and you incur $254.00 of usage during a given month, your credit card will be charged a total of three times during the month:
-- Once for usage between $0 and $100: $100
-- Once for usage between $100 and $200: $100
-- Once at the end of the month for the remaining $54: $54  
-
-Note: this will be detailed in your monthly invoice.
-
-<div class="flex justify-center">
-	<img class="block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/billing/explain-threshold.png "/>
-</div>
-
-You can view invoices and receipts for the last 3 months in your billing dashboard.
-
-<div class="flex justify-center">
-	<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/billing/threshold-payments-light.png "/>
-	<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/billing/threshold-payments-dark.png"/>
-</div>
-
 ## Cloud providers partnerships
 
 We partner with cloud providers like [AWS](https://huggingface.co/blog/aws-partnership), [Azure](https://huggingface.co/blog/hugging-face-endpoints-on-azure),


### PR DESCRIPTION
## What

Removes the `### Billing thresholds & Invoicing` section from `docs/hub/billing.md`.

## Why

That section described the old **post-paid threshold model** — being charged each time accrued usage crossed a $100 threshold (the `$100 / $100 / $54` example). This contradicts the **prepaid-credits + automatic-recharge** model that is already documented in the same file's Support FAQ:

- *"Why do I need to add credits?"*
- *"What happens if I run out of credits? → We recommend enabling automatic recharge to avoid service disruptions."*

Monthly invoice timing is also already covered earlier in the file (*"Invoices for compute services are edited at the beginning of each month."*).

## Notes

- No dangling references remain — nothing in `docs/` links to the `#billing-thresholds--invoicing` anchor or the removed `explain-threshold` / `threshold-payments` images.
- The orphaned images live in the external `huggingface/documentation-images` dataset, so nothing to clean up in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmkEbXiHr16TQM8o9TSna9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code or billing behavior impact.
> 
> **Overview**
> Removes the **`### Billing thresholds & Invoicing`** subsection from `docs/hub/billing.md`, including the post-paid threshold explanation ($100 billing triggers and the `$100 / $100 / $54` example) and the related screenshots.
> 
> This aligns hub billing docs with the **prepaid credits + automatic recharge** model already described in the Support FAQ, and avoids duplicating monthly invoice timing already stated under compute services.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91de209805ce2db76c012443cb34ea43a84b5a7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->