### PR TITLE
Add SkyPilot to storage bucket integrations

### DIFF
--- a/docs/hub/storage-buckets-access.md
+++ b/docs/hub/storage-buckets-access.md
@@ -8,10 +8,11 @@ Beyond the [CLI and Python SDK](./storage-buckets#managing-files), there are sev
 |--------|----------|---------|
 | **hf-mount** | Mount as local filesystem — any tool works | [See below](#mount-as-a-local-filesystem) |
 | **Volume mounts** | HF Jobs & Spaces (same idea, managed for you) | [See below](#volume-mounts-in-jobs-and-spaces) |
-| **SkyPilot** | Cloud training/serving jobs across 20+ clouds | [Bucket Integrations](./storage-buckets-integrations#skypilot) |
 | **hf:// paths** (fsspec) | Python data tools (pandas, DuckDB) | [See below](#python-data-tools) |
 | **CLI sync** | Batch transfers, backups | [Sync docs](./storage-buckets#syncing-directories) |
 | **S3 API** | Existing S3 tooling (AWS CLI, boto3, s5cmd) | [S3-Compatible API](./storage-buckets-s3) |
+
+For tools that use buckets as a backend (SkyPilot, Inspect, …), see [Integrations](./storage-buckets-integrations).
 
 ## Mount as a Local Filesystem
 

--- a/docs/hub/storage-buckets-access.md
+++ b/docs/hub/storage-buckets-access.md
@@ -8,6 +8,7 @@ Beyond the [CLI and Python SDK](./storage-buckets#managing-files), there are sev
 |--------|----------|---------|
 | **hf-mount** | Mount as local filesystem — any tool works | [See below](#mount-as-a-local-filesystem) |
 | **Volume mounts** | HF Jobs & Spaces (same idea, managed for you) | [See below](#volume-mounts-in-jobs-and-spaces) |
+| **SkyPilot** | Cloud training/serving jobs across 20+ clouds | [Bucket Integrations](./storage-buckets-integrations#skypilot) |
 | **hf:// paths** (fsspec) | Python data tools (pandas, DuckDB) | [See below](#python-data-tools) |
 | **CLI sync** | Batch transfers, backups | [Sync docs](./storage-buckets#syncing-directories) |
 | **S3 API** | Existing S3 tooling (AWS CLI, boto3, s5cmd) | [S3-Compatible API](./storage-buckets-s3) |

--- a/docs/hub/storage-buckets-integrations.md
+++ b/docs/hub/storage-buckets-integrations.md
@@ -79,6 +79,48 @@ inspect view
 
 See [Inspect's eval logs guide](https://inspect.aisi.org.uk/eval-logs.html#sec-hugging-face-storage-buckets) for details.
 
+## SkyPilot
+
+[SkyPilot](https://docs.skypilot.co/) runs AI workloads across 20+ clouds, Kubernetes, and on-prem, and can use Hugging Face storage as a backend — so one bucket is readable from every cloud with no per-cloud copies. Set `store: hf` on a `file_mounts` entry to mount a bucket read-write or a repo read-only:
+
+```yaml
+# qwen-sft.yaml — launch anywhere: sky launch qwen-sft.yaml --infra aws|gcp|...
+resources:
+  accelerators: H100:1
+
+file_mounts:
+  /base-model:
+    source: hf://Qwen/Qwen2.5-3B           # model repo, read-only
+    store: hf
+    mode: MOUNT
+  /data:
+    source: hf://datasets/username/my-data@v1.0   # dataset repo, pinned to a tag, read-only
+    store: hf
+    mode: MOUNT
+  /checkpoints:
+    source: hf://buckets/username/qwen-sft   # bucket, read-write — checkpoints sync back
+    store: hf
+    mode: MOUNT
+
+run: |
+  python train.py --model /base-model --output_dir /checkpoints
+```
+
+Authenticate once - `hf auth login` (or `export HF_TOKEN=<your-token>`) is all SkyPilot needs. It forwards your local Hugging Face token to every cloud, so the bucket and repo mounts authenticate automatically:
+
+```bash
+pip install "skypilot[huggingface]"
+hf auth login                              # or: export HF_TOKEN=<your-token>
+sky launch qwen-sft.yaml
+```
+
+If your own `run` code pulls gated repos, add `--secret HF_TOKEN` to the launch command to also expose the token as an env var.
+
+> [!TIP]
+> `MOUNT` and `MOUNT_CACHED` behave identically for `hf` and use the [hf-mount](https://github.com/huggingface/hf-mount) FUSE backend, which needs a base image with glibc ≥ 2.34 and `/dev/fuse`. Bare-VM clouds provide both. SkyPilot's default Kubernetes image ships older glibc, so set a newer `image_id` (e.g. `docker:mirror.gcr.io/ubuntu:22.04`). See the [SkyPilot storage docs](https://docs.skypilot.co/en/latest/reference/storage.html) for the current environment requirements.
+
+See the [SkyPilot + Hugging Face storage blog post](https://huggingface.co/blog/skypilot-hf-storage) for benchmarks and a full walkthrough.
+
 ## Filesystem operations
 
 For direct file operations, `huggingface_hub` exposes a pre-instantiated [filesystem object](/docs/huggingface_hub/guides/hf_file_system), `hffs`:


### PR DESCRIPTION
Adds SkyPilot to the Storage Buckets docs:

- `storage-buckets-integrations.md` - new `## SkyPilot` section showing
  `store: hf` file mounts (read-only model/dataset repos + a read-write
  bucket for checkpoints), the auth flow, and a note on hf-mount's base-image
  requirements.
- `storage-buckets-access.md` - a SkyPilot row in the access-method table,
  linking to the new section.

Context: https://huggingface.co/blog/skypilot-hf-storage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security behavior impact.
> 
> **Overview**
> Documents using **SkyPilot** with Hugging Face storage buckets and repos via the integrations guide.
> 
> **`storage-buckets-integrations.md`** adds a **SkyPilot** section: `store: hf` on `file_mounts` for read-only model/dataset repos and read-write buckets (example training YAML), auth with `hf auth login` / `HF_TOKEN` and `skypilot[huggingface]`, optional `--secret HF_TOKEN` for gated repos, a tip on hf-mount glibc/FUSE image requirements on Kubernetes, and a link to the SkyPilot + HF blog post.
> 
> **`storage-buckets-access.md`** adds a short pointer under the access-method table to the integrations page (SkyPilot alongside Inspect).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf096e767a0dd1801b22c96fc689a8e39c800899. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->