### PR TITLE
Add tip for retrieving short-lived HF token via CLI

### DIFF
--- a/docs/hub/trusted-publishers.md
+++ b/docs/hub/trusted-publishers.md
@@ -123,6 +123,18 @@ HF_OIDC_ID_TOKEN="$ID_TOKEN" HF_OIDC_RESOURCE="your-hf-username" hf download acm
 
 The resulting token can read gated repos you have access to and uses your account's rate limits. It **cannot** write anything, and **cannot** read your private repos.
 
+> [!TIP]
+> Need the token itself (for `curl`, `git clone`, or a tool that reads `HF_TOKEN`)? `hf auth token` performs the exchange and prints the short-lived token to stdout:
+>
+> ```yaml
+>       - name: Get a short-lived HF token
+>         env:
+>           HF_OIDC_RESOURCE: your-hf-username  # or a repo, e.g. acme/awesome-model
+>         run: echo "HF_TOKEN=$(hf auth token)" >> "$GITHUB_ENV"
+> ```
+>
+> This works with both user publishers and repo publishers — the token is scoped to whatever `HF_OIDC_RESOURCE` points at.
+
 ## Supported CI providers
 
 The settings UI ships with presets for the providers below, but any OIDC-compliant provider works (AWS, GCP, Buildkite, your own IdP, …).


### PR DESCRIPTION
https://moon-ci-docs.huggingface.co/docs/hub/pr_2683/en/trusted-publishers#api-reference

<img width="1043" height="488" alt="image" src="https://github.com/user-attachments/assets/92fc5d85-959f-4147-94a0-e46622e8c324" />


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security behavior impact.
> 
> **Overview**
> Adds a **TIP** in the gated-repo CI section of `trusted-publishers.md` for workflows that need the exchanged token as a string (e.g. `curl`, `git clone`, or tools that read `HF_TOKEN`).
> 
> Documents that **`hf auth token`** runs the OIDC exchange and prints the short-lived token to stdout, with a GitHub Actions example that sets `HF_OIDC_RESOURCE` and writes `HF_TOKEN` to `GITHUB_ENV`. Notes that scoping applies to both user and repo publishers via `HF_OIDC_RESOURCE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa30e2f3a6bca55e8cf2c5cffd024a6222f24cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->