### PR TITLE
Document redirect URI matching rules and the loopback port exception

### DIFF
--- a/docs/hub/oauth.md
+++ b/docs/hub/oauth.md
@@ -37,8 +37,6 @@ A few things to keep in mind:
 - Loopback hosts are matched individually: a request for `http://localhost:49282/callback` does not match a registered `http://127.0.0.1/callback`. Register both if your app may use either.
 - Only the port may differ. Path, query and userinfo must still match exactly.
 
-When the authorization code is going to be sent to a loopback address, the authorization screen tells the user that the app is a local application, and shows the host it will be sent to.
-
 ### If you are hosting in Spaces
 
 > [!TIP]

--- a/docs/hub/oauth.md
+++ b/docs/hub/oauth.md
@@ -25,6 +25,20 @@ You can create or use OAuth apps without a client secret. This is useful for nat
 
 Public apps authenticate using only the client ID (e.g. in device code or authorization code flows with PKCE). Apps that have a secret can still use the secret when needed (e.g. `Authorization: Basic` for token requests).
 
+### Redirect URIs
+
+The `redirect_uri` sent in an authorization request must exactly match one of the redirect URIs registered on your app.
+
+Loopback redirect URIs are the one exception: for URIs using the `http` scheme on a loopback host (`localhost`, `127.0.0.1` or `[::1]`), any port is accepted at request time, as long as every other component matches a registered URI. This follows [RFC 8252 §7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3) / OAuth 2.1, and lets native apps, CLIs and MCP clients register a port-less URI such as `http://localhost/callback` and then listen on whatever ephemeral port the operating system assigns them (e.g. `http://localhost:49282/callback`).
+
+A few things to keep in mind:
+
+- The exception only applies to the `http` scheme. `https` and custom-scheme (e.g. `myapp://callback`) redirect URIs always require an exact match, port included.
+- Loopback hosts are matched individually: a request for `http://localhost:49282/callback` does not match a registered `http://127.0.0.1/callback`. Register both if your app may use either.
+- Only the port may differ. Path, query and userinfo must still match exactly.
+
+When the authorization code is going to be sent to a loopback address, the authorization screen tells the user that the app is a local application, and shows the host it will be sent to.
+
 ### If you are hosting in Spaces
 
 > [!TIP]
@@ -48,6 +62,8 @@ Hugging Face supports CIMD aka [Client ID Metadata Documents](https://datatracke
 ```
 
 - Use `"[your website url]/.well-known/oauth-cimd"` as client ID, and PCKE as auth mechanism
+
+Native apps and MCP clients that receive the authorization code on a local port can list port-less loopback URIs in `redirect_uris`, e.g. `["http://localhost/callback", "http://127.0.0.1/callback"]` — see [Redirect URIs](#redirect-uris).
 
 This is particularly useful for ephemeral environments or MCP clients. See an [implementation example](https://github.com/huggingface/chat-ui/pull/1978) in Hugging Chat.
 


### PR DESCRIPTION
The OAuth authorization endpoint now accepts any port for http loopback redirect URIs (RFC 8252 §7.3 / OAuth 2.1), so native apps, CLIs and MCP clients can register a port-less http://localhost/callback and bind an ephemeral port at request time. Everything else still requires an exact match.

[Doc page](https://moon-ci-docs.huggingface.co/docs/hub/pr_2680/en/oauth#redirect-uris)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security behavior modifications in this diff.
> 
> **Overview**
> Documents how Hugging Face Hub OAuth treats **`redirect_uri`** on authorization requests: it must **exactly match** a registered redirect URI, with one exception for **HTTP loopback** URIs per RFC 8252 §7.3 / OAuth 2.1.
> 
> Adds a **Redirect URIs** section explaining that apps can register port-less loopback callbacks (e.g. `http://localhost/callback`) and use whatever ephemeral port the OS assigns at request time. It also clarifies limits: the port exception applies only to **`http`** on `localhost` / `127.0.0.1` / `[::1]`; **`https`** and custom schemes still need exact matches; loopback hostnames are not interchangeable; only the port may differ (path, query, userinfo must match).
> 
> Updates the **CIMD / automated OAuth app** section with an example of listing port-less loopback URIs in `redirect_uris` for native apps and MCP clients, with a link to the new section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 767cd107161014255bb57b1f1d855c4924117606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->