### PR TITLE
Remove FAQ on choosing inference container referencing TGI

### DIFF
--- a/docs/sagemaker/source/dlcs/available.md
+++ b/docs/sagemaker/source/dlcs/available.md
@@ -61,14 +61,6 @@ Finally, there is the Text Embeddings Inference (TEI) DLC for high-performance s
 
 ## FAQ
 
-**How to choose the right inference container for my use case?**
-
-![inference-dlc-decision-tree](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/sagemaker/inference-dlc-decision-tree.png)
-
-*Note:* See [here](https://huggingface.co/docs/sagemaker/main/en/reference/inference-toolkit) for the list of supported task in the inference toolkit.
-
-*Note:* Browse through the Hub to see if your model is tagged ["text-generation-inference"](https://huggingface.co/models?other=text-generation-inference) or ["text-embeddings-inference"](https://huggingface.co/models?other=text-embeddings-inference).
-
 **How to find the URI of my container?**
 
 The URI is built with an AWS account ID and an AWS region. Those two values need to be replaced depending on your use case.


### PR DESCRIPTION
Removed FAQ section about choosing the right inference container referencing TGI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only deletion with no runtime or configuration impact.
> 
> **Overview**
> Removes the **FAQ** entry *“How to choose the right inference container for my use case?”* from the SageMaker DLC availability doc, including the decision-tree image and notes linking to the inference toolkit and Hub tags for TGI/TEI.
> 
> Other FAQ items (finding container URIs and `image_uris.retrieve`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35696e6bc72b5363c275d0a454ac9e65eecfe2f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->