### PR TITLE
Document `hf models ls --inference-provider` / `--warm` on the Inference Providers Hub API page

### DIFF
--- a/docs/inference-providers/guides/first-api-call.md
+++ b/docs/inference-providers/guides/first-api-call.md
@@ -26,7 +26,7 @@ For this example, we'll use [FLUX.1-schnell](https://huggingface.co/black-forest
 > You can also do this step from the terminal — or have a coding agent do it for you. The `hf` CLI (installed with `huggingface_hub`) supports the same filters:
 >
 > ```bash
-> hf models ls --filter text-to-image --warm --sort trending_score
+> hf models ls --pipeline-tag text-to-image --warm --sort trending_score
 > ```
 >
 > Swap `--warm` for `--inference-provider fal-ai` to narrow to a specific provider, or add `--json` for machine-readable output. See the [Hub API page](https://huggingface.co/docs/inference-providers/hub-api) for the full set of filters.

--- a/docs/inference-providers/guides/first-api-call.md
+++ b/docs/inference-providers/guides/first-api-call.md
@@ -22,6 +22,15 @@ Visit the [Hugging Face Hub](https://huggingface.co/models?pipeline_tag=text-to-
 
 For this example, we'll use [FLUX.1-schnell](https://huggingface.co/black-forest-labs/FLUX.1-schnell), a powerful text-to-image model. Next, navigate to the model page and scroll down to find the inference widget on the right side. 
 
+> [!TIP]
+> You can also do this step from the terminal — or have a coding agent do it for you. The `hf` CLI (installed with `huggingface_hub`) supports the same filters:
+>
+> ```bash
+> hf models ls --filter text-to-image --warm --sort trending_score
+> ```
+>
+> Swap `--warm` for `--inference-provider fal-ai` to narrow to a specific provider, or add `--json` for machine-readable output. See the [Hub API page](https://huggingface.co/docs/inference-providers/hub-api) for the full set of filters.
+
 ## Step 2: Try the Interactive Widget
 
 Before writing any code, try the widget directly on the [model page](https://huggingface.co/black-forest-labs/FLUX.1-dev?inference_provider=fal-ai):  

--- a/docs/inference-providers/hub-api.md
+++ b/docs/inference-providers/hub-api.md
@@ -52,6 +52,18 @@ Finally, you can select all models served by at least one inference provider:
 "BagOu22/Lora_HKLPAZ"
 ```
 
+The same filters are available from the terminal with the [`hf` CLI](https://huggingface.co/docs/huggingface_hub/package_reference/cli#hf-models-list):
+
+```sh
+# List models served by Fireworks AI, most downloaded first
+~ hf models ls --inference-provider fireworks-ai --sort downloads
+
+# List "llama" models served by at least one provider
+~ hf models ls --warm --search llama
+```
+
+Repeat `--inference-provider` to match models served by any of several providers. Add `--expand inferenceProviderMapping` to see which provider serves each model and the provider-specific model id.
+
 ## Get model status
 
 To find an inference provider for a specific model, request the `inference` attribute in the model info endpoint:

--- a/docs/inference-providers/hub-api.md
+++ b/docs/inference-providers/hub-api.md
@@ -58,14 +58,14 @@ The same filters are available from the terminal with the [`hf` CLI](https://hug
 # List models served by at least one inference provider
 hf models ls --warm
 
-# Is GLM-5.2 served by at least one provider?
+# Check whether GLM-5.2 is served by at least one provider
 hf models ls --warm --search GLM-5.2
 
 # List models served by Fireworks AI, most downloaded first
 hf models ls --inference-provider fireworks-ai --sort downloads
 ```
 
-Repeat `--inference-provider` to match models served by any of several providers. Add `--expand inferenceProviderMapping` to see which provider serves each model and the provider-specific model id.
+Repeat `--inference-provider` to match models served by any of several providers. Add `--expand inferenceProviderMapping` to see which provider serves each model and the provider-specific model id, or `--json` for machine-readable output.
 
 ## Get model status
 

--- a/docs/inference-providers/hub-api.md
+++ b/docs/inference-providers/hub-api.md
@@ -54,12 +54,15 @@ Finally, you can select all models served by at least one inference provider:
 
 The same filters are available from the terminal with the [`hf` CLI](https://huggingface.co/docs/huggingface_hub/package_reference/cli#hf-models-list):
 
-```sh
-# List models served by Fireworks AI, most downloaded first
-~ hf models ls --inference-provider fireworks-ai --sort downloads
+```bash
+# List models served by at least one inference provider
+hf models ls --warm
 
-# List "llama" models served by at least one provider
-~ hf models ls --warm --search llama
+# Is GLM-5.2 served by at least one provider?
+hf models ls --warm --search GLM-5.2
+
+# List models served by Fireworks AI, most downloaded first
+hf models ls --inference-provider fireworks-ai --sort downloads
 ```
 
 Repeat `--inference-provider` to match models served by any of several providers. Add `--expand inferenceProviderMapping` to see which provider serves each model and the provider-specific model id.

--- a/docs/inference-providers/hub-api.md
+++ b/docs/inference-providers/hub-api.md
@@ -58,7 +58,7 @@ The same filters are available from the terminal with the [`hf` CLI](https://hug
 # List models served by at least one inference provider
 hf models ls --warm
 
-# Check whether GLM-5.2 is served by at least one provider
+# Search served models for GLM-5.2
 hf models ls --warm --search GLM-5.2
 
 # List text-to-image models served by Fal AI

--- a/docs/inference-providers/hub-api.md
+++ b/docs/inference-providers/hub-api.md
@@ -61,6 +61,9 @@ hf models ls --warm
 # Check whether GLM-5.2 is served by at least one provider
 hf models ls --warm --search GLM-5.2
 
+# List text-to-image models served by Fal AI
+hf models ls --inference-provider fal-ai --pipeline-tag text-to-image
+
 # List models served by Fireworks AI, most downloaded first
 hf models ls --inference-provider fireworks-ai --sort downloads
 ```

--- a/docs/inference-providers/index.md
+++ b/docs/inference-providers/index.md
@@ -98,6 +98,8 @@ Before diving into integration, explore models interactively with our [Inference
 
 <a href="https://huggingface.co/playground" target="blank"><img src="https://cdn-uploads.huggingface.co/production/uploads/5f17f0a0925b9863e28ad517/9_Tgf0Tv65srhBirZQMTp.png" alt="Inference Playground thumbnail" style="max-width: 550px; width: 100%;"/></a>
 
+Prefer the terminal? Run `hf models ls --warm` with the [`hf` CLI](https://huggingface.co/docs/huggingface_hub/package_reference/cli#hf-models-list) to list every model served by at least one provider, and add `--json` for scripts and agents. See the [Hub API](./hub-api) page for the full set of filters.
+
 ### Authentication
 
 You'll need a Hugging Face token to authenticate your requests. Create one by visiting your [token settings](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained) and generating a `fine-grained` token with `Make calls to Inference Providers` permissions.


### PR DESCRIPTION
## What

Documents the new `hf models ls` inference-provider discovery flags (huggingface/huggingface_hub#4497, motivated by huggingface/huggingface_hub#4441: humans *and* coding agents need a one-command way to find "models I can actually call") in three places:

- **`hub-api.md` (List models)**: CLI examples alongside the existing `curl` filters — `--warm`, `--warm --search GLM-5.2`, `--inference-provider fireworks-ai --sort downloads` — plus `--expand inferenceProviderMapping` / `--json` pointers.
- **`guides/first-api-call.md` (Step 1)**: a TIP showing the terminal/agent equivalent of the browser model-search step, so the guide is followable end-to-end without a browser.
- **`index.md` (Inference Playground)**: a one-sentence terminal pointer next to the Playground option.

All documented commands and variants verified against a git-main install of `huggingface_hub`.

## Why draft

The flags are merged but not yet in a `huggingface_hub` release (latest is v1.22.0, 2026-07-03). Marking ready once the next release ships so the docs don't point at commands users can't run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior; the only caveat is users may not have the CLI flags until the next `huggingface_hub` release.
> 
> **Overview**
> Documents **`hf models ls`** discovery flags (`--warm`, `--inference-provider`, `--pipeline-tag`, `--search`, `--sort`, `--json`, `--expand inferenceProviderMapping`) as the terminal equivalent of existing Hub API `curl` filters.
> 
> On **`hub-api.md`**, a new CLI section sits after the **List models** `curl` examples with sample commands and notes on repeating `--inference-provider` and machine-readable output.
> 
> **`guides/first-api-call.md`** adds a TIP under Step 1 so model search can be done from the terminal or by agents without the browser.
> 
> **`index.md`** adds a one-line terminal pointer next to the Inference Playground section, linking to the Hub API page for full filters.
> 
> **Note:** These CLI flags depend on a **`huggingface_hub`** release newer than what users may have installed today; the PR description flags that timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71df584373d040e624aae336ac92fbac5864d82e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->