### PR TITLE
Add AWS Deadline Cloud to Hugging Face on AWS docs

### DIFF
--- a/docs/sagemaker/source/_toctree.yml
+++ b/docs/sagemaker/source/_toctree.yml
@@ -37,6 +37,11 @@
           title: EC2, ECS and EKS Quickstart
       title: EC2, ECS and EKS
       isExpanded: false
+    - sections:
+        - local: tutorials/deadline-cloud/deadline-cloud-quickstart
+          title: Deadline Cloud Quickstart
+      title: AWS Deadline Cloud
+      isExpanded: false
   title: Tutorials
   isExpanded: false
 

--- a/docs/sagemaker/source/index.md
+++ b/docs/sagemaker/source/index.md
@@ -25,6 +25,7 @@ You can deploy any Hugging Face Model on AWS with:
 - [AWS Bedrock](#deploy-with-aws-bedrock)
 - [Hugging Face Inference Endpoints](#deploy-with-hugging-face-inference-endpoints)
 - [ECS, EKS, and EC2](#deploy-with-ecs-eks-and-ec2)
+- [AWS Deadline Cloud](#run-batch-inference-with-aws-deadline-cloud)
 
 ### Deploy with Sagemaker SDK
 
@@ -58,6 +59,12 @@ AWS Elastic Container Service (ECS), Elastic Kubernetes Service (EKS), and Elast
 
 [EC2, ECS and EKS Quickstart](https://huggingface.co/docs/sagemaker/main/en/tutorials/compute-services/compute-services-quickstart)
 
+### Run batch inference with AWS Deadline Cloud
+
+AWS Deadline Cloud is a fully managed service for running batch compute workloads at scale, with built-in job queuing, scheduling, and auto-scaling pay-as-you-go worker fleets, including GPU instances. Its Open Job Description job bundles are a great fit for offline, batch-style Hugging Face workloads where you don't need an always-on endpoint: batch LLM inference with vLLM, large-scale text-to-image generation, model evaluation across benchmarks, or protein structure prediction with ESMFold.
+
+[AWS Deadline Cloud Quickstart](https://huggingface.co/docs/sagemaker/main/en/tutorials/deadline-cloud/deadline-cloud-quickstart)
+
 ## Train models on AWS
 
 Training Hugging Face models on AWS is streamlined through various services. Here's how you can fine-tune your models using AWS and Hugging Face offerings.
@@ -65,6 +72,7 @@ Training Hugging Face models on AWS is streamlined through various services. Her
 You can fine-tune any Hugging Face Model on AWS with:
 - [Amazon Sagemaker SDK](#train-with-sagemaker-sdk)
 - [ECS, EKS, and EC2](#train-with-ecs-eks-and-ec2)
+- [AWS Deadline Cloud](#train-with-aws-deadline-cloud)
 
 ### Train with Sagemaker SDK
 
@@ -79,3 +87,9 @@ Hugging Face provides Training Deep Learning Containers (DLCs) to AWS users, opt
 AWS Elastic Container Service (ECS), Elastic Kubernetes Service (EKS), and Elastic Compute Cloud (EC2) allow you to leverage DLCs directly.
 
 [EC2, ECS and EKS Quickstart](https://huggingface.co/docs/sagemaker/main/en/tutorials/compute-services/compute-services-quickstart)
+
+### Train with AWS Deadline Cloud
+
+AWS Deadline Cloud's job bundles can also express training workflows on auto-scaling GPU fleets, from single-step LoRA fine-tuning of any Hugging Face causal language model with 🤗 Transformers, PEFT, and bitsandbytes, to multi-step pipelines that combine data preparation, training, and evaluation as dependent steps in a single job.
+
+[AWS Deadline Cloud Quickstart](https://huggingface.co/docs/sagemaker/main/en/tutorials/deadline-cloud/deadline-cloud-quickstart)

--- a/docs/sagemaker/source/tutorials/deadline-cloud/deadline-cloud-quickstart.md
+++ b/docs/sagemaker/source/tutorials/deadline-cloud/deadline-cloud-quickstart.md
@@ -1,0 +1,108 @@
+# Quickstart — Run Hugging Face Models with AWS Deadline Cloud
+
+## Why use Deadline Cloud for Hugging Face models?
+
+AWS Deadline Cloud is a fully managed batch compute service with job queuing, scheduling, and auto-scaling worker fleets. Unlike an always-on inference endpoint, you pay only while jobs are running — a natural fit for offline Hugging Face workloads: generating LLM responses for thousands of prompts, fine-tuning a model on a custom dataset, batch image generation, or evaluating models across benchmarks.
+
+Jobs are defined as [Open Job Description job bundles](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/build-job-bundle.html): a directory with a YAML template, parameters, and the files your job needs. The [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/job_bundles) repository provides ready-to-submit bundles built on Hugging Face models and libraries:
+
+| Sample | What it does |
+|---|---|
+| [vLLM batch inference](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/job_bundles/vllm_batch) | High-throughput LLM inference over a JSONL file of prompts, fanned out across a GPU fleet |
+| [LoRA / QLoRA fine-tuning](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/job_bundles/hf_finetune_lora) | Fine-tune any Hugging Face causal LM with 🤗 Transformers, PEFT, and bitsandbytes |
+| [Text-to-image batch generation](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/job_bundles/text_to_image_batch) | Generate images at scale from a batch of prompts |
+| [FLUX.2 Klein LoRA](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/job_bundles/flux2_klein_lora) | LoRA training and image generation on GPUs |
+| [vLLM evaluation leaderboard](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/job_bundles/vllm_lm_eval_leaderboard) | Compare multiple LLMs across benchmarks with CSV/Markdown aggregation |
+| [ESMFold prediction](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/job_bundles/esmfold_predict) | Parallel protein structure prediction from FASTA to PDB |
+
+In this quickstart, we will run batch LLM inference with vLLM, then fine-tune a model with QLoRA.
+
+## 1. Prerequisites
+
+| | Requirement |
+|---|---|
+| AWS account | An AWS account with AWS Deadline Cloud enabled. |
+| A farm with a GPU fleet | A Deadline Cloud farm with a service-managed fleet of Linux NVIDIA GPU workers (≥ 16 GB VRAM for fine-tuning, ≥ 32 GB RAM for vLLM) and a queue with a Conda queue environment. The fastest path is deploying the [`cuda_farm` CloudFormation template](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/cloudformation/farm_templates/cuda_farm). |
+| Deadline Cloud CLI | `pip install deadline[gui]` — see the [Deadline Cloud CLI](https://github.com/aws-deadline/deadline-cloud) repository. |
+| Service quotas | GPU instances (e.g. g5/g6 families) require vCPU quota in your region. |
+
+Configure the CLI defaults after your farm is created:
+
+```bash
+deadline config set defaults.farm_id <FARM_ID>
+deadline config set defaults.queue_id <QUEUE_ID>
+```
+
+Then clone the samples:
+
+```bash
+git clone https://github.com/aws-deadline/deadline-cloud-samples.git
+cd deadline-cloud-samples/job_bundles
+```
+
+## 2. Batch LLM inference with vLLM
+
+The `vllm_batch` bundle takes a JSONL file where each line is one prompt, loads the model once per worker with a vLLM server step environment, and fans prompts out across the fleet in chunked tasks.
+
+Create an input file:
+
+```jsonl
+{"prompt": "What is photosynthesis?", "id": "001"}
+{"prompt": "Write a haiku about clouds.", "id": "002"}
+{"prompt": "Explain gravity to a 5 year old.", "id": "003", "max_tokens": 256, "temperature": 0.9}
+```
+
+Submit the job — either with the GUI submitter (`deadline bundle gui-submit vllm_batch/`) or the CLI:
+
+```bash
+deadline bundle submit vllm_batch/ \
+  --parameter InputFile=prompts.jsonl \
+  --parameter Prompts=1-3 \
+  --parameter ChunkSize=5 \
+  --parameter OutputDir=$PWD/results
+```
+
+When the job completes, download the results:
+
+```bash
+deadline job download-output --job-id <JOB_ID>
+open results/output/results.html   # standalone visual results viewer
+cat results/output/output.jsonl    # combined results, one JSON object per line
+```
+
+## 3. Fine-tune a model with LoRA / QLoRA
+
+The `hf_finetune_lora` bundle fine-tunes any Hugging Face causal language model on an instruction dataset (JSONL with `instruction` and `output` fields) and returns a small LoRA adapter (~50–200 MB) you can load on top of the base model.
+
+```bash
+deadline bundle submit hf_finetune_lora/ \
+  -p BaseModel=Qwen/Qwen2.5-1.5B \
+  -p DatasetPath=/path/to/your/data \
+  -p Epochs=5 -p LoraRank=16 -p LearningRate=2e-4 \
+  -p OutputDir=/tmp/lora-output \
+  -p AdapterName=my-adapter
+```
+
+Submitting with all defaults trains on the bundle's included sample dataset, so you can verify your farm end to end before bringing your own data. Dropdown models are public; provide a `HuggingFaceToken` parameter only for gated models such as Llama or Gemma.
+
+Wait for completion and download the adapter:
+
+```bash
+deadline job wait --job-id <JOB_ID> --timeout 3600
+deadline job download-output --job-id <JOB_ID>
+```
+
+Then load it locally with 🤗 PEFT:
+
+```python
+from peft import PeftModel
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+base = AutoModelForCausalLM.from_pretrained("Qwen/Qwen2.5-1.5B")
+model = PeftModel.from_pretrained(base, "/tmp/lora-output/my-adapter")
+tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-1.5B")
+```
+
+## 4. Clean up
+
+Deadline Cloud service-managed fleets auto-scale to zero when queues are empty, so completed jobs stop incurring compute charges automatically. To remove everything, delete the CloudFormation stack (if you used the `cuda_farm` template) or delete the queue, fleet, and farm in the Deadline Cloud console.

--- a/docs/sagemaker/source/tutorials/index.md
+++ b/docs/sagemaker/source/tutorials/index.md
@@ -19,3 +19,7 @@ Take a look at our tutorials about using Hugging Face models on AWS.
 ## EC2, ECS and EKS
 
 - [EC2, ECS and EKS Quickstart](https://huggingface.co/docs/sagemaker/main/en/tutorials/compute-services/compute-services-quickstart)
+
+## AWS Deadline Cloud
+
+- [AWS Deadline Cloud Quickstart](https://huggingface.co/docs/sagemaker/main/en/tutorials/deadline-cloud/deadline-cloud-quickstart)


### PR DESCRIPTION
## What does this PR do?

Adds AWS Deadline Cloud alongside SageMaker, Bedrock, Inference Endpoints, and EC2/ECS/EKS as an option for running Hugging Face models on AWS in the "Hugging Face on AWS" docs.

AWS Deadline Cloud is a fully managed batch compute service (job queuing, scheduling, auto-scaling GPU worker fleets) and its samples repository, [aws-deadline/deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/job_bundles), includes a growing set of ready-to-submit job bundles built on Hugging Face models and libraries: batch LLM inference with vLLM, LoRA/QLoRA fine-tuning with Transformers + PEFT + bitsandbytes, text-to-image batch generation, FLUX.2 Klein LoRA training, LLM benchmark evaluation, and ESMFold protein structure prediction.

## Changes

- **`docs/sagemaker/source/index.md`** — two new sections following the existing per-service pattern (short description + quickstart link):
  - *Run batch inference with AWS Deadline Cloud* under "Deploy models on AWS"
  - *Train with AWS Deadline Cloud* under "Train models on AWS"
- **`docs/sagemaker/source/tutorials/deadline-cloud/deadline-cloud-quickstart.md`** — new quickstart modeled on the Bedrock/JumpStart quickstarts: why Deadline Cloud, prerequisites, batch LLM inference with the `vllm_batch` bundle, LoRA/QLoRA fine-tuning with the `hf_finetune_lora` bundle, clean-up. Commands and parameters are taken from the sample READMEs.
- **`docs/sagemaker/source/_toctree.yml`** and **`docs/sagemaker/source/tutorials/index.md`** — navigation entries.

*Note: I work on the AWS Deadline Cloud team and maintain the samples this references. Happy to adjust wording, structure, or link style (the quickstart links use absolute URLs to match the existing sections; they will resolve once the page is published).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security impact.
> 
> **Overview**
> Documents **AWS Deadline Cloud** as another way to run Hugging Face workloads on AWS, alongside SageMaker, Bedrock, Inference Endpoints, and EC2/ECS/EKS.
> 
> The landing page (`index.md`) gains bullet links plus two sections in the same style as existing services: **batch inference** under “Deploy models on AWS” and **training** (LoRA/QLoRA and multi-step pipelines) under “Train models on AWS”. A new **Deadline Cloud Quickstart** tutorial covers prerequisites, `vllm_batch` JSONL inference, `hf_finetune_lora` submission, PEFT loading, and cleanup, with pointers to `deadline-cloud-samples` job bundles. **`_toctree.yml`** and **`tutorials/index.md`** add navigation to that quickstart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46b1c5bc18b325ded484662dd584cfca804881e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->