### PR TITLE
Use hf auth login instead of deprecated huggingface-cli in leaderboard guide

### DIFF
--- a/docs/hub/leaderboard-data-guide.md
+++ b/docs/hub/leaderboard-data-guide.md
@@ -41,7 +41,7 @@ for entry in leaderboard[:5]:
 ```
 
 > [!TIP]
-> `huggingface_hub` uses your cached token by default. For gated benchmark datasets, make sure you are logged in (`huggingface-cli login`) or pass a token explicitly:
+> `huggingface_hub` uses your cached token by default. For gated benchmark datasets, make sure you are logged in (`hf auth login`) or pass a token explicitly:
 > ```python
 > leaderboard = api.get_dataset_leaderboard("gated/benchmark", token="hf_...")
 > ```


### PR DESCRIPTION
One-liner: the leaderboard data guide still points users at `huggingface-cli login`; the `huggingface-cli` name is deprecated in favor of `hf`. Swapped for `hf auth login` (verified current on huggingface_hub 1.22.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or API impact.
> 
> **Overview**
> Updates the gated-benchmark tip in **leaderboard-data-guide** so login instructions use the current **`hf auth login`** command instead of the deprecated **`huggingface-cli login`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313f6c9ec08e43241a6417aa199cb21fb63fa5d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->