### PR TITLE
Document local-directory volumes in the Jobs configuration guide

### DIFF
--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -103,7 +103,7 @@ You can pass environment variables to your job using
 
 ## Volumes
 
-Mount Hugging Face repositories (models, datasets) or [Storage Buckets](./storage-buckets) as volumes in your job container using `-v` or `--volume`. The syntax uses the `hf://` URL scheme: `hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]`.
+Mount Hugging Face repositories (models, datasets), [Storage Buckets](./storage-buckets), or local directories as volumes in your job container using `-v` or `--volume`. Hub sources use the `hf://` URL scheme: `hf://[TYPE/]SOURCE:/MOUNT_PATH[:ro]`; a local directory is passed directly as the source.
 
 Volume types:
 
@@ -113,6 +113,7 @@ Volume types:
 | Dataset repo | `-v hf://datasets/stanfordnlp/imdb:/data` |
 | Storage bucket | `-v hf://buckets/username/my-bucket:/mnt` |
 | Subfolder | `-v hf://datasets/org/my-dataset/train:/data` |
+| Local directory | `-v ./training-data:/data` |
 
 Then use the mounted volume as a local directory inside the container:
 
@@ -138,6 +139,16 @@ Models and datasets are always mounted **read-only**. Storage buckets are **read
 ```bash
 >>> hf jobs run -v hf://buckets/username/my-bucket:/mnt:ro python:3.12 ls /mnt
 ```
+
+### Local directories
+
+Passing a local directory as the source syncs it to your private `jobs-artifacts` [Storage Bucket](./storage-buckets) (created automatically) before the Job starts, then mounts it in the container. Local directories are mounted **read-only** by default; use `:rw` to write outputs:
+
+```bash
+>>> hf jobs uv run -v ./pdfs:/input -v ./md-out:/output:rw ocr.py
+```
+
+Re-syncing the same directory only uploads new or modified files. To retrieve files a Job wrote to a read-write volume, sync its bucket folder back once the Job is over — the CLI prints the exact `hf buckets sync` command when the Job starts. Scheduled jobs work too: the directory is synced once when the schedule is created, and every trigger mounts the same folder. In Python, use [`sync_job_volume`](https://huggingface.co/docs/huggingface_hub/guides/jobs#mount-local-data).
 
 In Python, use the [`Volume`](https://huggingface.co/docs/huggingface_hub/package_reference/jobs#huggingface_hub.Volume) class:
 

--- a/docs/hub/storage-buckets-access.md
+++ b/docs/hub/storage-buckets-access.md
@@ -41,6 +41,8 @@ Volume mounts in [Jobs](./jobs) and [Spaces](./spaces) are the same idea as `hf-
 hf jobs run -v hf://buckets/username/my-bucket:/data python:3.12 python script.py
 ```
 
+Jobs can also take a **local directory** as the volume source (`-v ./training-data:/data`): the directory is synced to your private `jobs-artifacts` bucket and mounted from there, so incremental re-syncs and output pull-back come for free.
+
 For the full volume mount syntax and Python API, see the [Jobs configuration docs](./jobs-configuration#volumes) and the [Spaces volume mount guide](/docs/huggingface_hub/guides/manage-spaces#mount-volumes-in-your-space).
 
 ## Python Data Tools


### PR DESCRIPTION
huggingface_hub v1.22.0 added local directories as `-v` sources in `hf jobs run` / `hf jobs uv run` (and the `scheduled` variants): the directory is synced to the user's private `jobs-artifacts` Storage Bucket and mounted from there (huggingface/huggingface_hub#4346).

The hub-docs Volumes section only covered `hf://` sources. This PR:
- adds a **Local directory** row to the volume-types table and rewords the intro (local paths aren't `hf://` syntax)
- adds a short **Local directories** subsection: read-only by default / `:rw`, incremental re-sync, output pull-back via the `hf buckets sync` command the CLI prints, scheduled-jobs semantics (synced once at creation), and a link to the [`sync_job_volume` guide section](https://huggingface.co/docs/huggingface_hub/guides/jobs#mount-local-data) for Python
- one cross-link sentence in the Buckets access page's "Volume Mounts in Jobs and Spaces" section, so Buckets readers discover the local-dir flow

Behavior claims verified against the released v1.22.0 `hf jobs uv run --help` text and the tested output in huggingface/huggingface_hub#4346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or security behavior changes.
> 
> **Overview**
> Documents **local directories** as a `-v` / `--volume` source for Jobs, matching `huggingface_hub` v1.22.0.
> 
> The Jobs **Volumes** section now treats local paths alongside `hf://` mounts: the intro clarifies that hub repos use `hf://` while local dirs are passed as the source, the types table adds a **Local directory** example, and a new **Local directories** subsection explains sync into the auto-created `jobs-artifacts` bucket, default **read-only** mounts with `:rw` for outputs, incremental re-sync, pulling results back via the CLI’s `hf buckets sync` hint, scheduled-job behavior, and the Python [`sync_job_volume`](https://huggingface.co/docs/huggingface_hub/guides/jobs#mount-local-data) helper.
> 
> The storage **Volume Mounts in Jobs and Spaces** page gets a short cross-link so bucket readers see the same local-dir → `jobs-artifacts` flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdef305fbddb9c5448c47424496c7698ad7ee791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->