### PR TITLE
change: huggingface-vllm v0.25.1 vmbumped to v0.25.1

### DIFF
--- a/docs/sagemaker/source/dlcs/available.md
+++ b/docs/sagemaker/source/dlcs/available.md
@@ -38,7 +38,7 @@ In case you want to serve text generation models with vLLM, there are specific D
 
 | vLLM version | Container URI                                                                                                                    | Accelerator |
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| 0.25.0         | 763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-vllm:0.25-transformers5.10-gpu-py312-cu130-ubuntu22.04 | GPU         |
+| 0.25.1         | 763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-vllm:0.25.1-transformers5.10-gpu-py312-cu130-ubuntu22.04 | GPU         |
 | 0.11.0         | 763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-vllm-inference-neuronx:0.11.0-optimum0.4.5-neuronx-py310-sdk2.26.1-ubuntu22.04 | Neuron         |
 
 ### vLLM Omni


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to container version and URI; no runtime or application code affected.
> 
> **Overview**
> Updates the **vLLM** GPU inference DLC entry in `docs/sagemaker/source/dlcs/available.md` from **0.25.0** to **0.25.1**, including the documented version column and the ECR image tag (`huggingface-vllm:0.25.1-transformers5.10-gpu-py312-cu130-ubuntu22.04`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f29b76e02213b40e855838bbcc097461966d2c97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->