### PR TITLE
Dask: show streaming read/write in bucket integrations

### DIFF
--- a/docs/hub/storage-buckets-integrations.md
+++ b/docs/hub/storage-buckets-integrations.md
@@ -15,11 +15,16 @@ df.to_parquet("hf://buckets/username/my-bucket/output.parquet")
 
 ## Dask
 
+Dask reads and writes lazily, one partition per file, so you can process datasets larger than memory straight from a bucket:
+
 ```python
 import dask.dataframe as dd
 
-df = dd.read_parquet("hf://buckets/username/my-bucket/data.parquet")
+df = dd.read_parquet("hf://buckets/username/my-bucket/data/")
+df.to_parquet("hf://buckets/username/my-bucket/output/")
 ```
+
+See [Dask on the Hub](./datasets-dask) for more.
 
 ## Daft
 


### PR DESCRIPTION
The Dask section under [Bucket Integrations](https://huggingface.co/docs/hub/storage-buckets-integrations) showed only a single-file read, while the neighbouring pandas section shows read + write. This:

- adds the streaming `to_parquet` write
- uses directory paths (Dask's partition-per-file model)
- links the canonical [Dask on the Hub](./datasets-dask) guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or security impact.
> 
> **Overview**
> Updates the **Dask** section in the bucket integrations doc so it matches how Dask is actually used with buckets and aligns better with the pandas example nearby.
> 
> Adds a short note that Dask reads/writes **lazily** with **one partition per file**, so large datasets can be processed from a bucket without loading everything into memory. The sample now uses **directory** `hf://buckets/...` paths for `read_parquet` and includes **`to_parquet`** for writing output, instead of a single-file read only. A link to **[Dask on the Hub](./datasets-dask)** points readers to the fuller guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fafc0a82cf21350af13b0afad8741eb9cc74322. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->