### PR TITLE
Update models-downloading with downloading behind a proxy or firewall…

### DIFF
--- a/docs/hub/models-downloading.md
+++ b/docs/hub/models-downloading.md
@@ -82,3 +82,44 @@ hf-mount start repo openai-community/gpt2 /tmp/gpt2
 ```
 
 Repos are mounted read-only. See [Mount as a Local Filesystem](./storage-buckets-access#mount-as-a-local-filesystem) for full setup details, backend options, and caching.
+
+## Downloading behind a proxy or firewall
+
+If your network restricts outbound traffic through a firewall or proxy, downloading models and datasets requires more than just `huggingface.co`. File contents are served from separate storage and CDN hostnames, and `from_pretrained` / `hf download` will fail if these are not reachable, even when `huggingface.co` itself is allowlisted.
+
+Allowlist the following hostnames (all over HTTPS / port 443):
+
+| Hostname | Purpose |
+|---|---|
+| `huggingface.co` | Hub API, metadata, and download redirects |
+| `cas-server.xethub.hf.co` | Xet storage coordination (US) |
+| `transfer.xethub.hf.co` | Xet chunk transfer (US) |
+| `cas-bridge.xethub.hf.co` | Xet content delivery bridge (US) |
+| `cas-server.xethub-eu.hf.co` | Xet storage coordination (EU) |
+| `transfer.xethub-eu.hf.co` | Xet chunk transfer (EU) |
+| `cas-bridge.xethub-eu.hf.co` | Xet content delivery bridge (EU) |
+| `us.aws.cdn.hf.co` | CDN edge (AWS, US) |
+| `us.gcp.cdn.hf.co` | CDN edge (GCP, US) |
+| `cdn-lfs.hf.co` | LFS file content (legacy/global CDN) |
+| `cdn-lfs-us-1.hf.co` | LFS file content (US CDN) |
+| `cdn-lfs-eu-1.hf.co` | LFS file content (EU CDN) |
+| `cdn-lfs.huggingface.co` | LFS file content (legacy) |
+| `cdn-lfs-us-1.huggingface.co` | LFS file content (US, legacy) |
+| `cdn-lfs-eu-1.huggingface.co` | LFS file content (EU, legacy) |
+
+> [!TIP]
+> Downloads follow HTTP redirects from `huggingface.co` to these hostnames, so
+> allowlisting `huggingface.co` alone is not sufficient. A `ReadTimeoutError` (rather than
+> a connection error) partway through a download usually means the initial connection
+> succeeded but a storage or CDN host is blocked.
+
+> [!TIP]
+> If you use wildcard rules, `*.hf.co` and `*.xethub.hf.co` cover current and future
+> CDN and Xet endpoints. Note that the legacy `cdn-lfs*.huggingface.co` hosts are on
+> `huggingface.co`, not `hf.co`, so a `*.hf.co` wildcard does not cover them, keep
+> `*.huggingface.co` allowlisted as well, or list those hosts explicitly.
+
+> [!WARNING]
+> These hostnames may change as our storage and CDN infrastructure evolves. Where your
+> security policy allows it, prefer the `*.hf.co` / `*.xethub.hf.co` / `*.huggingface.co`
+> wildcards so allowlists don't break when a specific endpoint changes.

--- a/docs/hub/models-downloading.md
+++ b/docs/hub/models-downloading.md
@@ -92,14 +92,14 @@ Allowlist the following hostnames (all over HTTPS / port 443):
 | Hostname | Purpose |
 |---|---|
 | `huggingface.co` | Hub API, metadata, and download redirects |
-| `cas-server.xethub.hf.co` | Xet storage coordination (US) |
-| `transfer.xethub.hf.co` | Xet chunk transfer (US) |
-| `cas-bridge.xethub.hf.co` | Xet content delivery bridge (US) |
-| `cas-server.xethub-eu.hf.co` | Xet storage coordination (EU) |
-| `transfer.xethub-eu.hf.co` | Xet chunk transfer (EU) |
-| `cas-bridge.xethub-eu.hf.co` | Xet content delivery bridge (EU) |
-| `us.aws.cdn.hf.co` | CDN edge (AWS, US) |
-| `us.gcp.cdn.hf.co` | CDN edge (GCP, US) |
+| `cas-server.xethub.hf.co` | Xet storage protocol APIs + upload (US) |
+| `transfer.xethub.hf.co` | Xet storage download APIs (US) |
+| `cas-bridge.xethub.hf.co` | HTTP/LFS content delivery bridge, legacy (US) |
+| `cas-server.xethub-eu.hf.co` | Xet storage protocol APIs + upload (EU) |
+| `transfer.xethub-eu.hf.co` | Xet storage download APIs (EU) |
+| `cas-bridge.xethub-eu.hf.co` | HTTP/LFS content delivery bridge, legacy (EU) |
+| `us.aws.cdn.hf.co` | CDN edge (AWS) |
+| `us.gcp.cdn.hf.co` | CDN edge (GCP) |
 | `cdn-lfs.hf.co` | LFS file content (legacy/global CDN) |
 | `cdn-lfs-us-1.hf.co` | LFS file content (US CDN) |
 | `cdn-lfs-eu-1.hf.co` | LFS file content (EU CDN) |
@@ -114,12 +114,18 @@ Allowlist the following hostnames (all over HTTPS / port 443):
 > succeeded but a storage or CDN host is blocked.
 
 > [!TIP]
-> If you use wildcard rules, `*.hf.co` and `*.xethub.hf.co` cover current and future
-> CDN and Xet endpoints. Note that the legacy `cdn-lfs*.huggingface.co` hosts are on
-> `huggingface.co`, not `hf.co`, so a `*.hf.co` wildcard does not cover them, keep
-> `*.huggingface.co` allowlisted as well, or list those hosts explicitly.
+> Wildcard behavior depends on how your proxy matches domains. Many enterprise proxies
+> treat an allowlist entry as a suffix match that covers subdomains at any depth. If yours
+> does, the simplest option is to allowlist the suffixes `hf.co` and `huggingface.co` —
+> these cover every current and future storage and CDN endpoint.
+>
+> If your proxy only supports single-label wildcards (where `*.hf.co` matches
+> `cdn-lfs.hf.co` but not the deeper `us.aws.cdn.hf.co` or `cas-bridge.xethub.hf.co`),
+> allowlist the explicit hostnames from the table above. Note that `*.xethub.hf.co` does
+> not cover the EU hosts under `xethub-eu.hf.co`, and `*.cdn.hf.co` does not cover the
+> two-label `us.aws.cdn.hf.co` / `us.gcp.cdn.hf.co`.
 
 > [!WARNING]
 > These hostnames may change as our storage and CDN infrastructure evolves. Where your
-> security policy allows it, prefer the `*.hf.co` / `*.xethub.hf.co` / `*.huggingface.co`
-> wildcards so allowlists don't break when a specific endpoint changes.
+> security policy allows it, allowlist the `hf.co` and `huggingface.co` suffixes (all
+> subdomains) so your rules don't break when a specific endpoint changes.

--- a/docs/hub/models-downloading.md
+++ b/docs/hub/models-downloading.md
@@ -89,23 +89,24 @@ If your network restricts outbound traffic through a firewall or proxy, download
 
 Allowlist the following hostnames (all over HTTPS / port 443):
 
-| Hostname | Purpose |
-|---|---|
-| `huggingface.co` | Hub API, metadata, and download redirects |
-| `cas-server.xethub.hf.co` | Xet storage protocol APIs + upload (US) |
-| `transfer.xethub.hf.co` | Xet storage download APIs (US) |
-| `cas-bridge.xethub.hf.co` | HTTP/LFS content delivery bridge, legacy (US) |
-| `cas-server.xethub-eu.hf.co` | Xet storage protocol APIs + upload (EU) |
-| `transfer.xethub-eu.hf.co` | Xet storage download APIs (EU) |
-| `cas-bridge.xethub-eu.hf.co` | HTTP/LFS content delivery bridge, legacy (EU) |
-| `us.aws.cdn.hf.co` | CDN edge (AWS) |
-| `us.gcp.cdn.hf.co` | CDN edge (GCP) |
-| `cdn-lfs.hf.co` | LFS file content (legacy/global CDN) |
-| `cdn-lfs-us-1.hf.co` | LFS file content (US CDN) |
-| `cdn-lfs-eu-1.hf.co` | LFS file content (EU CDN) |
-| `cdn-lfs.huggingface.co` | LFS file content (legacy) |
-| `cdn-lfs-us-1.huggingface.co` | LFS file content (US, legacy) |
-| `cdn-lfs-eu-1.huggingface.co` | LFS file content (EU, legacy) |
+
+| Hostname                      | Purpose                                   |
+|-------------------------------|-------------------------------------------|
+| `huggingface.co`              | Hub API, metadata, and download redirects |
+| `cas-server.xethub.hf.co`     | Xet storage protocol APIs + upload (US)   |
+| `cas-server.xethub-eu.hf.co`  | Xet storage protocol APIs + upload (EU)   |
+| `transfer.xethub.hf.co`       | Xet storage download APIs (US)            |
+| `transfer.xethub-eu.hf.co`    | Xet storage download APIs (EU)            |
+| `cas-bridge.xethub.hf.co`     | Bridge CDN, legacy (US)                   |
+| `cas-bridge.xethub-eu.hf.co`  | Bridge CDN, legacy (EU)                   |
+| `us.aws.cdn.hf.co`            | CDN edge (US)                             |
+| `us.gcp.cdn.hf.co`            | CDN edge (US)                             |
+| `cdn-lfs.hf.co`               | LFS CDN, legacy (global)                  |
+| `cdn-lfs-us-1.hf.co`          | LFS CDN (US)                              |
+| `cdn-lfs-eu-1.hf.co`          | LFS CDN (EU)                              |
+| `cdn-lfs.huggingface.co`      | LFS CDN, legacy (global)                  |
+| `cdn-lfs-us-1.huggingface.co` | LFS CDN, legacy (US)                      |
+| `cdn-lfs-eu-1.huggingface.co` | LFS CDN, legacy (EU)                      |
 
 > [!TIP]
 > Downloads follow HTTP redirects from `huggingface.co` to these hostnames, so


### PR DESCRIPTION
Adds a "Downloading behind a proxy or firewall" section to the model downloading guide.

Downloads redirect from huggingface.co to separate storage, Xet, and CDN hosts, so allowlisting huggingface.co alone isn't enough; from_pretrained and hf download fail (typically a ReadTimeoutError mid-download) when those hosts are blocked. This list wasn't documented anywhere, so users in firewalled/proxied environments were reverse-engineering it from forum threads and third-party posts.

The new section lists the required hostnames (Hub API, Xet US/EU, CDN edges, and legacy LFS) with their purpose, plus wildcard guidance (*.hf.co / *.xethub.hf.co / *.huggingface.co) and a note on the legacy huggingface.co LFS hosts that *.hf.co doesn't cover.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the Hub model downloading guide; no application code, auth, or infrastructure behavior is modified.
> 
> **Overview**
> Adds a **Downloading behind a proxy or firewall** section to `models-downloading.md` after the hf-mount section.
> 
> It explains that downloads redirect from `huggingface.co` to separate Xet, storage, and CDN hosts, so allowlisting only the Hub domain is insufficient and `from_pretrained` / `hf download` can fail (often with `ReadTimeoutError` mid-download). The section documents an explicit HTTPS allowlist table (Hub API, Xet US/EU, CDN edges, legacy LFS hosts) and tips on suffix vs single-label wildcard rules, plus a warning that endpoint hostnames may change over time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a9e062fcd52676befbf7f050123c9f79cb96d33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->