### PR TITLE
Add Daft to bucket integrations

### DIFF
--- a/docs/hub/storage-buckets-integrations.md
+++ b/docs/hub/storage-buckets-integrations.md
@@ -27,8 +27,11 @@ Daft supports `hf://buckets/` paths natively, with [Xet-accelerated reads](https
 
 ```python
 import daft
+from daft.io import IOConfig, HuggingFaceConfig
+from huggingface_hub import get_token
 
-df = daft.read_parquet("hf://buckets/username/my-bucket/data.parquet")
+io_config = IOConfig(hf=HuggingFaceConfig(token=get_token()))
+df = daft.read_parquet("hf://buckets/username/my-bucket/data.parquet", io_config=io_config)
 ```
 
 ## PyArrow

--- a/docs/hub/storage-buckets-integrations.md
+++ b/docs/hub/storage-buckets-integrations.md
@@ -21,6 +21,16 @@ import dask.dataframe as dd
 df = dd.read_parquet("hf://buckets/username/my-bucket/data.parquet")
 ```
 
+## Daft
+
+Daft supports `hf://buckets/` paths natively, with [Xet-accelerated reads](https://docs.daft.ai/en/stable/connectors/huggingface/) enabled by default:
+
+```python
+import daft
+
+df = daft.read_parquet("hf://buckets/username/my-bucket/data.parquet")
+```
+
 ## PyArrow
 
 ```python
@@ -88,4 +98,4 @@ text_files = hffs.glob("buckets/username/my-bucket/*.txt")
 
 ## Coming soon
 
-Native `hf://` URL support is on the way for more libraries — including Polars, DuckDB, Daft, and webdataset. In the meantime, all of these already work today through the [S3-compatible API](./storage-buckets-s3).
+Native `hf://` URL support is on the way for more libraries — including Polars, DuckDB, and webdataset. In the meantime, all of these already work today through the [S3-compatible API](./storage-buckets-s3).


### PR DESCRIPTION
Daft merged native `hf://buckets/` path support with Xet-accelerated reads via the `hf-xet` crate (Eventual-Inc/Daft#7183 and prior bucket-path work, on `main`).

Draft until the next Daft release ships it (latest release v0.7.15 predates both) — will verify the snippet against the released wheel, then mark ready.

Moves Daft out of the "Coming soon" list into its own section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-path behavior changes in this repo.
> 
> **Overview**
> Documents **Daft** as a first-class bucket integration with a new section after Dask, including a `read_parquet` example on `hf://buckets/` paths using `IOConfig` / `HuggingFaceConfig` and `get_token()`, and notes **Xet-accelerated reads** via Daft’s Hugging Face connector.
> 
> Updates **Coming soon** to drop Daft from the pending native `hf://` list (Polars, DuckDB, and webdataset remain).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a69eca45b788aadb5bf0d6a783d7e157383f0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->