### PR TITLE
Document proxy/firewall hostnames for dataset downloads

### DIFF
--- a/docs/hub/datasets-downloading.md
+++ b/docs/hub/datasets-downloading.md
@@ -72,3 +72,44 @@ hf-mount start repo datasets/stanfordnlp/imdb /tmp/imdb
 ```
 
 Repos are mounted read-only. See [Mount as a Local Filesystem](./storage-buckets-access#mount-as-a-local-filesystem) for full setup details, backend options, and caching.
+
+## Downloading behind a proxy or firewall
+
+If your network restricts outbound traffic through a firewall or proxy, downloading datasets requires more than just `huggingface.co`. File contents are served from separate storage and CDN hostnames, and `load_dataset` / `hf download` will fail if these are not reachable, even when `huggingface.co` itself is allowlisted.
+
+Allowlist the following hostnames (all over HTTPS / port 443):
+
+| Hostname                     | Purpose                                   |
+|------------------------------|-------------------------------------------|
+| `huggingface.co`             | Hub API, metadata, and download redirects |
+| `cas-server.xethub.hf.co`    | Xet storage protocol APIs + upload (US)   |
+| `cas-server.xethub-eu.hf.co` | Xet storage protocol APIs + upload (EU)   |
+| `transfer.xethub.hf.co`      | Xet storage download APIs (US)            |
+| `transfer.xethub-eu.hf.co`   | Xet storage download APIs (EU)            |
+| `us.aws.cdn.hf.co`           | CDN edge (US)                             |
+| `us.gcp.cdn.hf.co`           | CDN edge (US)                             |
+| `cdn-lfs-us-1.hf.co`         | LFS CDN (US)                              |
+| `cdn-lfs-eu-1.hf.co`         | LFS CDN (EU)                              |
+
+> [!TIP]
+> Downloads follow HTTP redirects from `huggingface.co` to these hostnames, so
+> allowlisting `huggingface.co` alone is not sufficient. A `ReadTimeoutError` (rather than
+> a connection error) partway through a download usually means the initial connection
+> succeeded but a storage or CDN host is blocked.
+
+> [!TIP]
+> Wildcard behavior depends on how your proxy matches domains. Many enterprise proxies
+> treat an allowlist entry as a suffix match that covers subdomains at any depth. If yours
+> does, the simplest option is to allowlist the suffixes `hf.co` and `huggingface.co` —
+> these cover every current and future storage and CDN endpoint.
+>
+> If your proxy only supports single-label wildcards (where `*.hf.co` matches
+> `cdn-lfs-us-1.hf.co` but not the deeper `us.aws.cdn.hf.co` or `cas-server.xethub.hf.co`),
+> allowlist the explicit hostnames from the table above. Note that `*.xethub.hf.co` does
+> not cover the EU hosts under `xethub-eu.hf.co`, and `*.cdn.hf.co` does not cover the
+> two-label `us.aws.cdn.hf.co` / `us.gcp.cdn.hf.co`.
+
+> [!WARNING]
+> These hostnames may change as our storage and CDN infrastructure evolves. Where your
+> security policy allows it, allowlist the `hf.co` and `huggingface.co` suffixes (all
+> subdomains) so your rules don't break when a specific endpoint changes.

--- a/docs/hub/models-downloading.md
+++ b/docs/hub/models-downloading.md
@@ -90,23 +90,17 @@ If your network restricts outbound traffic through a firewall or proxy, download
 Allowlist the following hostnames (all over HTTPS / port 443):
 
 
-| Hostname                      | Purpose                                   |
-|-------------------------------|-------------------------------------------|
-| `huggingface.co`              | Hub API, metadata, and download redirects |
-| `cas-server.xethub.hf.co`     | Xet storage protocol APIs + upload (US)   |
-| `cas-server.xethub-eu.hf.co`  | Xet storage protocol APIs + upload (EU)   |
-| `transfer.xethub.hf.co`       | Xet storage download APIs (US)            |
-| `transfer.xethub-eu.hf.co`    | Xet storage download APIs (EU)            |
-| `cas-bridge.xethub.hf.co`     | Bridge CDN, legacy (US)                   |
-| `cas-bridge.xethub-eu.hf.co`  | Bridge CDN, legacy (EU)                   |
-| `us.aws.cdn.hf.co`            | CDN edge (US)                             |
-| `us.gcp.cdn.hf.co`            | CDN edge (US)                             |
-| `cdn-lfs.hf.co`               | LFS CDN, legacy (global)                  |
-| `cdn-lfs-us-1.hf.co`          | LFS CDN (US)                              |
-| `cdn-lfs-eu-1.hf.co`          | LFS CDN (EU)                              |
-| `cdn-lfs.huggingface.co`      | LFS CDN, legacy (global)                  |
-| `cdn-lfs-us-1.huggingface.co` | LFS CDN, legacy (US)                      |
-| `cdn-lfs-eu-1.huggingface.co` | LFS CDN, legacy (EU)                      |
+| Hostname                     | Purpose                                   |
+|------------------------------|-------------------------------------------|
+| `huggingface.co`             | Hub API, metadata, and download redirects |
+| `cas-server.xethub.hf.co`    | Xet storage protocol APIs + upload (US)   |
+| `cas-server.xethub-eu.hf.co` | Xet storage protocol APIs + upload (EU)   |
+| `transfer.xethub.hf.co`      | Xet storage download APIs (US)            |
+| `transfer.xethub-eu.hf.co`   | Xet storage download APIs (EU)            |
+| `us.aws.cdn.hf.co`           | CDN edge (US)                             |
+| `us.gcp.cdn.hf.co`           | CDN edge (US)                             |
+| `cdn-lfs-us-1.hf.co`         | LFS CDN (US)                              |
+| `cdn-lfs-eu-1.hf.co`         | LFS CDN (EU)                              |
 
 > [!TIP]
 > Downloads follow HTTP redirects from `huggingface.co` to these hostnames, so
@@ -121,7 +115,7 @@ Allowlist the following hostnames (all over HTTPS / port 443):
 > these cover every current and future storage and CDN endpoint.
 >
 > If your proxy only supports single-label wildcards (where `*.hf.co` matches
-> `cdn-lfs.hf.co` but not the deeper `us.aws.cdn.hf.co` or `cas-bridge.xethub.hf.co`),
+> `cdn-lfs-us-1.hf.co` but not the deeper `us.aws.cdn.hf.co` or `cas-server.xethub.hf.co`),
 > allowlist the explicit hostnames from the table above. Note that `*.xethub.hf.co` does
 > not cover the EU hosts under `xethub-eu.hf.co`, and `*.cdn.hf.co` does not cover the
 > two-label `us.aws.cdn.hf.co` / `us.gcp.cdn.hf.co`.


### PR DESCRIPTION
Adds the models-downloading allowlist section into datasets-downloading and drops the legacy cdn-lfs*/cas-bridge hosts per review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Hub download guides; no runtime or security behavior changes.
> 
> **Overview**
> Adds a **Downloading behind a proxy or firewall** section to `datasets-downloading.md`, mirroring the models guide but wording it for `load_dataset` / `hf download` and dataset downloads.
> 
> **Trims and aligns** the hostname allowlist in both `models-downloading.md` and the new datasets section: drops legacy endpoints (`cas-bridge.*`, global `cdn-lfs.hf.co`, and `cdn-lfs-*.huggingface.co`) so both pages list the same current Xet, transfer, CDN, and regional LFS hosts. The single-label wildcard tip now cites `cdn-lfs-us-1.hf.co` and `cas-server.xethub.hf.co` instead of the removed bridge/LFS names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ddd3b85a854f0f35eef3dd37e0b9462167f338a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->