### PR TITLE
docs: document training_regime field in the annotated model card

### DIFF
--- a/docs/hub/model-card-annotated.md
+++ b/docs/hub/model-card-annotated.md
@@ -174,6 +174,13 @@ _Write 1-2 sentences on what the training data is. Ideally this links to a Datas
 
 _Detail tokenization, resizing/rewriting (depending on the modality), etc._
 
+### Training Hyperparameters
+
+
+`training_regime`
+
+_The training regime, i.e. the numerical precision the model was actually trained with: `fp32`, `fp16` mixed precision, `bf16` mixed precision, `bf16` non-mixed precision, `fp16` non-mixed precision, or `fp8` mixed precision. This affects training speed and memory footprint, and in some cases the numerical stability of results, so it's useful for anyone trying to reproduce training or understand its resource requirements._
+
 ### Speeds, Sizes, Times
 
 


### PR DESCRIPTION
Closes #1125.

## Problem

`modelcard_template.md` (in `huggingface_hub`) has always had a `training_regime` field under "Training Hyperparameters":

```
- **Training regime:** {{ training_regime | default(...) }} <!--fp32, fp16 mixed precision, bf16 mixed precision, bf16 non-mixed precision, fp16 non-mixed precision, fp8 mixed precision -->
```

But `docs/hub/model-card-annotated.md` — the doc that's supposed to explain every field in the template — jumps straight from `### Preprocessing` to `### Speeds, Sizes, Times`. There's no "Training Hyperparameters" subsection at all, so `training_regime` is never explained anywhere a user would actually look for it, exactly as reported in #1125.

## Fix

Added the missing `### Training Hyperparameters` subsection between Preprocessing and Speeds/Sizes/Times, documenting `training_regime` with the same field-name + italicized-explanation style used for every other field in this file. The definition (fp32 / fp16 / bf16 / fp8, mixed vs. non-mixed precision) is sourced directly from the template's own inline HTML comment, not invented.

## Consistency check

This repo's `model_card_consistency_reminder` workflow flags several files as containing duplicated model-card content, so I checked all of them before committing to a single-file fix:

- `modelcard.md` (this repo) — only YAML frontmatter metadata, no body template section. Not applicable.
- `docs/hub/model-cards.md` — explicitly defers body-template explanations to the annotated card ("Details on how to fill out the human-readable portion... is available in the Annotated Model Card") rather than duplicating them. Not applicable.
- `huggingface_hub`'s `modelcard_template.md` and `repocard.py` — already reference `training_regime` correctly; nothing to fix there.

So `docs/hub/model-card-annotated.md` is the one place this needed to change.

## Disclosure

I used AI assistance (Claude) to investigate this issue and draft the fix. I reviewed the change and take responsibility for its accuracy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or security impact.
> 
> **Overview**
> Adds the missing **Training Hyperparameters** subsection to `docs/hub/model-card-annotated.md`, between Preprocessing and Speeds, Sizes, Times, so the annotated guide matches `modelcard_template.md`.
> 
> Documents the `training_regime` placeholder with the same backtick field + italic explanation pattern as other fields, covering precision options (fp32, fp16/bf16/fp8, mixed vs non-mixed) and why the field matters for reproduction and resource planning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2812008ead68e806d3ffdbf3dbf1be091f50d39b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->