### PR TITLE
Jobs: document names and label updates (huggingface_hub v1.24.0)

### DIFF
--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -377,7 +377,7 @@ Note that you can pass a token with the right permission manually:
 
 ## Labels
 
-Add one or more labels to a Job to add some metadata with `-l` or `-label`.
+Add one or more labels to a Job to add some metadata with `-l` or `--label`.
 You can use such metadata later to filter Jobs on the website or in the CLI.
 
 Add labels with `--label my-label` or key-value labels with `--label key=value`.
@@ -388,3 +388,26 @@ hf jobs uv run --label fine-tuning --label model=Qwen3-0.6B --label dataset=Capy
 ```
 
 Note that using the same `key` multiple times causes the last `key=value` to overwrite and discard any previous label with `key`.
+
+### Name a Job
+
+Give a Job a name to make it easier to find and identify in the UI. The name is stored as the `name` label. Names are optional and do not have to be unique:
+
+```bash
+hf jobs run --name daily-report python:3.12 python report.py
+```
+
+### Update labels
+
+Update labels on an existing Job with `hf jobs labels`. Passing `--label` replaces all existing labels; passing `--name` alone keeps them:
+
+```bash
+# Replace the labels on a Job
+hf jobs labels <job_id> --label env=prod --label team=ml
+
+# Name an existing Job (keeps its other labels)
+hf jobs labels <job_id> --name daily-report
+
+# Remove all labels from a Job
+hf jobs labels <job_id> --clear
+```

--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -391,7 +391,7 @@ Note that using the same `key` multiple times causes the last `key=value` to ove
 
 ### Name a Job
 
-Give a Job a name to make it easier to find and identify in the UI. The name is stored as the `name` label. Names are optional and do not have to be unique:
+Give a Job a name to make it easier to find and identify in the UI. The name is stored as the `name` label. Names are optional and do not have to be unique. In the UI Jobs will be grouped by name.
 
 ```bash
 hf jobs run --name daily-report python:3.12 python report.py

--- a/docs/hub/jobs-schedule.md
+++ b/docs/hub/jobs-schedule.md
@@ -19,6 +19,9 @@ Use `hf jobs uv run ` or `hf jobs run` with a schedule of `@annually`, `@yearly`
 
 # Schedule a Python script with a label
 >>> hf jobs scheduled uv run --label fine-tuning @hourly my_script.py
+
+# Schedule a named job (names show up in the UI and do not have to be unique)
+>>> hf jobs scheduled run --name hourly-task @hourly python:3.12 python -c "print('This runs every hour!')"
 ```
 
 Use the same parameters as `hf jobs uv run` and `hf jobs run` to pass environment variables, secrets, timeout, labels, etc.


### PR DESCRIPTION
huggingface_hub v1.24.0 added optional names for Jobs ([release notes](https://github.com/huggingface/huggingface_hub/releases/tag/v1.24.0), huggingface/huggingface_hub#4532): a `--name` flag on `hf jobs run` / `uv run` / `scheduled run`, and a `hf jobs labels` command to update labels on an existing Job. Names are stored as the `name` label and shown in the Jobs UI.

This PR brings the hub-docs Jobs pages up to date:

- `jobs-configuration.md`: adds a "Name a Job" subsection and an "Update labels" subsection (`hf jobs labels` with `--label` / `--name` / `--clear` semantics) to the existing Labels section; fixes a `-label` -> `--label` typo.
- `jobs-schedule.md`: adds a named scheduled job example.

All examples were run against v1.24.0 before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLsT16XBYd5dTHhJvMxpVm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Updates the Hub Jobs docs for **huggingface_hub v1.24.0** CLI behavior around labels and optional job names.
> 
> In **`jobs-configuration.md`**, the Labels section now documents **`--name`** on `hf jobs run` (stored as the `name` label, UI grouping, non-unique), **`hf jobs labels`** for mutating labels on existing jobs (`--label` replaces all labels, `--name` alone preserves others, `--clear` removes all), and fixes a typo (`-label` → **`--label`**).
> 
> **`jobs-schedule.md`** adds an example for **`hf jobs scheduled run --name`** on recurring jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8aaefb757ac1f8fc1761a2e04a839eca4193619. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->