### PR TITLE
Fix Sagemaker tutorial examples' links

### DIFF
--- a/docs/sagemaker/scripts/auto-generate-examples.py
+++ b/docs/sagemaker/scripts/auto-generate-examples.py
@@ -102,7 +102,7 @@ def process_file(root, file, dirname):
         print("No relative paths found in the processed file.")
 
     # Calculate the example URL
-    example_url = f"https://github.com/huggingface/hub-docs/tree/{BRANCH_NAME}/{root}"
+    example_url = f"https://github.com/huggingface/hub-docs/tree/{BRANCH_NAME}/docs/sagemaker/{root}"
     if file.__contains__("sagemaker-notebook"):
         example_url += "/sagemaker-notebook.ipynb"
 


### PR DESCRIPTION
Previous implementation generated urls of this shape `https://github.com/huggingface/hub-docs/tree/{BRANCH_NAME}/{root}` while the correct one is "https://github.com/huggingface/hub-docs/tree/{BRANCH_NAME}/docs/sagemaker/{root}"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line URL fix in a docs generation script; no runtime or security impact.
> 
> **Overview**
> Fixes broken **“Find the complete example on GitHub”** links appended when `auto-generate-examples.py` converts SageMaker notebook READMEs into MDX.
> 
> The generated `example_url` now includes the `docs/sagemaker/` path segment (`.../tree/{branch}/docs/sagemaker/{root}`), matching how other link rewrites in the same script already point into the repo. Previously the tip linked to `.../tree/{branch}/{root}` only, which did not match where examples actually live.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e38912393ee1fc53b4acfd42fd5213f554d4ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->