### PR TITLE
fix: Grammar error in xet upload docs

### DIFF
--- a/docs/xet/upload-protocol.md
+++ b/docs/xet/upload-protocol.md
@@ -2,7 +2,7 @@
 
 This document describes how files are uploaded in the Xet protocol to the Content Addressable Storage (CAS) service.
 The flow converts input files into chunks, applies deduplication, groups chunks into xorbs, uploads xorbs, then forms and uploads shards that reference those xorbs.
-The steps can be done all be done concurrently except that all xorbs MUST be uploaded before a shard referencing them is uploaded.
+The steps can all be done concurrently except that all xorbs MUST be uploaded before a shard referencing them is uploaded.
 Content addressing uses hashes as stable keys for deduplication and integrity verification.
 
 ## Xet Object Types

--- a/docs/xet/upload-protocol.md
+++ b/docs/xet/upload-protocol.md
@@ -35,7 +35,7 @@ Xorbs are always less than or equal to 64MiB in length and on average contain 10
 A file reconstruction is a "recipe" to recreate a file using data from xorbs.
 
 Each file reconstruction is made of a series of "terms" where each term contains a xorb hash and a chunk index range.
-To reconstruct a file, a user needs will need the chunks at the specified range for each term, deserialized and decompressed and concatenated in term order.
+To reconstruct a file, a user will need the chunks at the specified range for each term, deserialized and decompressed and concatenated in term order.
 
 ### Shards
 


### PR DESCRIPTION
Removes 2 tiny double-word errors in xet spec upload docs page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no runtime or API impact.
> 
> **Overview**
> **Documentation-only** edits in `docs/xet/upload-protocol.md` for clearer wording.
> 
> The concurrency sentence drops a duplicated **“be”** (“can all be done” → “can all be done” after removing “all be”). The file reconstruction sentence fixes **“a user needs will need”** to **“a user will need”**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f6353d6502e1fe401fcef7447d95ada16df977c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->