### PR TITLE
add per repo consideration to docs

### DIFF
--- a/docs/hub/enterprise-service-accounts.md
+++ b/docs/hub/enterprise-service-accounts.md
@@ -27,6 +27,13 @@ Service accounts do not have a password and cannot sign in interactively — the
 
 A service account's access to your organization is defined entirely by the fine-grained access tokens you issue to it. For each token, you choose a name and a set of fine-grained permissions, so you can grant only the access a given workflow needs.
 
+Permissions can be granted at two levels:
+
+- Organization-wide — apply a permission (for example, read or write access to repository contents) across all repositories in the organization.
+- Per-repository — scope read or write access to specific repositories only. Search for and select the repositories the token should apply to, then choose the permissions for each. Selected repositories must be owned by the organization or be public.
+
+This lets you issue narrowly-scoped tokens — for example, a token that can only read a single model repository — rather than granting access to the entire organization.
+
 <div class="flex justify-center">
   <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/service-account-create-token.png" alt="Creating a new access token with fine-grained permissions for a service account."/>
   <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/dark-service-account-create-token.png" alt="Creating a new access token with fine-grained permissions for a service account."/>

--- a/docs/hub/enterprise-service-accounts.md
+++ b/docs/hub/enterprise-service-accounts.md
@@ -30,7 +30,7 @@ A service account's access to your organization is defined entirely by the fine-
 Permissions can be granted at two levels:
 
 - Organization-wide — apply a permission (for example, read or write access to repository contents) across all repositories in the organization.
-- Per-repository — scope read or write access to specific repositories only. Search for and select the repositories the token should apply to, then choose the permissions for each. Selected repositories must be owned by the organization or be public.
+- Per-repository — scope read or write access to specific repositories only. Search for and select the repositories the token should apply to, then choose the permissions to grant. Selected repositories must be owned by the organization or be public.
 
 This lets you issue narrowly-scoped tokens — for example, a token that can only read a single model repository — rather than granting access to the entire organization.
 

--- a/docs/hub/enterprise-service-accounts.md
+++ b/docs/hub/enterprise-service-accounts.md
@@ -29,10 +29,10 @@ A service account's access to your organization is defined entirely by the fine-
 
 Permissions can be granted at two levels:
 
-- Organization-wide — apply a permission (for example, read or write access to repository contents) across all repositories in the organization.
-- Per-repository — scope read or write access to specific repositories only. Search for and select the repositories the token should apply to, then choose the permissions to grant. Selected repositories must be owned by the organization or be public.
+- **Organization-wide** — apply a permission (for example, read or write access to repository contents) across all repositories in the organization.
+- **Per-repository** — scope read or write access to specific repositories only. Search for and select the repositories the token should apply to, then choose the permissions to grant. Selected repositories must be owned by the organization or be public.
 
-This lets you issue narrowly-scoped tokens — for example, a token that can only read a single model repository — rather than granting access to the entire organization.
+This lets you issue narrowly scoped tokens — for example, a token that can only read a single model repository — rather than granting access to the entire organization.
 
 <div class="flex justify-center">
   <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/service-account-create-token.png" alt="Creating a new access token with fine-grained permissions for a service account."/>


### PR DESCRIPTION
add per repo consideration to docs. new change from this pr: https://github.com/huggingface-internal/moon-landing/pull/18964

(also to share with this customer https://huggingface.slack.com/archives/C08NNTKSHH9/p1783446066600199)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security behavior impact.
> 
> **Overview**
> Updates **`docs/hub/enterprise-service-accounts.md`** in the **Managing Access Tokens** section to describe how fine-grained permissions can be scoped.
> 
> **Organization-wide** permissions apply across all org repos; **per-repository** permissions limit read/write to selected repos (org-owned or public), with a short example of a single-model read-only token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9860aeafaf9fd42e8a2dead5bd97a155a1c79ff9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->