### PR TITLE
Document API access to user hardware items

### DIFF
--- a/docs/hub/hardware.md
+++ b/docs/hub/hardware.md
@@ -33,6 +33,34 @@ While your hardware is public:
 - A **TFLOPS** badge appears on your profile, summarizing your estimated total compute power.
 - You can browse [what the community is running](https://huggingface.co/hardware) and see how your setup compares across GPUs, CPUs, and Apple Silicon.
 
+## Read hardware from the API
+
+While your hardware is public, it is also available programmatically:
+
+- `GET https://huggingface.co/api/users/{username}/overview` returns a `hardwareItems` array for any user whose hardware is public.
+- `GET https://huggingface.co/oauth/userinfo` includes a `hardwareItems` claim when your app was granted the `profile` scope, so a [Sign in with Hugging Face](./oauth) app can read the signed-in user's setup without an extra call.
+
+```bash
+curl https://huggingface.co/api/users/{username}/overview
+```
+
+```json
+{
+  "hardwareItems": [
+    { "sku": ["GPU", "NVIDIA", "RTX 4090"], "mem": 24, "num": 2, "isPrimary": true }
+  ]
+}
+```
+
+Each item contains:
+
+- `sku`: a `[type, provider, model]` triplet.
+- `mem`: the memory in GB (VRAM, RAM, or unified memory).
+- `num`: the number of units.
+- `isPrimary`: only present on the item marked as primary.
+
+If the user turned off the **Publicly Visible** toggle, `hardwareItems` is omitted from both responses. See the [Hub API documentation](./api) for the full response schemas.
+
 ## Next steps
 
 - [Use AI Models Locally](./local-apps) — run models with your favorite local app.

--- a/docs/hub/hardware.md
+++ b/docs/hub/hardware.md
@@ -35,7 +35,7 @@ While your hardware is public:
 
 ## Read hardware from the API
 
-While your hardware is public, it is also [available programmatically](https://huggingface-openapi.hf.space/#tag/users/GET/api/users/%7Busername%7D/overview):
+While your hardware is public, it is also [available programmatically](https://huggingface-openapi.hf.space/#tag/users/GET/api/users/{username}/overview):
 
 - `GET https://huggingface.co/api/users/{username}/overview` returns a `hardwareItems` array for any user whose hardware is public.
 - `GET https://huggingface.co/oauth/userinfo` includes a `hardwareItems` claim when your app was granted the `profile` scope, so a [Sign in with Hugging Face](./oauth) app can read the signed-in user's setup without an extra call.

--- a/docs/hub/hardware.md
+++ b/docs/hub/hardware.md
@@ -35,7 +35,7 @@ While your hardware is public:
 
 ## Read hardware from the API
 
-While your hardware is public, it is also available programmatically:
+While your hardware is public, it is also [available programmatically](https://huggingface-openapi.hf.space/#tag/users/GET/api/users/{username}/overview):
 
 - `GET https://huggingface.co/api/users/{username}/overview` returns a `hardwareItems` array for any user whose hardware is public.
 - `GET https://huggingface.co/oauth/userinfo` includes a `hardwareItems` claim when your app was granted the `profile` scope, so a [Sign in with Hugging Face](./oauth) app can read the signed-in user's setup without an extra call.

--- a/docs/hub/hardware.md
+++ b/docs/hub/hardware.md
@@ -35,7 +35,7 @@ While your hardware is public:
 
 ## Read hardware from the API
 
-While your hardware is public, it is also [available programmatically](https://huggingface-openapi.hf.space/#tag/users/GET/api/users/{username}/overview):
+While your hardware is public, it is also [available programmatically](https://huggingface-openapi.hf.space/#tag/users/GET/api/users/%7Busername%7D/overview):
 
 - `GET https://huggingface.co/api/users/{username}/overview` returns a `hardwareItems` array for any user whose hardware is public.
 - `GET https://huggingface.co/oauth/userinfo` includes a `hardwareItems` claim when your app was granted the `profile` scope, so a [Sign in with Hugging Face](./oauth) app can read the signed-in user's setup without an extra call.


### PR DESCRIPTION
The user overview endpoint now returns a hardwareItems array, and /oauth/userinfo includes a hardwareItems claim with the profile scope, for users whose hardware is public.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or data-handling code modifications.
> 
> **Overview**
> Adds a **Read hardware from the API** section to the Hub hardware docs describing how public hardware setups are exposed over HTTP.
> 
> It documents `GET /api/users/{username}/overview` returning a `hardwareItems` array, and `GET /oauth/userinfo` including `hardwareItems` when the OAuth app has the `profile` scope. The section includes a curl example, sample JSON, field meanings (`sku`, `mem`, `num`, `isPrimary`), and notes that `hardwareItems` is omitted when hardware is not publicly visible, with a pointer to the full Hub API schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad3dd44d70ec19b82533638110fed089b230d6b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->