### PR TITLE
fix and add download analytics page

### DIFF
--- a/docs/hub/_toctree.yml
+++ b/docs/hub/_toctree.yml
@@ -29,6 +29,8 @@
     title: Gating Group Collections
   - local: enterprise-network-security
     title: Network Security
+  - local: download-analytics
+    title: Download Analytics
   - local: rate-limits
     title: Rate Limits
   - local: enterprise-blog-articles

--- a/docs/hub/download-analytics.md
+++ b/docs/hub/download-analytics.md
@@ -4,7 +4,7 @@ Download Analytics gives organizations a bandwidth-level view of their Hugging F
 
 ## Accessing Download Analytics
 
-Organization admins can find Download Analytics on the organization's Downloads settings page, at `https://huggingface.co/organizations/<name>/settings/downloads`. Individual users can see their own usage at `https://huggingface.co/settings/downloads`.
+Organization admins can find Download Analytics on the organization's Downloads settings page, at `https://huggingface.co/organizations/[organizationIdentifier]/settings/downloads`. Individual users can see their own usage at `https://huggingface.co/settings/downloads`.
 
 ## Egress overview
 

--- a/docs/hub/download-analytics.md
+++ b/docs/hub/download-analytics.md
@@ -1,0 +1,30 @@
+# Download Analytics
+
+Download Analytics gives organizations a bandwidth-level view of their Hugging Face usage: how much data is being downloaded and by whom.
+
+## Accessing Download Analytics
+
+Organization admins can find Download Analytics on the organization's Downloads settings page, at `https://huggingface.co/organizations/<name>/settings/downloads`. Individual users can see their own usage at `https://huggingface.co/settings/downloads`.
+
+## Egress overview
+
+The page shows a daily egress (download bandwidth) graph, along with your month-to-date total compared against your plan's included egress allowance. Only traffic that passes through the Hugging Face CDN is counted, and figures may increase over time as data settles.
+
+## Per-member breakdown
+
+For each member of the organization, the breakdown shows:
+
+- Total data downloaded, in bytes
+- Date of their last download
+
+This gives admins a quick way to see who is driving bandwidth usage across the organization, at a glance.
+
+## Scope of the data
+
+Download Analytics reports total bandwidth per member; it does not record which specific repositories, revisions, or files were downloaded.
+
+If you publish your own models or datasets and want per-repository download counts for those repos, see [Publisher Analytics](./publisher-analytics).
+
+## Data availability and retention
+
+Historical data is available from when this feature rolled out; CDN usage metering is retained for 90 days.

--- a/docs/hub/download-analytics.md
+++ b/docs/hub/download-analytics.md
@@ -27,4 +27,4 @@ If you publish your own models or datasets and want per-repository download coun
 
 ## Data availability and retention
 
-Historical data is available from when this feature rolled out; CDN usage metering is retained for 90 days.
+CDN usage metering is retained for 90 days.

--- a/docs/hub/download-analytics.md
+++ b/docs/hub/download-analytics.md
@@ -2,6 +2,19 @@
 
 Download Analytics gives organizations a bandwidth-level view of their Hugging Face usage: how much data is being downloaded and by whom.
 
+<div class="flex justify-center" style="max-width: 750px">
+  <img
+    class="block dark:hidden m-0!"
+    src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/download-analytics.png"
+    alt="screenshot of the organization Downloads settings page, showing daily egress usage and the per-member breakdown"
+  />
+  <img
+    class="hidden dark:block m-0!"
+    src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/dark-download-analytics.png"
+    alt="screenshot of the organization Downloads settings page, showing daily egress usage and the per-member breakdown"
+  />
+</div>
+
 ## Accessing Download Analytics
 
 Organization admins can find Download Analytics on the organization's Downloads settings page, at `https://huggingface.co/organizations/[organizationIdentifier]/settings/downloads`. Individual users can see their own usage at `https://huggingface.co/settings/downloads`.

--- a/docs/hub/enterprise.md
+++ b/docs/hub/enterprise.md
@@ -90,7 +90,7 @@ Team & Enterprise organization plans add advanced capabilities to organizations,
 | [Resource groups](./enterprise-advanced-security)                   |  ❌  |     ✅      |     ✅      |       ✅        |
 | [Tokens admin / management](./enterprise-tokens-management)         |  ❌  |     ✅      |     ✅      |       ✅        |
 | [Token revocation](./enterprise-tokens-management#revoking-via-api) |  ❌  |     ❌      |     ✅      |       ✅        |
-| [Users Download analytics](./enterprise-network-security)           |  ❌  |     ❌      |     ❌      |       ✅        |
+| [Download analytics](./download-analytics)                          |  ✅  |     ✅      |     ✅      |       ✅        |
 | [Content access / policy controls](./enterprise-network-security)   |  ❌  |     ❌      |     ❌      |       ✅        |
 | [Network access controls](./enterprise-network-security)            |  ❌  |     ❌      |     ❌      |       ✅        |
 | [Enforced authentication (advanced)](./enterprise-network-security) |  ❌  |     ❌      |     ❌      |       ✅        |


### PR DESCRIPTION
- fix entry on enterprise table for downloads
- add a page for download 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no product code or security behavior changes.
> 
> **Overview**
> Adds a dedicated **Download Analytics** Hub doc and wires it into the Team & Enterprise navigation.
> 
> The new page explains org/user Downloads settings URLs, daily CDN egress vs plan allowance, per-member bandwidth breakdown, scope limits (no per-repo/file detail), 90-day retention, and points readers to Publisher Analytics for repo-level stats.
> 
> The **Governance, auditing, compliance** matrix is corrected: the row is renamed to **Download analytics**, links to `./download-analytics` instead of `./enterprise-network-security`, and availability is shown as ✅ for **Free, Team, Enterprise, and Enterprise Plus** (replacing Enterprise Plus–only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 598a25113234d119382dbaefc327b5ed2227516a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->