### PR TITLE
Add nvidia-open-model-agreement and modified-mit license

### DIFF
--- a/docs/hub/repositories-licenses.md
+++ b/docs/hub/repositories-licenses.md
@@ -12,6 +12,8 @@ A full list of the available licenses is available here:
 | -------------------------------------------------------------- | ---------------------------------------- |
 | Apache license 2.0                                             | `apache-2.0`                             |
 | MIT                                                            | `mit`                                    |
+| Modified MIT                                                   | `modified-mit`                           | <!-- info: used by moonshotai/Kimi-K2.7-Code -->
+| NVIDIA Open Model Agreement                                    | `nvidia-open-model-agreement`            | <!-- license: https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-agreement/ -->
 | OpenRAIL license family                                        | `openrail`                               | <!-- info: https://huggingface.co/blog/open_rail -->
 | BigScience OpenRAIL-M                                          | `bigscience-openrail-m`                  | <!-- info: https://bigscience.huggingface.co/blog/bigscience-openrail-m -->
 | CreativeML OpenRAIL-M                                          | `creativeml-openrail-m`                  | <!-- info: https://huggingface.co/spaces/CompVis/stable-diffusion-license -->


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only update to the license list; no runtime or API behavior changes.
> 
> **Overview**
> Extends the Hub license reference table with two identifiers repo cards can use: **`modified-mit`** (noted for moonshotai/Kimi-K2.7-Code) and **`nvidia-open-model-agreement`** (with a link to NVIDIA’s agreement text).
> 
> Both entries are inserted near the existing MIT row in `docs/hub/repositories-licenses.md`, following the same table format and inline comment style as other vendor-specific licenses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52d3ee2791566000d0ae8843d2ae2fe82f770fd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->