### PR TITLE
Document publisher gating download blocking and blocked regions

### DIFF
--- a/docs/hub/enterprise-gating-group-collections.md
+++ b/docs/hub/enterprise-gating-group-collections.md
@@ -143,7 +143,7 @@ Organizations can customize the gating parameters as well as the user informatio
 
 ## Advanced settings
 
-Enterprise Plus organizations can block visitors from specific locations across all of their models and datasets. These settings live in the **Publisher Analytics** settings, under the **Advanced Gating** tab.
+Enterprise Plus organizations can automatically reject or block visitors from specific locations across all of their models and datasets. These settings live in the **Publisher Analytics** settings, under the **Advanced Gating** tab.
 
 ### Blocked locations
 

--- a/docs/hub/enterprise-gating-group-collections.md
+++ b/docs/hub/enterprise-gating-group-collections.md
@@ -161,9 +161,6 @@ The **Enforcement** setting controls what blocked visitors are denied:
 
 Enforcement applies to visitors from the blocked countries and regions, whether or not they are signed in. Members of the organization are not exempt.
 
-> [!TIP]
-> Blocking is based on IP geolocation, which is best-effort. Use it to enforce a policy, not as a hard security boundary.
-
 ## Access gated repos in a Gating Group Collection as a user
 
 A Gated Group Collection shows a specific icon next to its name:

--- a/docs/hub/enterprise-gating-group-collections.md
+++ b/docs/hub/enterprise-gating-group-collections.md
@@ -145,13 +145,6 @@ Organizations can customize the gating parameters as well as the user informatio
 
 Enterprise Plus organizations can automatically reject or block visitors from specific locations across all of their models and datasets. These settings live in the **Publisher Analytics** settings, under the **Advanced Gating** tab.
 
-### Blocked locations
-
-Two lists define the blocked locations:
-
-- **Blocked countries**: countries, identified by their [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code.
-- **Blocked regions**: specific territories to block in addition to the countries above, for territories that are not distinct countries and therefore cannot be selected in the list above.
-
 ### Enforcement
 
 The **Enforcement** setting controls what blocked visitors are denied:
@@ -160,6 +153,13 @@ The **Enforcement** setting controls what blocked visitors are denied:
 - **All repositories**: in addition to auto-rejecting access requests, downloads are denied on every repository of the organization, including public ones. Blocked visitors see a "not available in your region" notice on the repository page, and the dataset viewer is disabled for them.
 
 Enforcement applies to visitors from the blocked countries and regions, whether or not they are signed in. Members of the organization are not exempt.
+
+### Blocked locations
+
+Two lists define the blocked locations:
+
+- **Blocked countries**: countries, identified by their [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code.
+- **Blocked regions**: specific territories to block in addition to the countries above, for territories that are not distinct countries and therefore cannot be selected in the list above.
 
 ## Access gated repos in a Gating Group Collection as a user
 

--- a/docs/hub/enterprise-gating-group-collections.md
+++ b/docs/hub/enterprise-gating-group-collections.md
@@ -150,7 +150,7 @@ Enterprise Plus organizations can block visitors from specific locations across 
 Two lists define the blocked locations:
 
 - **Blocked countries**: countries, identified by their [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code.
-- **Blocked regions**: specific territories to block in addition to the countries above, for territories that are not distinct countries and therefore cannot be selected in the list above. The available regions are Crimea, Sevastopol, Donetsk and Luhansk.
+- **Blocked regions**: specific territories to block in addition to the countries above, for territories that are not distinct countries and therefore cannot be selected in the list above.
 
 ### Enforcement
 

--- a/docs/hub/enterprise-gating-group-collections.md
+++ b/docs/hub/enterprise-gating-group-collections.md
@@ -143,7 +143,26 @@ Organizations can customize the gating parameters as well as the user informatio
 
 ## Advanced settings
 
-Enterprise Plus organizations can define **blocked countries** to automatically reject access requests across their gated models and datasets. This setting is available in the **Publisher Analytics** settings, under the **Advanced Gating** tab.
+Enterprise Plus organizations can block visitors from specific locations across all of their models and datasets. These settings live in the **Publisher Analytics** settings, under the **Advanced Gating** tab.
+
+### Blocked locations
+
+Two lists define the blocked locations:
+
+- **Blocked countries**: countries, identified by their [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code.
+- **Blocked regions**: specific territories to block in addition to the countries above, for territories that are not distinct countries and therefore cannot be selected in the list above. The available regions are Crimea, Sevastopol, Donetsk and Luhansk.
+
+### Enforcement
+
+The **Enforcement** setting controls what blocked visitors are denied:
+
+- **Gated repositories**: access requests to the organization's gated repositories are auto-rejected.
+- **All repositories**: in addition to auto-rejecting access requests, downloads are denied on every repository of the organization, including public ones. Blocked visitors see a "not available in your region" notice on the repository page, and the dataset viewer is disabled for them.
+
+Enforcement applies to visitors from the blocked countries and regions, whether or not they are signed in. Members of the organization are not exempt.
+
+> [!TIP]
+> Blocking is based on IP geolocation, which is best-effort. Use it to enforce a policy, not as a hard security boundary.
 
 ## Access gated repos in a Gating Group Collection as a user
 


### PR DESCRIPTION
Updates the **Advanced settings** section of the Gating Group Collections page to cover the publisher gating changes that shipped for Enterprise Plus orgs.

Previously the docs only described **blocked countries** auto-rejecting access requests on gated repos. The settings now also include:

- **Blocked regions**, for territories that aren't distinct countries and so can't be picked from the country list.
- An **Enforcement** choice between "Gated repositories" (auto-reject access requests, the previous behavior) and "All repositories", which also denies downloads on every repo including public ones, shows a "not available in your region" notice, and disables the dataset viewer for blocked visitors.

Also notes that org members aren't exempt from enforcement.

### Notes for reviewers

- This content lives on the Gating Group Collections page because that's where the existing blocked-countries paragraph was. The "All repositories" scope applies org-wide and isn't specific to gating group collections, so it may deserve its own page or a home under the Enterprise docs. Happy to move it if you'd prefer.
- The **Advanced Gating** tab name is unchanged, though it now covers more than gating.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security behavior impact.
> 
> **Overview**
> Updates the **Advanced settings** section on the Gating Group Collections page to match current Enterprise Plus **Publisher Analytics → Advanced Gating** behavior.
> 
> The intro now describes **blocking or auto-rejecting visitors by location** across org models and datasets (not only auto-rejecting gated access requests). New **Enforcement** docs explain **Gated repositories** vs **All repositories** (download denial on public repos, regional notice, dataset viewer off). It also states enforcement applies to signed-in and anonymous visitors from blocked locations, and **org members are not exempt**.
> 
> A **Blocked locations** subsection adds **Blocked regions** alongside **Blocked countries** (ISO alpha-2), for territories that cannot be picked from the country list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8104760c16845a724d7f4b04496fbdb5327a69c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->