### PR TITLE
docs: document assigning collections to resource groups

### DIFF
--- a/docs/hub/collections.md
+++ b/docs/hub/collections.md
@@ -61,6 +61,12 @@ You can use a collection to [gate](https://huggingface.co/docs/hub/en/models-gat
 
 This feature is reserved for [Team & Enterprise](https://huggingface.co/docs/hub/en/enterprise) subscribers: more information about Gating Group Collections can be found in [our dedicated doc](https://huggingface.co/docs/hub/en/enterprise-gating-group-collections).
 
+### Assigning a collection to a Resource Group (Team & Enterprise)
+
+Organization collections can be assigned to a [Resource Group](./security-resource-groups) to control which members can access them, the same way repositories are. You can pick a Resource Group when creating an organization collection, and members with the appropriate permissions can move a collection to a different Resource Group later from the collection's menu. Private collections that belong to a Resource Group are only visible to members of that group.
+
+This feature is reserved for [Team & Enterprise](https://huggingface.co/docs/hub/en/enterprise) subscribers.
+
 ### Ordering your collections and their items
 
 You can use the drag and drop handles in the collections list (on the left side of your collections page) to change the order of your collections (1). The first two collections will be directly visible on your profile/organization pages.

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -11,6 +11,8 @@ Resource Groups allow organization administrators to group related repositories 
 
 A repository can belong to only one Resource Group.
 
+Organization collections can also be assigned to a Resource Group, following the same rules as repositories: a collection can belong to only one Resource Group, and can be moved between groups by members with the appropriate permissions.
+
 Organizations members need to be added to the Resource Group to access its repositories. An Organization Member can belong to several Resource Groups.
 
 Members are assigned a role in each Resource Group that determines their permissions for the group's repositories. Four distinct roles exist for Resource Groups:
@@ -22,7 +24,7 @@ Members are assigned a role in each Resource Group that determines their permiss
 
 In addition, Organization admins can manage all resource groups inside the organization. This includes moving repositories in and out of any Resource Group.
 
-Resource Groups also affect the visibility of private repositories inside the organization. A private repository that is part of a Resource Group will only be visible to members of that Resource Group. Public repositories, on the other hand, are visible to anyone, inside and outside the organization.
+Resource Groups also affect the visibility of private repositories inside the organization. A private repository that is part of a Resource Group will only be visible to members of that Resource Group. Public repositories, on the other hand, are visible to anyone, inside and outside the organization. The same visibility rules apply to private collections that belong to a Resource Group.
 
 ## Getting started
 


### PR DESCRIPTION
Collections can now be assigned to a Resource Group (Team & Enterprise), following the same access-control and visibility rules as repositories.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no application, API, or security logic changes.
> 
> **Overview**
> Documents **Team & Enterprise** support for tying **organization collections** to **Resource Groups**, mirroring repository access control.
> 
> **`collections.md`** adds a section on choosing a Resource Group at creation, moving collections via the collection menu, and limiting visibility of private collections to group members, with a link to `security-resource-groups`.
> 
> **`security-resource-groups.md`** states that collections follow the same one-group-per-resource rules as repos and that private collections in a group use the same visibility rules as private repos in that group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e064695ac830c014bafbfc52822027f35ab541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->