### PR TITLE
change: huggingface vllm docs vbump

### DIFF
--- a/docs/sagemaker/source/dlcs/available.md
+++ b/docs/sagemaker/source/dlcs/available.md
@@ -38,7 +38,7 @@ In case you want to serve text generation models with vLLM, there are specific D
 
 | vLLM version | Container URI                                                                                                                    | Accelerator |
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| 0.21.0         | 763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-vllm:0.21.0-transformers5.8.1-gpu-py312-cu130-ubuntu22.04 | GPU         |
+| 0.25.0         | 763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-vllm:0.25-transformers5.10-gpu-py312-cu130-ubuntu22.04 | GPU         |
 | 0.11.0         | 763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-vllm-inference-neuronx:0.11.0-optimum0.4.5-neuronx-py310-sdk2.26.1-ubuntu22.04 | Neuron         |
 
 ### vLLM Omni


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to a container version table; no code or runtime behavior.
> 
> **Overview**
> Updates the SageMaker **Available DLCs** doc so the GPU vLLM inference row points at the newer container image.
> 
> The listed version moves from **0.21.0** to **0.25.0**, and the ECR URI is updated to `huggingface-vllm:0.25-transformers5.10-gpu-py312-cu130-ubuntu22.04` (Transformers **5.10** in the tag). Neuron vLLM and other inference tables are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48c4fbdcb5924964ddc34b694f0550a0a053aa90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->