### PR TITLE
Link the live agent-usage dataset from agents-overview

### DIFF
--- a/docs/hub/agents-overview.md
+++ b/docs/hub/agents-overview.md
@@ -184,7 +184,7 @@ Agent: [Fetches documentation]
 
 ## Register your agent harness
 
-Hugging Face maintains a public registry of agent harnesses, the coding agents and tools that interact with the Hub (Claude Code, Codex, Cursor, and more). When `huggingface_hub` detects it is running inside a registered harness, it reports it via the user agent on Hub requests. Registering your harness means this activity is attributed to your tool by name and gives your project a friendly display label, links back to your docs and repository, and a place in upcoming agent leaderboards.
+Hugging Face maintains a public registry of agent harnesses, the coding agents and tools that interact with the Hub (Claude Code, Codex, Cursor, and more). When `huggingface_hub` detects it is running inside a registered harness, it reports it via the user agent on Hub requests. Registering your harness means this activity is attributed to your tool by name and gives your project a friendly display label, links back to your docs and repository, and a place in the public [agent usage dataset](https://huggingface.co/datasets/huggingface/agent-usage) — unregistered tools are only counted in its aggregate `unknown` share.
 
 To register a harness, open a Pull Request adding an entry to [`agent-harnesses.ts`](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/agent-harnesses.ts) in the `@huggingface/tasks` package:
 
@@ -197,7 +197,7 @@ To register a harness, open a Pull Request adding an entry to [`agent-harnesses.
   - If your harness sets one of the standard environment variables (`AI_AGENT` or `AGENT`), its value is used directly as the identifier and no extra config is needed.
   - Otherwise, set `envVars` to map environment variable names to value patterns. Use `"*"` to match any non-empty value, an exact string for an exact match, or `"<prefix>*"` for prefix matching.
 
-And that's it! Once the PR is merged, we will start tracking usage of the `hf` CLI by your agent harness.
+And that's it! Once the PR is merged, `huggingface_hub` traffic (including the `hf` CLI) from your agent harness is attributed to it by name, and it appears in the [agent usage dataset](https://huggingface.co/datasets/huggingface/agent-usage) from the next monthly update.
 
 ## Next Steps
 


### PR DESCRIPTION
The registration section promised "upcoming agent leaderboards" — [`huggingface/agent-usage`](https://huggingface.co/datasets/huggingface/agent-usage) is now live, so link it. Also corrects the tracking scope in the closing line (all `huggingface_hub` traffic, not only the `hf` CLI).

Draft until the dataset flips public (imminent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and links; no runtime or API behavior changes.
> 
> **Overview**
> Updates the **Register your agent harness** section in `agents-overview.md` now that the public [agent usage dataset](https://huggingface.co/datasets/huggingface/agent-usage) is live.
> 
> Replaces the promise of **upcoming agent leaderboards** with a link to that dataset and a note that unregistered tools roll into its aggregate **`unknown`** share. The post-merge paragraph now states that **all `huggingface_hub` traffic** (not only the `hf` CLI) is attributed to a registered harness and that it shows up in the dataset from the **next monthly update**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b91621447bdbe69636fd14af3b3ae789329c7d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->