### PR TITLE
Jobs: add "Persist your results" section

### DIFF
--- a/docs/hub/jobs-manage.md
+++ b/docs/hub/jobs-manage.md
@@ -185,6 +185,22 @@ Because `hf jobs wait` returns a non-zero exit code when a Job fails, you can ch
 >>> hf jobs wait 693994e21a39f67af5a41ad0 && echo "job completed successfully"
 ```
 
+## Persist your results
+
+A Job's filesystem is deleted when the Job ends. Write anything you want to keep somewhere durable before the Job exits:
+
+- **Intermediate artifacts, checkpoints, and logs → a Storage Bucket volume.** Mount a bucket and write outputs under the mount path (see [Volumes](./jobs-configuration#volumes)). Volume mounts are authorized with your Hugging Face identity when the Job is created, so your script doesn't need a token to write to them:
+
+  ```bash
+  >>> hf jobs uv run -v hf://buckets/username/my-bucket:/outputs train.py --output-dir /outputs/run-1
+  ```
+
+- **Final models and datasets → push to a Hub repo.** Jobs have no Hugging Face token unless you pass one, e.g. `--secrets HF_TOKEN` (the bare form resolves to your logged-in token automatically). If your script calls `push_to_hub()` or `create_repo()`, make sure the token has write access (fine-grained tokens need repo write and create permissions). A common failure mode is a Job that completes hours of compute and then errors on the final upload because the token can't write — the compute is done, but the results aren't saved.
+
+- **Print key results to the logs.** Job logs are retained after the Job ends and can be fetched anytime with `hf jobs logs <job-id>`. Printing final metrics to stdout keeps them recoverable even if an upload step fails.
+
+After a Job completes, check that your outputs actually landed (for example with `hf buckets list`) — a `COMPLETED` status means the command exited successfully, not that files were persisted where you expected.
+
 ## Debug a Job
 
 If a Job has an error, you can see it in on the Job page

--- a/docs/hub/jobs-manage.md
+++ b/docs/hub/jobs-manage.md
@@ -189,11 +189,7 @@ Because `hf jobs wait` returns a non-zero exit code when a Job fails, you can ch
 
 A Job's filesystem is deleted when the Job ends. Write anything you want to keep somewhere durable before the Job exits:
 
-- **Intermediate artifacts, checkpoints, and logs → a Storage Bucket volume.** Mount a bucket and write outputs under the mount path (see [Volumes](./jobs-configuration#volumes)). Volume mounts are authorized with your Hugging Face identity when the Job is created, so your script doesn't need a token to write to them:
-
-  ```bash
-  >>> hf jobs uv run -v hf://buckets/username/my-bucket:/outputs train.py --output-dir /outputs/run-1
-  ```
+- **Intermediate artifacts, checkpoints, and logs → a Storage Bucket volume.** Mount a bucket and write outputs under the mount path — see [Volumes](./jobs-configuration#volumes) for examples. Volume mounts are authorized with your Hugging Face identity when the Job is created, so your script doesn't need a token to write to them.
 
 - **Final models and datasets → push to a Hub repo.** Jobs have no Hugging Face token unless you pass one, e.g. `--secrets HF_TOKEN` (the bare form resolves to your logged-in token automatically). If your script calls `push_to_hub()` or `create_repo()`, make sure the token has write access (fine-grained tokens need repo write and create permissions). A common failure mode is a Job that completes hours of compute and then errors on the final upload because the token can't write — the compute is done, but the results aren't saved.
 

--- a/docs/hub/jobs-quickstart.md
+++ b/docs/hub/jobs-quickstart.md
@@ -100,7 +100,7 @@ Save this script as `train.py`, and we can now run it with UV on Hugging Face Jo
 
 ## Run the training job
 
-`hf jobs` takes several arguments: select the hardware with `--flavor`, choose a maximum duration with `--timeout`, and pass environment variable with `--env` and `--secrets`. Here we use the A100 Large GPU flavor with `--flavor a100-large` and pass your Hugging Face token as a secret with `--secrets HF_TOKEN` in order to be able to push the resulting model to your account.
+`hf jobs` takes several arguments: select the hardware with `--flavor`, choose a maximum duration with `--timeout`, and pass environment variable with `--env` and `--secrets`. Here we use the A100 Large GPU flavor with `--flavor a100-large` and pass your Hugging Face token as a secret with `--secrets HF_TOKEN` in order to be able to push the resulting model to your account. See [Persist your results](./jobs-manage#persist-your-results) for how to make sure your Job's outputs survive after it finishes.
 
 Moreover, UV accepts the `--with` argument to define python dependencies, so we use `--with trl` to have the `trl` library available.
 


### PR DESCRIPTION
Adds a "Persist your results" section to `jobs-manage.md` (placed before "Debug a Job"), plus a one-line cross-reference from the quickstart's `--secrets HF_TOKEN` paragraph.

The docs currently don't say that a Job's filesystem is ephemeral, that no token is present in the container unless you pass one, or how volume mounts are authorized. A recurring failure pattern in the wild (seen across the ICML 2026 reproducibility-challenge logbooks) is a Job that completes hours of compute and then fails at the final `push_to_hub` because the token can't write — with the results lost unless they happen to be in the logs.

The section distinguishes:
- bucket volumes for intermediate artifacts/checkpoints (authorized at Job creation with the submitter's identity — no token needed in the Job),
- `push_to_hub` to model/dataset repos for final artifacts (needs `--secrets HF_TOKEN` with write access),
- logs as the always-available fallback for key metrics.

Claims verified against current behavior: a default Job container has no token env vars (tested with a cpu-basic job), a mounted bucket is writable from a Job with no token passed (tested), and bare `--secrets HF_TOKEN` resolves from the stored login token client-side (`huggingface_hub/cli/_cli_utils.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Hub Jobs guides; no runtime, auth, or product code paths are modified.
> 
> **Overview**
> Documents that **Job filesystems are ephemeral** and how to keep outputs after a run finishes.
> 
> A new **Persist your results** section in `jobs-manage.md` (before **Debug a Job**) covers three paths: **bucket volumes** for checkpoints and intermediates (identity at job creation, no in-container token), **`push_to_hub` / Hub repos** for final artifacts (requires `--secrets HF_TOKEN` with write/create permissions), and **stdout logs** as a fallback for metrics. It also warns that **COMPLETED** only means the process exited cleanly—not that files were saved—and suggests verifying with e.g. `hf buckets list`.
> 
> The quickstart’s `--secrets HF_TOKEN` paragraph now links to that section so readers know outputs must be persisted explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9b54f2890b5cbf0d88e1c9179b0d1301ac97191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->