### PR TITLE
Mention hf datasets sql in the datasets DuckDB and Data Studio docs

### DIFF
--- a/docs/hub/data-studio.md
+++ b/docs/hub/data-studio.md
@@ -34,7 +34,7 @@ You can run SQL queries on the dataset in the browser using the SQL Console. Thi
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/sql-ai-dark.png"/>
 </div>
 
-For more information see our guide on [SQL Console](./datasets-viewer-sql-console).
+For more information see our guide on [SQL Console](./datasets-viewer-sql-console). You can run the same DuckDB SQL queries from the command line with [`hf datasets sql`](/docs/huggingface_hub/package_reference/cli#hf-datasets-sql) or with [DuckDB](./datasets-duckdb) directly.
 
 ## Share a specific row
 
@@ -76,7 +76,7 @@ When you create a new dataset, the [`parquet-converter` bot](https://huggingface
 
 ### Programmatic access
 
-You can also access the list of Parquet files programmatically using the [Hub API](./api#get-apidatasetsrepoidparquet); for example, endpoint [`https://huggingface.co/api/datasets/nyu-mll/glue/parquet`](https://huggingface.co/api/datasets/nyu-mll/glue/parquet) lists the parquet files of the `nyu-mll/glue` dataset.
+You can also access the list of Parquet files programmatically using the [Hub API](./api#get-apidatasetsrepoidparquet); for example, endpoint [`https://huggingface.co/api/datasets/nyu-mll/glue/parquet`](https://huggingface.co/api/datasets/nyu-mll/glue/parquet) lists the parquet files of the `nyu-mll/glue` dataset. The `hf` CLI provides the same list with [`hf datasets parquet`](/docs/huggingface_hub/package_reference/cli#hf-datasets-parquet), and [`hf datasets sql`](/docs/huggingface_hub/package_reference/cli#hf-datasets-sql) lets you query the files with SQL.
 
 We also have a specific documentation about the [Dataset Viewer API](https://huggingface.co/docs/dataset-viewer), which you can call directly. That API lets you access the contents, metadata and basic statistics of all Hugging Face Hub datasets, and powers the Dataset viewer frontend.
 

--- a/docs/hub/datasets-duckdb-auth.md
+++ b/docs/hub/datasets-duckdb-auth.md
@@ -4,6 +4,9 @@ To access private or gated datasets, you need to configure your Hugging Face Tok
 
 Visit [Hugging Face Settings - Tokens](https://huggingface.co/settings/tokens) to obtain your access token.
 
+> [!TIP]
+> If you query through [`hf datasets sql`](/docs/huggingface_hub/package_reference/cli#hf-datasets-sql), the token secret is configured automatically from your logged-in session (or `--token`) — no manual secret setup is needed.
+
 DuckDB supports two providers for managing secrets:
 
 - `CONFIG`: Requires the user to pass all configuration information into the CREATE SECRET statement.

--- a/docs/hub/datasets-duckdb.md
+++ b/docs/hub/datasets-duckdb.md
@@ -13,6 +13,9 @@ There are also other APIs available for running DuckDB, including Python, C++, G
 > [!TIP]
 > For installation details, visit the [installation page](https://duckdb.org/docs/installation).
 
+> [!TIP]
+> If you use the `hf` CLI, you can run DuckDB queries directly with [`hf datasets sql`](/docs/huggingface_hub/package_reference/cli#hf-datasets-sql), e.g. `hf datasets sql "FROM 'hf://datasets/ibm/duorc/ParaphraseRC/*.parquet' LIMIT 3"`. Authentication for gated and private datasets is configured automatically from your logged-in token, and `--format json` returns machine-readable output.
+
 Starting from version `v0.10.3`, the DuckDB CLI includes native support for accessing datasets on the Hugging Face Hub via URLs with the `hf://` scheme. Here are some features you can leverage with this powerful tool:
 
 - Query public datasets and your own gated and private datasets

--- a/docs/hub/datasets-viewer-sql-console.md
+++ b/docs/hub/datasets-viewer-sql-console.md
@@ -21,7 +21,7 @@ Through the SQL Console, you can:
 - Query datasets with natural language
 
 > [!TIP]
-> You can also use the DuckDB locally through the CLI to query the dataset via the `hf://` protocol. See the <a href="https://huggingface.co/docs/hub/en/datasets-duckdb" target="_blank" rel="noopener noreferrer">DuckDB Datasets documentation</a> for more information. The SQL Console provides a convenient `Copy to DuckDB CLI` button that generates the SQL query for creating views and executing your query in the DuckDB CLI.
+> You can also use the DuckDB locally through the CLI to query the dataset via the `hf://` protocol. See the <a href="https://huggingface.co/docs/hub/en/datasets-duckdb" target="_blank" rel="noopener noreferrer">DuckDB Datasets documentation</a> for more information. The SQL Console provides a convenient `Copy to DuckDB CLI` button that generates the SQL query for creating views and executing your query in the DuckDB CLI. Alternatively, run the same queries from a terminal or script with [`hf datasets sql`](/docs/huggingface_hub/package_reference/cli#hf-datasets-sql).
 
 
 ## Examples


### PR DESCRIPTION
The `hf` CLI ships `hf datasets sql` (and `hf datasets parquet`), but the datasets docs never mention them: the DuckDB section only describes installing the standalone DuckDB CLI and manually configuring token secrets, and the SQL Console pages only cover the browser. Anyone (or any agent) landing on these pages gets sent down the slower path when a single command already does the job.

This PR adds short pointers — one tip or one sentence per page, each linking to the [CLI reference](https://huggingface.co/docs/huggingface_hub/package_reference/cli#hf-datasets-sql) rather than duplicating it:

- `datasets-duckdb.md` — tip with a runnable example (reusing the page's existing `ibm/duorc` demo query), noting automatic auth and `--format json`
- `datasets-duckdb-auth.md` — tip that `hf datasets sql` configures the token secret automatically, so the manual `CREATE SECRET` steps can be skipped
- `datasets-viewer-sql-console.md` — extends the existing "DuckDB locally" tip with the CLI alternative
- `data-studio.md` — CLI alternative in the "Run SQL queries" section; `hf datasets parquet` added next to the parquet-list API under "Programmatic access"

Verified against `hf` CLI v1.23.0: the example query runs as written, auth is injected automatically from the logged-in token, and both CLI-reference anchors resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, auth, or API behavior changes.
> 
> **Overview**
> Hub dataset docs now point readers at **`hf datasets sql`** and **`hf datasets parquet`** instead of only describing the browser SQL Console, standalone DuckDB CLI, and Hub API.
> 
> **`data-studio.md`** adds a CLI option next to the SQL Console guide and documents **`hf datasets parquet`** / **`hf datasets sql`** under programmatic Parquet access. **`datasets-duckdb.md`** adds a tip with a runnable `ibm/duorc` example, auto-auth, and **`--format json`**. **`datasets-duckdb-auth.md`** notes that **`hf datasets sql`** skips manual DuckDB secret setup. **`datasets-viewer-sql-console.md`** extends the existing local DuckDB tip with the **`hf`** CLI alternative. All links target the huggingface_hub CLI reference rather than duplicating command docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30fe3603af456e14100b21525ba0a057fd77c6a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->