### PR TITLE
docs(xet): document shard/chunk cache and other Xet environment variables

### DIFF
--- a/docs/hub/xet/using-xet-storage.md
+++ b/docs/hub/xet/using-xet-storage.md
@@ -141,14 +141,12 @@ Both `hf_xet` and Git Xet are powered by `xet-core`, which can be configured via
 
 ### General
 
-High-level flags that most users reach for first. `HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY` and `HF_XET_NUM_CONCURRENT_RANGE_GETS` are read by the `huggingface_hub` / `hf_xet` Python integration; the rest are read directly by `xet-core`.
+High-level flags that most users reach for first.
 
 | Environment Variable | Default | Description |
 |---|---|---|
 | `HF_XET_HIGH_PERFORMANCE` (alias `HF_XET_HP`) | off | Convenience flag that maximizes network and CPU usage by raising concurrency, buffer sizes, and parallel file limits at once. See the note above — best on machines with high bandwidth and at least 64 GB of RAM. |
 | `HF_XET_CACHE` | `$HF_HOME/xet` | Directory where Xet caches data locally (downloaded chunks and deduplication shards). Takes precedence over `HF_HOME`. |
-| `HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY` | off | Write downloaded files sequentially instead of in parallel. The default parallel writes are tuned for SSD/NVMe; enable this on spinning HDDs to avoid seek thrashing. |
-| `HF_XET_NUM_CONCURRENT_RANGE_GETS` | `16` | Number of byte ranges (chunks) downloaded concurrently per file. Raise it to use more download bandwidth per file. |
 
 ### Adaptive Concurrency
 
@@ -224,7 +222,7 @@ The **chunk cache** stores downloaded byte ranges (chunks) on disk so overlappin
 
 | Environment Variable | Default | Description |
 |---|---|---|
-| `HF_XET_CHUNK_CACHE_SIZE_BYTES` | `0` for `hf_xet`; `10gb` for Git Xet | Size of the local chunk cache. The `hf_xet` Python package ships with the cache **disabled by default** (`0`), while Git Xet enables a 10 GB cache. Set to a large byte count (e.g. `10000000000` for 10 GB) to enable it, or `0` to disable it. |
+| `HF_XET_CHUNK_CACHE_SIZE_BYTES` | `0` (disabled) | Size of the local chunk cache. The `hf_xet` Python package ships with the cache **disabled by default**; set a byte count (e.g. `10000000000` for 10 GB) to enable it, or `0` to disable it. This variable has no effect in Git Xet v0. |
 
 ### Logging
 

--- a/docs/hub/xet/using-xet-storage.md
+++ b/docs/hub/xet/using-xet-storage.md
@@ -141,13 +141,12 @@ Both `hf_xet` and Git Xet are powered by `xet-core`, which can be configured via
 
 ### General
 
-High-level flags that most users reach for first. `HF_HUB_DISABLE_XET`, `HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY`, and `HF_XET_NUM_CONCURRENT_RANGE_GETS` are read by the `huggingface_hub` / `hf_xet` Python integration; the rest are read directly by `xet-core`.
+High-level flags that most users reach for first. `HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY` and `HF_XET_NUM_CONCURRENT_RANGE_GETS` are read by the `huggingface_hub` / `hf_xet` Python integration; the rest are read directly by `xet-core`.
 
 | Environment Variable | Default | Description |
 |---|---|---|
 | `HF_XET_HIGH_PERFORMANCE` (alias `HF_XET_HP`) | off | Convenience flag that maximizes network and CPU usage by raising concurrency, buffer sizes, and parallel file limits at once. See the note above — best on machines with high bandwidth and at least 64 GB of RAM. |
 | `HF_XET_CACHE` | `$HF_HOME/xet` | Directory where Xet caches data locally (downloaded chunks and deduplication shards). Takes precedence over `HF_HOME`. |
-| `HF_HUB_DISABLE_XET` | off | Disable `hf-xet` even when it is installed, falling back to the [LFS bridge](legacy-git-lfs#backward-compatibility-with-lfs). |
 | `HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY` | off | Write downloaded files sequentially instead of in parallel. The default parallel writes are tuned for SSD/NVMe; enable this on spinning HDDs to avoid seek thrashing. |
 | `HF_XET_NUM_CONCURRENT_RANGE_GETS` | `16` | Number of byte ranges (chunks) downloaded concurrently per file. Raise it to use more download bandwidth per file. |
 
@@ -217,8 +216,6 @@ The **shard cache** holds the deduplication index (the "shards" describing chunk
 |---|---|---|
 | `HF_XET_SHARD_CACHE_SIZE_LIMIT` | `16gb` | Soft cap on the on-disk shard cache. The cache is pruned to this size at the **start** of a run, but may grow past it within a single long-running session. As a rough guide, a cache of size *X* deduplicates against roughly 1000 × *X* of data (16 GB → ~16 TB). Raise it for better dedup on very large repos; lower it if the growing cache risks filling your disk. Accepts a human-readable size (e.g. `32gb`) or a raw byte count. |
 | `HF_XET_SHARD_CHUNK_INDEX_TABLE_MAX_SIZE` | `64mb` | Maximum size of the in-memory chunk index. Once reached, no further chunks are loaded for deduplication. |
-| `HF_XET_SHARD_TARGET_SIZE` | `64mb` | Target size of an individual shard file. |
-| `HF_XET_SHARD_MAX_TARGET_SIZE` | `64mb` | Maximum shard size; smaller shards are aggregated until they reach at most this size. |
 | `HF_XET_SHARD_CACHE_SUBDIR` | `shard-cache` | Subdirectory for the shard cache within the Xet cache directory. |
 
 ### Chunk Cache
@@ -228,13 +225,6 @@ The **chunk cache** stores downloaded byte ranges (chunks) on disk so overlappin
 | Environment Variable | Default | Description |
 |---|---|---|
 | `HF_XET_CHUNK_CACHE_SIZE_BYTES` | `0` for `hf_xet`; `10gb` for Git Xet | Size of the local chunk cache. The `hf_xet` Python package ships with the cache **disabled by default** (`0`), while Git Xet enables a 10 GB cache. Set to a large byte count (e.g. `10000000000` for 10 GB) to enable it, or `0` to disable it. |
-
-### Deduplication
-
-| Environment Variable | Default | Description |
-|---|---|---|
-| `HF_XET_DEDUPLICATION_GLOBAL_DEDUP_QUERY_ENABLED` | `true` | Query the server for deduplication shards (by chunk hash) so uploads can deduplicate against data in **other** repositories, not just the one being written. |
-| `HF_XET_DATA_MIN_SPACING_BETWEEN_GLOBAL_DEDUP_QUERIES` | `256` | Minimum spacing, in chunks, between successive global-dedup queries to the server (256 chunks ≈ 4 MB). Limits how frequently the client issues cross-repo dedup queries. |
 
 ### Logging
 

--- a/docs/hub/xet/using-xet-storage.md
+++ b/docs/hub/xet/using-xet-storage.md
@@ -139,6 +139,18 @@ Both `hf_xet` and Git Xet are powered by `xet-core`, which can be configured via
 > [!NOTE]
 > `HF_XET_HIGH_PERFORMANCE=1` is a convenience flag that adjusts several settings at once (concurrency bounds, buffer sizes, and parallel file limits). It is intended for machines with high bandwidth **and at least 64 GB of RAM** for buffering. On machines with less memory, it may degrade performance.
 
+### General
+
+High-level flags that most users reach for first. `HF_HUB_DISABLE_XET`, `HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY`, and `HF_XET_NUM_CONCURRENT_RANGE_GETS` are read by the `huggingface_hub` / `hf_xet` Python integration; the rest are read directly by `xet-core`.
+
+| Environment Variable | Default | Description |
+|---|---|---|
+| `HF_XET_HIGH_PERFORMANCE` (alias `HF_XET_HP`) | off | Convenience flag that maximizes network and CPU usage by raising concurrency, buffer sizes, and parallel file limits at once. See the note above — best on machines with high bandwidth and at least 64 GB of RAM. |
+| `HF_XET_CACHE` | `$HF_HOME/xet` | Directory where Xet caches data locally (downloaded chunks and deduplication shards). Takes precedence over `HF_HOME`. |
+| `HF_HUB_DISABLE_XET` | off | Disable `hf-xet` even when it is installed, falling back to the [LFS bridge](legacy-git-lfs#backward-compatibility-with-lfs). |
+| `HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY` | off | Write downloaded files sequentially instead of in parallel. The default parallel writes are tuned for SSD/NVMe; enable this on spinning HDDs to avoid seek thrashing. |
+| `HF_XET_NUM_CONCURRENT_RANGE_GETS` | `16` | Number of byte ranges (chunks) downloaded concurrently per file. Raise it to use more download bandwidth per file. |
+
 ### Adaptive Concurrency
 
 By default, `xet-core` uses adaptive concurrency — dynamically adjusting parallelism based on real-time network conditions. These are advanced settings that are unlikely to be needed in most cases. The variables below control the adaptive controller's behavior:
@@ -196,6 +208,33 @@ These control memory usage during downloads. `HF_XET_HIGH_PERFORMANCE=1` raises 
 | `HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT` | `8gb` | `64gb` | Hard limit on total download buffer memory. |
 | `HF_XET_RECONSTRUCTION_TARGET_BLOCK_COMPLETION_TIME` | `15m` | — | Target time for completing a prefetch block. Used to determine how much data to prefetch ahead during downloads. |
 | `HF_XET_RECONSTRUCTION_MIN_PREFETCH_BUFFER` | `1gb` | — | Minimum amount of data to keep prefetched during downloads, regardless of estimated completion time. |
+
+### Shard Cache
+
+The **shard cache** holds the deduplication index (the "shards" describing chunks already uploaded) on disk, under the Xet cache directory. A larger cache lets the client deduplicate against more previously-seen data, so fewer bytes are re-uploaded.
+
+| Environment Variable | Default | Description |
+|---|---|---|
+| `HF_XET_SHARD_CACHE_SIZE_LIMIT` | `16gb` | Soft cap on the on-disk shard cache. The cache is pruned to this size at the **start** of a run, but may grow past it within a single long-running session. As a rough guide, a cache of size *X* deduplicates against roughly 1000 × *X* of data (16 GB → ~16 TB). Raise it for better dedup on very large repos; lower it if the growing cache risks filling your disk. Accepts a human-readable size (e.g. `32gb`) or a raw byte count. |
+| `HF_XET_SHARD_CHUNK_INDEX_TABLE_MAX_SIZE` | `64mb` | Maximum size of the in-memory chunk index. Once reached, no further chunks are loaded for deduplication. |
+| `HF_XET_SHARD_TARGET_SIZE` | `64mb` | Target size of an individual shard file. |
+| `HF_XET_SHARD_MAX_TARGET_SIZE` | `64mb` | Maximum shard size; smaller shards are aggregated until they reach at most this size. |
+| `HF_XET_SHARD_CACHE_SUBDIR` | `shard-cache` | Subdirectory for the shard cache within the Xet cache directory. |
+
+### Chunk Cache
+
+The **chunk cache** stores downloaded byte ranges (chunks) on disk so overlapping data isn't re-fetched from storage. It is most useful when repeatedly downloading, or generating new revisions of, related models or datasets.
+
+| Environment Variable | Default | Description |
+|---|---|---|
+| `HF_XET_CHUNK_CACHE_SIZE_BYTES` | `0` for `hf_xet`; `10gb` for Git Xet | Size of the local chunk cache. The `hf_xet` Python package ships with the cache **disabled by default** (`0`), while Git Xet enables a 10 GB cache. Set to a large byte count (e.g. `10000000000` for 10 GB) to enable it, or `0` to disable it. |
+
+### Deduplication
+
+| Environment Variable | Default | Description |
+|---|---|---|
+| `HF_XET_DEDUPLICATION_GLOBAL_DEDUP_QUERY_ENABLED` | `true` | Query the server for deduplication shards (by chunk hash) so uploads can deduplicate against data in **other** repositories, not just the one being written. |
+| `HF_XET_DATA_MIN_SPACING_BETWEEN_GLOBAL_DEDUP_QUERIES` | `256` | Minimum spacing, in chunks, between successive global-dedup queries to the server (256 chunks ≈ 4 MB). Limits how frequently the client issues cross-repo dedup queries. |
 
 ### Logging
 


### PR DESCRIPTION
## What

Expands the **Environment Variables** section of *Using Xet Storage* with the Xet client's user-tunable variables that weren't yet documented. Three new subsections:

- **General** — `HF_XET_HIGH_PERFORMANCE` (alias `HF_XET_HP`), `HF_XET_CACHE`
- **Shard Cache** — `HF_XET_SHARD_CACHE_SIZE_LIMIT`, `HF_XET_SHARD_CHUNK_INDEX_TABLE_MAX_SIZE`, `HF_XET_SHARD_CACHE_SUBDIR`
- **Chunk Cache** — `HF_XET_CHUNK_CACHE_SIZE_BYTES`

## Why

`HF_XET_SHARD_CACHE_SIZE_LIMIT` came up in a customer migration: with `HF_XET_HIGH_PERFORMANCE=1`, the on-disk shard cache can grow enough to fill the disk, and capping it below free space is the fix — but the variable wasn't documented here. This change also folds in the "other Xet environment variables" listed on the `huggingface_hub` reference page so the Hub page is self-contained.

## Accuracy notes (verified against xet-core `v1.5.1` and `main`)

- **Shard cache soft limit is 16 GB** (`xet_runtime/src/config/groups/shard.rs`), not 4 GB. The `huggingface_hub` env-vars page still says 4 GB — stale; worth a follow-up there.
- **Chunk cache default is `0` (disabled)**: `hf_xet`'s Cargo default enables `no-default-cache`. Per @seanses, the `10 GB` build-feature default doesn't apply to Git Xet either — Git Xet v0 goes through the bridge, where the variable has no effect. Documented as a single default plus that caveat.
- **Two variables dropped after review** (@seanses): `HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY` (writes are now always buffered sequential writes pinned to one writer thread) and `HF_XET_NUM_CONCURRENT_RANGE_GETS` (superseded by adaptive concurrency). Neither exists in xet-core anymore; both still appear on the `huggingface_hub` env-vars page — stale, follow-up needed there too.

## Scope

Limited to user-facing knobs. Internal/testing fields (CAS endpoint/scheme/prefix, session xorb-flush internals, dedup fragmentation estimators and global-dedup query controls, shard target sizes, progress-aggregation internals, `USE_VECTORED_WRITE`, `HF_HUB_DISABLE_XET`) are intentionally left out. Purely additive — no existing rows changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XmgpfqHUeQtJthDXJddq9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions to the Hub Xet guide; no runtime, auth, or data-path code changes.
> 
> **Overview**
> Expands the **Environment Variables** section in `using-xet-storage.md` so Hub readers can tune Xet without cross-linking only to `huggingface_hub`.
> 
> Adds a **General** table for `HF_XET_HIGH_PERFORMANCE` / `HF_XET_HP` and `HF_XET_CACHE`, plus new **Shard Cache** and **Chunk Cache** sections. Shard docs call out the **16 GB** soft on-disk limit for `HF_XET_SHARD_CACHE_SIZE_LIMIT`, pruning at run start, and when to lower the cap (e.g. under high-performance mode filling disk). Chunk cache docs note **`hf_xet` defaults to disabled (`0`)** and that `HF_XET_CHUNK_CACHE_SIZE_BYTES` does not apply to Git Xet v0.
> 
> Existing adaptive concurrency, network, buffer, and logging tables are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cebcfd0e6f29f4809e1531ec435ff07c7a9aec68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
