### PR TITLE
Clarify default 'auto' provider policy for chat completions

### DIFF
--- a/docs/inference-providers/guides/building-first-app.md
+++ b/docs/inference-providers/guides/building-first-app.md
@@ -226,7 +226,7 @@ async function transcribe(file) {
 <hfoptions id="summarization">
 <hfoption id="python">
 
-Next, we'll use a powerful language model like `deepseek-ai/DeepSeek-R1-0528` from DeepSeek via an Inference Provider. The `:fastest` policy is the default for chat completions, automatically selecting the best performing provider for this model.
+Next, we'll use a powerful language model like `deepseek-ai/DeepSeek-R1-0528` from DeepSeek via an Inference Provider. The `auto` policy is the default for chat completions, automatically selecting a suitable provider for this model.
 We will define a custom prompt to ensure the output is formatted as a summary with action items and decisions made:
 
 ```python
@@ -260,7 +260,7 @@ def generate_summary(transcript):
 </hfoption>
 <hfoption id="javascript">
 
-Next, we'll use a powerful language model like `deepseek-ai/DeepSeek-R1-0528` from DeepSeek via an Inference Provider. The `:fastest` policy is the default for chat completions, automatically selecting the best performing provider for this model.
+Next, we'll use a powerful language model like `deepseek-ai/DeepSeek-R1-0528` from DeepSeek via an Inference Provider. The `auto` policy is the default for chat completions, automatically selecting a suitable provider for this model.
 We will define a custom prompt to ensure the output is formatted as a summary with action items and decisions made:
 
 ```javascript

--- a/docs/inference-providers/guides/building-first-app.md
+++ b/docs/inference-providers/guides/building-first-app.md
@@ -226,7 +226,7 @@ async function transcribe(file) {
 <hfoptions id="summarization">
 <hfoption id="python">
 
-Next, we'll use a powerful language model like `deepseek-ai/DeepSeek-R1-0528` from DeepSeek via an Inference Provider. The `auto` policy is the default for chat completions, automatically selecting a suitable provider for this model.
+Next, we'll use a powerful language model like `deepseek-ai/DeepSeek-R1-0528` from DeepSeek via an Inference Provider. The `auto` policy is the default for chat completions, automatically selecting the best provider for this model.
 We will define a custom prompt to ensure the output is formatted as a summary with action items and decisions made:
 
 ```python

--- a/docs/inference-providers/guides/evaluation-inspect-ai.md
+++ b/docs/inference-providers/guides/evaluation-inspect-ai.md
@@ -100,7 +100,7 @@ inspect view
 ## Example: Comparing several inference providers for a task
 In this section, we will evaluate the same model across different providers. Inference Providers gives us access to many providers for the same model. Performance might vary across providers, so this is a useful factor, in addition to speed and cost, to choose the most appropriate inference provider for your task.
 
-If we don't specify a provider, like we did in our previous examples, the system automatically selects the fastest available provider for the specified model (equivalent to the `:fastest` policy). But we can also select the provider by appending the provider name to the model id (e.g. `openai/gpt-oss-120b:groq`).
+If we don't specify a provider, like we did in our previous examples, the system automatically selects a suitable provider for the specified model (the `auto` policy). But we can also select the provider by appending the provider name to the model id (e.g. `openai/gpt-oss-120b:groq`), or a policy suffix such as `:fastest`, `:cheapest`, or `:preferred`.
 
 Let's run the evaluations for `gpt-oss-120b` across several providers. Please note that this time we are using the `eval_set` function directly in Python for extra flexibility (e.g., changing the list of providers):
 

--- a/docs/inference-providers/guides/responses-api.md
+++ b/docs/inference-providers/guides/responses-api.md
@@ -89,7 +89,7 @@ curl https://router.huggingface.co/v1/responses \
 
 
 > [!TIP]
-> If you plan to use a specific provider, append it to the model id as `<repo>:<provider>` (for example `moonshotai/Kimi-K2-Instruct-0905:groq`). Otherwise, omit the suffix and the fastest available provider will be selected by default (equivalent to the `:fastest` policy). You can also use `:cheapest` or `:preferred` (follows your [Inference Provider settings](https://hf.co/settings/inference-providers) order).
+> If you plan to use a specific provider, append it to the model id as `<repo>:<provider>` (for example `moonshotai/Kimi-K2-Instruct-0905:groq`). Otherwise, omit the suffix and a suitable provider will be selected by default (the `auto` policy, which prioritizes providers supporting the model's advanced capabilities such as tool calling and structured outputs). You can also use `:fastest`, `:cheapest`, or `:preferred` (follows your [Inference Provider settings](https://hf.co/settings/inference-providers) order).
 
 ## Core Response patterns
 

--- a/docs/inference-providers/index.md
+++ b/docs/inference-providers/index.md
@@ -131,9 +131,9 @@ hf auth login # get a read token from hf.co/settings/tokens
 
 You can now use the client with a Python interpreter.
 
-By default, our system automatically selects the fastest available provider for the specified model (equivalent to the `:fastest` policy — highest throughput in tokens per second).
+By default, our system automatically selects a suitable provider for the specified model (the `auto` policy). For chat models, `auto` prioritizes providers that support the model's advanced capabilities, such as tool calling and structured outputs, using throughput (tokens per second) as a tiebreaker.
 
-You can change the provider selection policy by appending a policy suffix to the model id: `:cheapest` for the most cost-efficient provider (lowest price per output token), or `:preferred` to follow your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers). For example, `openai/gpt-oss-120b:cheapest`.
+You can change the provider selection policy by appending a policy suffix to the model id: `:fastest` for the highest-throughput provider (tokens per second), `:cheapest` for the most cost-efficient provider (lowest price per output token), or `:preferred` to follow your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers). For example, `openai/gpt-oss-120b:cheapest`.
 
 You can also select the provider of your choice by appending the provider name to the model id (e.g. `"openai/gpt-oss-120b:groq"`).
 
@@ -162,9 +162,9 @@ print(completion.choices[0].message)
 
 If you're already using OpenAI's Python client, then you need a **drop-in OpenAI replacement**. Just swap-out the base URL to instantly access hundreds of additional open-weights models through our provider network.
 
-By default, our system automatically selects the fastest available provider for the specified model (equivalent to the `:fastest` policy — highest throughput in tokens per second).
+By default, our system automatically selects a suitable provider for the specified model (the `auto` policy). For chat models, `auto` prioritizes providers that support the model's advanced capabilities, such as tool calling and structured outputs, using throughput (tokens per second) as a tiebreaker.
 
-You can change the provider selection policy by appending a policy suffix to the model id: `:cheapest` for the most cost-efficient provider (lowest price per output token), or `:preferred` to follow your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers). For example, `openai/gpt-oss-120b:cheapest`.
+You can change the provider selection policy by appending a policy suffix to the model id: `:fastest` for the highest-throughput provider (tokens per second), `:cheapest` for the most cost-efficient provider (lowest price per output token), or `:preferred` to follow your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers). For example, `openai/gpt-oss-120b:cheapest`.
 
 You can also select the provider of your choice by appending the provider name to the model id (e.g. `"openai/gpt-oss-120b:groq"`).
 
@@ -194,9 +194,9 @@ completion = client.chat.completions.create(
 
 For maximum control and interoperability with custom frameworks, use our OpenAI-compatible REST API directly.
 
-By default, our system automatically selects the fastest available provider for the specified model (equivalent to the `:fastest` policy — highest throughput in tokens per second).
+By default, our system automatically selects a suitable provider for the specified model (the `auto` policy). For chat models, `auto` prioritizes providers that support the model's advanced capabilities, such as tool calling and structured outputs, using throughput (tokens per second) as a tiebreaker.
 
-You can change the provider selection policy by appending a policy suffix to the model id: `:cheapest` for the most cost-efficient provider (lowest price per output token), or `:preferred` to follow your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers). For example, `openai/gpt-oss-120b:cheapest`.
+You can change the provider selection policy by appending a policy suffix to the model id: `:fastest` for the highest-throughput provider (tokens per second), `:cheapest` for the most cost-efficient provider (lowest price per output token), or `:preferred` to follow your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers). For example, `openai/gpt-oss-120b:cheapest`.
 
 You can also select the provider of your choice by appending the provider name to the model id (e.g. `"openai/gpt-oss-120b:groq"`).
 
@@ -242,9 +242,9 @@ npm install @huggingface/inference
 
 Then use the client with Javascript.
 
-By default, our system automatically selects the fastest available provider for the specified model (equivalent to the `:fastest` policy — highest throughput in tokens per second).
+By default, our system automatically selects a suitable provider for the specified model (the `auto` policy). For chat models, `auto` prioritizes providers that support the model's advanced capabilities, such as tool calling and structured outputs, using throughput (tokens per second) as a tiebreaker.
 
-You can change the provider selection policy by appending a policy suffix to the model id: `:cheapest` for the most cost-efficient provider (lowest price per output token), or `:preferred` to follow your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers). For example, `openai/gpt-oss-120b:cheapest`.
+You can change the provider selection policy by appending a policy suffix to the model id: `:fastest` for the highest-throughput provider (tokens per second), `:cheapest` for the most cost-efficient provider (lowest price per output token), or `:preferred` to follow your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers). For example, `openai/gpt-oss-120b:cheapest`.
 
 You can also select the provider of your choice by appending the provider name to the model id (e.g. `"openai/gpt-oss-120b:groq"`).
 
@@ -272,9 +272,9 @@ console.log(chatCompletion.choices[0].message);
 
 If you're already using OpenAI's Javascript client, then you need a **drop-in OpenAI replacement**. Just swap-out the base URL to instantly access hundreds of additional open-weights models through our provider network.
 
-By default, our system automatically selects the fastest available provider for the specified model (equivalent to the `:fastest` policy — highest throughput in tokens per second).
+By default, our system automatically selects a suitable provider for the specified model (the `auto` policy). For chat models, `auto` prioritizes providers that support the model's advanced capabilities, such as tool calling and structured outputs, using throughput (tokens per second) as a tiebreaker.
 
-You can change the provider selection policy by appending a policy suffix to the model id: `:cheapest` for the most cost-efficient provider (lowest price per output token), or `:preferred` to follow your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers). For example, `openai/gpt-oss-120b:cheapest`.
+You can change the provider selection policy by appending a policy suffix to the model id: `:fastest` for the highest-throughput provider (tokens per second), `:cheapest` for the most cost-efficient provider (lowest price per output token), or `:preferred` to follow your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers). For example, `openai/gpt-oss-120b:cheapest`.
 
 You can also select the provider of your choice by appending the provider name to the model id (e.g. `"openai/gpt-oss-120b:groq"`).
 
@@ -305,9 +305,9 @@ console.log(completion.choices[0].message.content);
 
 For lightweight applications or custom implementations, use our REST API directly with standard fetch.
 
-By default, our system automatically selects the fastest available provider for the specified model (equivalent to the `:fastest` policy — highest throughput in tokens per second).
+By default, our system automatically selects a suitable provider for the specified model (the `auto` policy). For chat models, `auto` prioritizes providers that support the model's advanced capabilities, such as tool calling and structured outputs, using throughput (tokens per second) as a tiebreaker.
 
-You can change the provider selection policy by appending a policy suffix to the model id: `:cheapest` for the most cost-efficient provider (lowest price per output token), or `:preferred` to follow your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers). For example, `openai/gpt-oss-120b:cheapest`.
+You can change the provider selection policy by appending a policy suffix to the model id: `:fastest` for the highest-throughput provider (tokens per second), `:cheapest` for the most cost-efficient provider (lowest price per output token), or `:preferred` to follow your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers). For example, `openai/gpt-oss-120b:cheapest`.
 
 You can also select the provider of your choice by appending the provider name to the model id (e.g. `"openai/gpt-oss-120b:groq"`).
 
@@ -344,9 +344,9 @@ console.log(await response.json());
 
 For testing, debugging, or integrating with any HTTP client, here's the raw REST API format.
 
-By default, our system automatically selects the fastest available provider for the specified model (equivalent to the `:fastest` policy — highest throughput in tokens per second).
+By default, our system automatically selects a suitable provider for the specified model (the `auto` policy). For chat models, `auto` prioritizes providers that support the model's advanced capabilities, such as tool calling and structured outputs, using throughput (tokens per second) as a tiebreaker.
 
-You can change the provider selection policy by appending a policy suffix to the model id: `:cheapest` for the most cost-efficient provider (lowest price per output token), or `:preferred` to follow your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers). For example, `openai/gpt-oss-120b:cheapest`.
+You can change the provider selection policy by appending a policy suffix to the model id: `:fastest` for the highest-throughput provider (tokens per second), `:cheapest` for the most cost-efficient provider (lowest price per output token), or `:preferred` to follow your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers). For example, `openai/gpt-oss-120b:cheapest`.
 
 You can also select the provider of your choice by appending the provider name to the model id (e.g. `"openai/gpt-oss-120b:groq"`).
 
@@ -485,16 +485,17 @@ result = client.chat_completion(
 
 **Provider Selection Policy:**
 
-- `provider: "auto"` (default): Selects the fastest available provider for the model (highest throughput in tokens per second), equivalent to the `:fastest` policy.
+- `provider: "auto"` (default): Automatically selects a suitable provider for the model. For chat models, this prioritizes providers that support the model's advanced capabilities (such as tool calling and structured outputs), using throughput as a tiebreaker. Append `:fastest` to the model id if you always want the highest-throughput provider regardless of capabilities.
 - `provider: "specific-provider"`: Forces use of a specific provider (e.g., "together", "replicate", "fal-ai", ...).
 
 ### Alternative: OpenAI-Compatible Chat Completions Endpoint (Chat Only)
 
 If you prefer to work with familiar OpenAI APIs or want to migrate existing chat completion code with minimal changes, we offer a drop-in compatible endpoint that handles all provider selection automatically on the server side.
 
-By default, the fastest available provider is selected for the model (highest throughput in tokens per second). This is equivalent to appending `:fastest` to the model name.
+By default, a suitable provider is selected for the model (the `auto` policy). For chat models, this prioritizes providers that support the model's advanced capabilities (such as tool calling and structured outputs), using throughput as a tiebreaker.
 You can change that policy by adding a suffix to the model name:
 
+- `:fastest` selects the highest-throughput provider for the model (tokens per second)
 - `:cheapest` selects the most cost-efficient provider for the model (lowest price per output tokens)
 - `:preferred` selects the first available provider sorted by your preference order in [Inference Provider settings](https://hf.co/settings/inference-providers)
 
@@ -562,7 +563,7 @@ curl https://router.huggingface.co/v1/chat/completions \
 
 **Key Features:**
 
-- **Server-Side Provider Selection**: The server automatically selects the fastest available provider by default (`:fastest` policy)
+- **Server-Side Provider Selection**: The server automatically selects a suitable provider by default (`auto` policy)
 - **Model Listing**: GET `/v1/models` returns available models across all providers, including per-provider pricing, context length, latency, and throughput when available
 - **OpenAI SDK Compatibility**: Works with existing OpenAI client libraries
 - **Chat Tasks Only**: Limited to conversational workloads


### PR DESCRIPTION
The default 'auto' policy for chat/conversational requests is no longer strictly equivalent to ':fastest'. It now prefers providers that support the model's advanced capabilities (tool calling and structured outputs), using throughput as a tiebreaker. Update the provider-selection docs to describe 'auto' accurately and document ':fastest' as an explicit policy suffix for users who always want the highest-throughput provider.

from https://github.com/huggingface-internal/moon-landing/pull/19060


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes; no runtime, API, or authentication behavior is modified in this diff.
> 
> **Overview**
> Updates Inference Providers documentation so the default **`auto`** policy is no longer described as equivalent to **`:fastest`**.
> 
> Across the main index, Responses API guide, first-app tutorial, and Inspect eval guide, prose now states that **`auto`** picks a suitable provider—for chat models, favoring backends that support advanced features (tool calling, structured outputs) and using throughput only as a tiebreaker. **`:fastest`** is documented explicitly as the suffix for highest-throughput routing when users want the old behavior.
> 
> The Provider Selection and OpenAI-compatible endpoint sections gain the same distinction, including listing **`:fastest`** alongside **`:cheapest`** and **`:preferred`** where policy suffixes are explained.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af5ca467049e4aaba8e4fe85d9dae40faa5a7280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->