### PR TITLE
Update Spaces docs: paid plan required for compute Spaces, ZeroGPU free tier

### DIFF
--- a/docs/hub/billing.md
+++ b/docs/hub/billing.md
@@ -29,7 +29,7 @@ The PRO subscription unlocks essential features for serious users, including:
 - Higher bandwidth and API [rate limits](./rate-limits)
 - Included credits for [Inference Providers](/docs/inference-providers/)
 - Higher tier for ZeroGPU Spaces usage, and pay-as-you-go quota extension
-- Ability to create ZeroGPU Spaces and use Dev Mode
+- Ability to create Gradio and Docker Spaces running on compute, host up to 10 ZeroGPU Spaces, and use Dev Mode
 - Ability to publish Social Posts and Community Blogs
 - Leverage the [Data Studio](./data-studio) on private datasets
 
@@ -56,7 +56,7 @@ See the full pricing tiers at [huggingface.co/pricing](https://huggingface.co/pr
 
 We also directly provide compute services with [Spaces](./spaces), [Inference Endpoints](https://huggingface.co/docs/inference-endpoints/index) and [Inference Providers](https://huggingface.co/docs/inference-providers/index).
 
-While most of our compute services have a comprehensive free tier, users and organizations can pay to access more powerful hardware accelerators.
+While several of our compute services have a free tier, users and organizations can pay to access more powerful hardware accelerators.
 
 The billing for our compute services is usage-based, meaning you only pay for what you use. You can monitor your usage at any time from your billing dashboard, located in your user's or organization's settings menu.
 

--- a/docs/hub/pro.md
+++ b/docs/hub/pro.md
@@ -6,7 +6,7 @@ The PRO subscription unlocks essential features for serious users, including:
 - Higher bandwidth and API [rate limits](./rate-limits)
 - Included credits for [Inference Providers](/docs/inference-providers/)
 - Higher tier for [ZeroGPU Spaces](./spaces-zerogpu) usage, and pay-as-you-go quota extension
-- Ability to create ZeroGPU Spaces and use [Dev Mode](./spaces-dev-mode)
+- Ability to create Gradio and Docker Spaces running on compute, host up to 10 [ZeroGPU Spaces](./spaces-zerogpu), and use [Dev Mode](./spaces-dev-mode)
 - Ability to publish Social Posts and Community Blogs
 - Leverage the [Data Studio](./data-studio) on private datasets
 

--- a/docs/hub/spaces-gpus.md
+++ b/docs/hub/spaces-gpus.md
@@ -28,6 +28,9 @@ In the following tables, you can see the Specs for the different upgrade options
 | CPU Basic              | 2 vCPU        | 16 GB        |  -              | 50 GB     | Free!             |
 | CPU Upgrade            | 8 vCPU        | 32 GB        |  -              | 50 GB     | $0.03             |
 
+> [!NOTE]
+> CPU Basic has no hourly cost, but creating a new Space that runs on compute (Gradio or Docker) requires a paid plan. Static Spaces are free for everyone. See the [Spaces Overview](./spaces-overview#hardware-resources) for details.
+
 ### GPU
 
 | **Hardware**           | **CPU**       | **Memory**   | **GPU Memory**  | **Disk**  | **Hourly Price**  |

--- a/docs/hub/spaces-overview.md
+++ b/docs/hub/spaces-overview.md
@@ -10,6 +10,9 @@ In the following sections, you'll learn the basics of creating a Space, configur
 
 **To make a new Space**, visit the [Spaces main page](https://huggingface.co/spaces) and click on **Create new Space**. Along with choosing a name for your Space, selecting an optional license, and setting your Space's [visibility](#space-visibility) (public, protected, or private), you'll be prompted to choose the **SDK** for your Space. The Hub offers three SDK options: Gradio, Docker and static HTML. If you select "Gradio" as your SDK, you'll be navigated to a new repo showing the following page:
 
+> [!WARNING]
+> Static Spaces are free for everyone. Gradio and Docker Spaces run on compute and require a paid plan to create: <a href="https://huggingface.co/pro">PRO</a> for personal accounts, <a href="https://huggingface.co/enterprise">Team or Enterprise</a> for organizations. Free personal accounts in good standing can still host up to 2 Gradio Spaces running on [ZeroGPU](./spaces-zerogpu).
+
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-blank-space.png"/>
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-blank-space-dark.png"/>
@@ -43,7 +46,7 @@ You can set a Space's visibility from the **Settings** tab using the visibility 
 
 ## Hardware resources
 
-Each Spaces environment is limited to 16GB RAM, 2 CPU cores and 50GB of (not persistent) disk space by default, which you can use free of charge. You can upgrade to better hardware, including a variety of GPU accelerators, for a [competitive price](https://huggingface.co/pricing#spaces). To request an upgrade, please click the _Settings_ button in your Space and select your preferred hardware environment.
+Each Spaces environment is limited to 16GB RAM, 2 CPU cores and 50GB of (not persistent) disk space by default. The default CPU Basic hardware has no hourly cost, but creating a Space that runs on compute (Gradio or Docker) requires a paid plan, while Static Spaces are free for everyone. You can upgrade to better hardware, including a variety of GPU accelerators, for a [competitive price](https://huggingface.co/pricing#spaces). To request an upgrade, please click the _Settings_ button in your Space and select your preferred hardware environment.
 
 | **Hardware**           | **CPU**       | **Memory**   | **GPU Memory**  | **Hourly Price**  |
 |----------------------- |-------------- |------------- |---------------- | ----------------- |
@@ -117,7 +120,7 @@ If you want to duplicate a Space, you can click the three dots at the top right 
 * Storage: If the original repo uses a storage bucket, you will be prompted to configure storage. Read more about disk usage and storage [here](./spaces-storage).
 * Secrets and variables: If the original repo has set some secrets and variables, you'll be able to set them while duplicating the repo.
 
-Some Spaces might have environment variables that you may need to set up. In these cases, the duplicate workflow will auto-populate the public Variables from the source Space, and give you a warning about setting up the Secrets. The duplicated Space will use a free CPU hardware by default, but you can later upgrade if needed.
+Some Spaces might have environment variables that you may need to set up. In these cases, the duplicate workflow will auto-populate the public Variables from the source Space, and give you a warning about setting up the Secrets. The duplicated Space will use CPU Basic hardware by default, but you can later upgrade if needed. Duplicating follows the same rules as creating a new Space: duplicating a Gradio or Docker Space requires a paid plan for the target account or organization (with the same [ZeroGPU free tier](./spaces-zerogpu) exception for personal accounts).
 
 ## Networking
 

--- a/docs/hub/spaces-sdks-static.md
+++ b/docs/hub/spaces-sdks-static.md
@@ -2,6 +2,8 @@
 
 Spaces also accommodate custom HTML for your app instead of using Streamlit or Gradio. Set `sdk: static` inside the `YAML` block at the top of your Spaces **README.md** file. Then you can place your HTML code within an **index.html** file.
 
+Static Spaces are free for everyone: they are served directly without running on compute, so unlike [Gradio](./spaces-sdks-gradio) and [Docker](./spaces-sdks-docker) Spaces, creating them never requires a paid plan.
+
 Here are some examples of Spaces using custom HTML:
 
 * [Smarter NPC](https://huggingface.co/spaces/mishig/smarter_npc): Display a PlayCanvas project with an iframe in Spaces.

--- a/docs/hub/spaces-zerogpu.md
+++ b/docs/hub/spaces-zerogpu.md
@@ -15,7 +15,8 @@ Unlike traditional single-GPU allocations, ZeroGPU's efficient system lowers bar
   - ZeroGPU Spaces are available to use for free to all users. (Visit [the curated list](https://huggingface.co/spaces/enzostvs/zero-gpu-spaces)).
   - [PRO users](https://huggingface.co/subscribe/pro) get x8 more daily usage quota, highest priority in GPU queues, and can go beyond their daily quota using pre-paid credits when using any ZeroGPU Spaces.
 - **Hosting your own ZeroGPU Spaces**
-  - Personal accounts: [Subscribe to PRO](https://huggingface.co/settings/billing/subscription) to access ZeroGPU in the hardware options when creating a new Gradio SDK Space.
+  - Free personal accounts: accounts in good standing (verified email, account older than 30 days) can host up to 2 ZeroGPU Spaces for free.
+  - PRO accounts: [Subscribe to PRO](https://huggingface.co/settings/billing/subscription) to host up to 10 ZeroGPU Spaces under your account.
   - Organizations: [Subscribe to a Team or Enterprise plan](https://huggingface.co/enterprise) to enable ZeroGPU Spaces for all organization members.
 
 ## Technical Specifications
@@ -175,6 +176,7 @@ You can add credits from your [billing settings](https://huggingface.co/settings
 
 ## Hosting Limitations
 
+- **Free personal accounts**: Maximum of 2 ZeroGPU Spaces, for accounts in good standing (verified email, account older than 30 days).
 - **Personal accounts ([PRO subscribers](https://huggingface.co/subscribe/pro))**: Maximum of 10 ZeroGPU Spaces.
 - **Organization accounts ([Team & Enterprise](https://huggingface.co/enterprise))**: Maximum of 50 ZeroGPU Spaces.
 


### PR DESCRIPTION
## What

Updates the Spaces documentation to match the new creation UX:

- Static Spaces stay free for everyone.
- Creating Gradio and Docker Spaces (anything that runs on compute, including CPU Basic) requires a paid plan: PRO for personal accounts, Team or Enterprise for organizations.
- Free personal accounts in good standing (verified email, account older than 30 days) can host up to 2 ZeroGPU Spaces. PRO accounts up to 10, paid organizations up to 50.
- Duplication follows the same rules as creation.

## Files

- `spaces-overview.md`: creation gate warning, hardware section wording, duplication note
- `spaces-gpus.md`: note under the CPU hardware table
- `spaces-zerogpu.md`: document the free tier in hosting section and hosting limitations
- `pro.md` / `billing.md`: PRO benefits bullet aligned with the pricing page copy
- `spaces-sdks-static.md`: static Spaces never require a paid plan

## When to merge

Draft until the corresponding Hub-side change is deployed. The ZeroGPU free tier is already live; the compute creation gate is not yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no runtime or security impact; note the PR is intended to merge after the Hub creation gate ships.
> 
> **Overview**
> Updates Hub docs to match the new Spaces creation rules: **static** Spaces stay free; **Gradio and Docker** (compute, including CPU Basic) require **PRO** (personal) or **Team/Enterprise** (orgs) to create or duplicate, with a **ZeroGPU** carve-out for eligible free personal accounts (up to **2** hosted Spaces; **PRO** up to **10**, orgs up to **50**).
> 
> Adds creation warnings in `spaces-overview.md`, a CPU Basic note in `spaces-gpus.md`, static-SDK clarification in `spaces-sdks-static.md`, and expanded ZeroGPU hosting limits in `spaces-zerogpu.md`. **PRO** / **billing** benefit bullets now mention compute Gradio/Docker creation plus the 10 ZeroGPU cap; billing copy no longer calls compute’s free tier “comprehensive.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbd84173f7e0cbab6bf863bc5970cd201726355d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->