### PR TITLE
Document public token revocation endpoint

### DIFF
--- a/docs/hub/enterprise-tokens-management.md
+++ b/docs/hub/enterprise-tokens-management.md
@@ -118,6 +118,9 @@ curl -X POST "https://huggingface.co/api/organizations/${ORG_NAME}/settings/toke
 
 An administrator cannot revoke their own token (`LEAKED_HF_TOKEN` cannot have the same value as `ADMIN_HF_TOKEN` in the snippet above).
 
+> [!NOTE]
+> This endpoint only revokes the token's access to your organization; the token keeps working for its owner's other resources. To invalidate a leaked token everywhere, use [`POST /api/credentials/revoke`](./security-tokens#revoking-a-leaked-token) instead, which requires no authentication and accepts a batch of raw token values.
+
 ## Programmatic Token Issuance
 
 > [!WARNING]

--- a/docs/hub/enterprise-tokens-management.md
+++ b/docs/hub/enterprise-tokens-management.md
@@ -110,7 +110,7 @@ Administrators can also revoke a token programmatically by providing the raw tok
 curl -X POST "https://huggingface.co/api/organizations/${ORG_NAME}/settings/tokens/revoke" \
   -H "Authorization: Bearer ${ADMIN_HF_TOKEN}" \
   -H "Content-Type: application/json" \
-  -d '{"token": "${LEAKED_HF_TOKEN}"}'
+    -d "{\"token\": \"${LEAKED_HF_TOKEN}\"}"
 ```
 
 > [!TIP]

--- a/docs/hub/security-secrets.md
+++ b/docs/hub/security-secrets.md
@@ -27,3 +27,5 @@ TruffleHog can verify secrets that work across multiple services, it is not rest
 
 You can opt-out from those email notifications from [your settings](https://huggingface.co/settings/notifications).
 
+If the leaked secret is a Hugging Face access token, you can invalidate it right away — including a token that is not yours — see [Revoking a leaked token](./security-tokens#revoking-a-leaked-token).
+

--- a/docs/hub/security-tokens.md
+++ b/docs/hub/security-tokens.md
@@ -56,7 +56,7 @@ model = AutoModel.from_pretrained("private/model", token=access_token)
 ```
 
 > [!WARNING]
-> Try not to leak your token! Though you can always rotate it, anyone will be able to read or write your private repos in the meantime which is 💩
+> Try not to leak your token! Though you can always rotate it, anyone will be able to read or write your private repos in the meantime which is 💩 See [Revoking a leaked token](#revoking-a-leaked-token) if a token has been exposed.
 
 ### Best practices
 
@@ -79,6 +79,28 @@ If you only need access from a CI/CD workflow (GitHub Actions, GitLab CI, Circle
 ### For Enterprise organizations
 
 If your organization needs to programmatically issue tokens for members without requiring each user to create their own token, see [OAuth Token Exchange](./oauth#token-exchange-for-organizations-rfc-8693). This Enterprise plan feature is ideal for building internal platforms, CI/CD pipelines, or custom integrations that need to access Hugging Face resources on behalf of organization members.
+
+## Revoking a leaked token
+
+If one of your own tokens has leaked, delete or refresh it from the [Access Tokens tab](https://huggingface.co/settings/tokens) of your settings.
+
+If you have found somebody else's Hugging Face access token — in a public repository, a log file, a notebook, a paste site, anywhere — you can invalidate it with the `POST /api/credentials/revoke` endpoint. Possession of the raw token value is the only proof required: no authentication is needed, and you don't need any rights over the account or organization that owns the token.
+
+```bash
+# LEAKED_HF_TOKEN should contain the raw token value to revoke
+curl -X POST "https://huggingface.co/api/credentials/revoke" \
+  -H "Content-Type: application/json" \
+  -d "{\"credentials\": [\"${LEAKED_HF_TOKEN}\"]}"
+```
+
+You can pass several token values in the `credentials` array in a single call, which is convenient for secret-scanning pipelines that report findings in batches.
+
+Every submitted token that matches an existing one is invalidated immediately and stops working everywhere — unlike [organization-level revocation](./enterprise-tokens-management#revoking-via-api), which only cuts off the token's access to a single organization. The owner of the token is notified by email and needs to create a new token to restore access.
+
+The endpoint always responds with `202 Accepted`, whether or not any of the tokens you submitted existed, so its response cannot be used to probe whether a token is valid. Submitting the same token again is harmless: repeat calls do nothing and the owner is only notified once.
+
+> [!TIP]
+> To avoid leaking token values in shell history or logs, pass them via environment variables or files, and avoid pasting raw tokens directly into command lines.
 
 ## Tokens in organizations with token management policies
 

--- a/docs/hub/security-tokens.md
+++ b/docs/hub/security-tokens.md
@@ -84,7 +84,7 @@ If your organization needs to programmatically issue tokens for members without 
 
 If one of your own tokens has leaked, delete or refresh it from the [Access Tokens tab](https://huggingface.co/settings/tokens) of your settings.
 
-If you have found somebody else's Hugging Face access token — in a public repository, a log file, a notebook, a paste site, anywhere — you can invalidate it with the `POST /api/credentials/revoke` endpoint. Possession of the raw token value is the only proof required: no authentication is needed, and you don't need any rights over the account or organization that owns the token.
+If you have found somebody else's Hugging Face access token you can invalidate it with the [`POST /api/credentials/revoke`](https://huggingface-openapi.hf.space/#tag/tokens/POST/api/credentials/revoke) endpoint. You don't need any rights over the account or organization that owns the token.
 
 ```bash
 # LEAKED_HF_TOKEN should contain the raw token value to revoke


### PR DESCRIPTION
Add a "Revoking a leaked token" section to the user access tokens page covering POST /api/credentials/revoke: no authentication required, batches of raw token values, always 202, owner notified by email, and idempotency.

Cross-link from the secrets scanning page and from the Enterprise org-level revocation section, clarifying that org revocation is scoped to one organization while this endpoint invalidates a token everywhere.

Follow up https://github.com/huggingface-internal/moon-landing/pull/19370


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or security logic changes.
> 
> **Overview**
> Documents **`POST /api/credentials/revoke`** for invalidating leaked Hugging Face access tokens globally, without authentication, including batch `credentials`, always-**202** responses (no token probing), idempotency, and owner email notification.
> 
> Adds a **Revoking a leaked token** section on the user access tokens page, cross-links from **secrets scanning** and the token-leak warning, and clarifies in **Enterprise org-level revocation** that admin revoke is organization-scoped while this endpoint invalidates tokens everywhere. Fixes the org-revoke **curl** example JSON quoting for shell variable expansion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93a6bf170811e6ca3d5d91b364ced46ad68cc46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->