### PR TITLE
Document  Content Access Policy repo metadata visibility option

### DIFF
--- a/docs/hub/enterprise-network-security.md
+++ b/docs/hub/enterprise-network-security.md
@@ -74,6 +74,12 @@ To define Blocked content, add rules that target a repository type, an organizat
 
 The Always allowed field lets you define exceptions to the blocking rules. You can target content that should remain accessible even when a block rule would otherwise apply.
 
+#### Keep repository metadata visible
+
+By default, when a repository is blocked by the Content Access Policy, the whole repository becomes inaccessible. Enable the "Keep repository metadata visible" option to only block a repository's content while keeping its metadata visible.
+
+When this option is enabled, blocked repositories still show their metadata (repo card, profile and listing pages), and only their content is blocked: file downloads, the dataset viewer, running Spaces and model inference.
+
 ## Manage Network Security via API
 
 You can read and update your organization's network security settings programmatically via the Hub API.


### PR DESCRIPTION
Update `enterprise-network-security.md` to document new option `Keep repository metadata visible`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior modifications in this PR.
> 
> **Overview**
> Adds a **Keep repository metadata visible** subsection under **Content Access Policy** in `enterprise-network-security.md`.
> 
> The new text explains default behavior (blocked repos are fully inaccessible) versus enabling the option (metadata such as repo cards and listing pages stay visible while downloads, dataset viewer, Spaces, and inference remain blocked).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 069da71630019203508b529cb623461453e987ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->