### PR TITLE
Add a DVC example to the Storage Buckets S3 page

### DIFF
--- a/docs/hub/storage-buckets-s3.md
+++ b/docs/hub/storage-buckets-s3.md
@@ -258,4 +258,4 @@ dvc push
 ```
 
 > [!NOTE]
-> Use your [namespace](#addressing-buckets) in `endpointurl` and the bare bucket name in the `s3://` URL. If `dvc push` fails with a checksum error, set `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` and `AWS_RESPONSE_CHECKSUM_VALIDATION=when_required` — recent `boto3` sends trailing checksums the gateway does not accept.
+> Use your [namespace](#addressing-buckets) in `endpointurl` and the bare bucket name in the `s3://` URL.

--- a/docs/hub/storage-buckets-s3.md
+++ b/docs/hub/storage-buckets-s3.md
@@ -231,3 +231,31 @@ rclone sync aws:my-source-bucket hf:my-bucket --progress
 
 > [!TIP]
 > For large imports, add `--transfers` and `--checkers` to raise the concurrency (e.g. `--transfers 16 --checkers 16`), and run `rclone check aws:my-source-bucket hf:my-bucket` afterwards to confirm every object made it across.
+
+### Version data with DVC
+
+[DVC](https://dvc.org/) versions datasets and models in git by keeping small pointer files in the repository and pushing the actual data to a remote. A bucket works as a DVC remote through the gateway, so your code and `.dvc` pointers stay in git while the data lives in your bucket. Install DVC with S3 support (`pip install 'dvc[s3]'`), then add the remote using the [client settings](#configuring-a-client) above:
+
+```bash
+dvc remote add -d hf-bucket s3://my-bucket/dvc-store
+dvc remote modify hf-bucket endpointurl https://s3.hf.co/<namespace>
+dvc remote modify hf-bucket region us-east-1
+```
+
+Pass the [S3 credentials](#generating-s3-credentials) through the environment, or with `dvc remote modify --local` so they stay out of git:
+
+```bash
+export AWS_ACCESS_KEY_ID=HFAK...
+export AWS_SECRET_ACCESS_KEY=...
+```
+
+Then track, push, and pull as usual — `dvc push` uploads to the bucket, and `dvc pull` on a fresh clone downloads it back:
+
+```bash
+dvc add data/
+git add data.dvc .gitignore .dvc/config && git commit -m "Track data with DVC"
+dvc push
+```
+
+> [!NOTE]
+> Use your [namespace](#addressing-buckets) in `endpointurl` and the bare bucket name in the `s3://` URL. If `dvc push` fails with a checksum error, set `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` and `AWS_RESPONSE_CHECKSUM_VALIDATION=when_required` — recent `boto3` sends trailing checksums the gateway does not accept.


### PR DESCRIPTION
Adds a **Version data with DVC** recipe to the Storage Buckets S3 page's Examples section, alongside the existing boto3 / DuckDB / rclone examples.

DVC can use a bucket as a [DVC remote](https://dvc.org/) through the S3-compatible gateway — code and `.dvc` pointers stay in git, the data lives in the bucket.

Follows the existing example pattern; references the page's own Credentials / Client / Addressing sections instead of restating them. One section, no new page, no `_toctree.yml` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code, config, or runtime behavior impact.
> 
> **Overview**
> Adds a **Version data with DVC** example to the Storage Buckets S3 **Examples** section, next to the existing `boto3`, DuckDB, and `rclone` recipes.
> 
> The new section explains using a bucket as a DVC S3 remote via the gateway: `pip install 'dvc[s3]'`, `dvc remote add` / `endpointurl` / `region`, credentials via env or `--local`, and a short `dvc add` → commit → `dvc push` flow. It links to the page’s **Configuring a client**, **Generating S3 credentials**, and **Addressing buckets** sections instead of duplicating them, and notes putting the namespace in `endpointurl` and the bare bucket name in the `s3://` URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cca2d7d571b065b6465c6b525bccf5c780099ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->