### PR TITLE
Update model-page Deploy to Spaces flow to reflect AI agent build prompt

### DIFF
--- a/docs/hub/spaces-more-ways-to-create.md
+++ b/docs/hub/spaces-more-ways-to-create.md
@@ -7,3 +7,8 @@ You can duplicate a Space by clicking the three dots at the top right and select
 ## Creating a Space from a model
 
 You can build a Space demo directly from most model pages, using the "Deploy -> Spaces" button. This opens a prompt you can copy and paste into your AI coding agent (Claude Code, Codex, and others), which reads the model's page and builds a Space with a demo for it.
+
+<div class="flex justify-center">
+  <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/deploy-model-as-space-with-agent-light.png"/>
+  <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/deploy-model-as-space-with-agent-dark.png"/>
+</div>

--- a/docs/hub/spaces-more-ways-to-create.md
+++ b/docs/hub/spaces-more-ways-to-create.md
@@ -7,7 +7,3 @@ You can duplicate a Space by clicking the three dots at the top right and select
 ## Creating a Space from a model
 
 You can build a Space demo directly from most model pages, using the "Deploy -> Spaces" button. This opens a prompt you can copy and paste into your AI coding agent (Claude Code, Codex, and others), which reads the model's page and builds a Space with a demo for it.
-
-<video src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/model-page-deploy-to-spaces.mp4" controls autoplay muted loop />
-
-As another example of how to create a Space from a set of models, the [Model Comparator Space Builder](https://huggingface.co/spaces/farukozderim/Model-Comparator-Space-Builder) from [@farukozderim](https://huggingface.co/farukozderim) can be used to create a Space directly from any model hosted on the Hub.

--- a/docs/hub/spaces-more-ways-to-create.md
+++ b/docs/hub/spaces-more-ways-to-create.md
@@ -9,6 +9,6 @@ You can duplicate a Space by clicking the three dots at the top right and select
 You can build a Space demo directly from most model pages, using the "Deploy -> Spaces" button. This opens a prompt you can copy and paste into your AI coding agent (Claude Code, Codex, and others), which reads the model's page and builds a Space with a demo for it.
 
 <div class="flex justify-center">
-  <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/deploy-model-as-space-with-agent-light.png"/>
-  <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/deploy-model-as-space-with-agent-dark.png"/>
+  <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/deploy-model-as-space-with-agent-modal-light.png"/>
+  <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/deploy-model-as-space-with-agent-modal-dark.png"/>
 </div>

--- a/docs/hub/spaces-more-ways-to-create.md
+++ b/docs/hub/spaces-more-ways-to-create.md
@@ -6,7 +6,7 @@ You can duplicate a Space by clicking the three dots at the top right and select
 
 ## Creating a Space from a model
 
-You can create a Gradio demo directly from most model pages, using the "Deploy -> Spaces" button.
+You can build a Space demo directly from most model pages, using the "Deploy -> Spaces" button. This opens a prompt you can copy and paste into your AI coding agent (Claude Code, Codex, and others), which reads the model's page and builds a Space with a demo for it.
 
 <video src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/model-page-deploy-to-spaces.mp4" controls autoplay muted loop />
 


### PR DESCRIPTION
Reflect https://github.com/huggingface-internal/moon-landing/pull/19157 changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no product code or runtime behavior affected.
> 
> **Overview**
> Updates **Creating a Space from a model** in `spaces-more-ways-to-create.md` to match the new model-page **Deploy → Spaces** experience.
> 
> The copy now explains that the button opens a **copy-paste prompt for AI coding agents** (Claude Code, Codex, etc.) that reads the model page and builds a Space demo, instead of implying a one-click Gradio deploy. The demo **video** and the **Model Comparator Space Builder** paragraph are removed and replaced with **light/dark screenshots** of the agent modal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56c9076c4d74e8f6d37f5404852c754d71d75bb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->