### PR TITLE
Address julien-c's review comments on hardware API docs

### DIFF
--- a/docs/hub/hardware.md
+++ b/docs/hub/hardware.md
@@ -35,10 +35,10 @@ While your hardware is public:
 
 ## Read hardware from the API
 
-While your hardware is public, it is also [available programmatically](https://huggingface-openapi.hf.space/#tag/users/GET/api/users/{username}/overview):
+If your hardware is public, it is also [available programmatically](https://huggingface-openapi.hf.space/#tag/users/GET/api/users/{username}/overview):
 
-- `GET https://huggingface.co/api/users/{username}/overview` returns a `hardwareItems` array for any user whose hardware is public.
 - `GET https://huggingface.co/oauth/userinfo` includes a `hardwareItems` claim when your app was granted the `profile` scope, so a [Sign in with Hugging Face](./oauth) app can read the signed-in user's setup without an extra call.
+- `GET https://huggingface.co/api/users/{username}/overview` returns a `hardwareItems` array for any user whose hardware is public.
 
 ```bash
 curl https://huggingface.co/api/users/{username}/overview


### PR DESCRIPTION
Follow-up to #2682, addressing @julien-c's post-merge review comments (https://github.com/huggingface/hub-docs/pull/2682#pullrequestreview-4859386686):

- Reword the intro to "If your hardware is public, ..." per the suggestion
- Invert the two endpoint bullets so `oauth/userinfo` comes first

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and bullet order; no runtime or API behavior changes.
> 
> **Overview**
> Updates the **Read hardware from the API** section in `hardware.md` per review feedback.
> 
> The section intro now uses **“If your hardware is public, …”** instead of **“While your hardware is public, …”**. The two endpoint bullets are **reordered** so `GET /oauth/userinfo` (profile scope / Sign in with Hugging Face) is listed before `GET /api/users/{username}/overview`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56aa146240ea2f6f67068fbb85a20d5f6852a8ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->