### PR TITLE
Document read-endpoints / write-endpoints OAuth scopes

### DIFF
--- a/docs/hub/oauth.md
+++ b/docs/hub/oauth.md
@@ -97,20 +97,20 @@ curl -X POST https://huggingface.co/oauth/token \
 
 The currently supported scopes are:
 
-- `openid`: Get the ID token in addition to the access token.
-- `profile`: Get the user's profile information (username, avatar, etc.)
-- `email`: Get the user's email address.
+- `openid`: Receive an ID token in addition to the access token.
+- `profile`: Access the user's profile information (username, avatar, etc.)
+- `email`: Access the user's email address.
 - `read-billing`: Know whether the user has a payment method set up.
-- `read-repos`: Get read access to the user's personal repos.
-- `gated-repos`: Get read access to the content of public gated repos the user has been granted access to. Unlike `read-repos`, this does not grant access to private repos.
-- `contribute-repos`: Can create repositories and access those created by this app. Cannot access any other repositories unless additional permissions are granted.
-- `write-repos`: Get write/read access to the user's personal repos.
-- `manage-repos`: Get full access to the user's personal repos. Also grants repo creation and deletion.
-- `read-collections`: Get read access to the user's personal collections.
-- `write-collections`: Get write/read access to the user's personal collections. Also grants collection creation and deletion.
-- `inference-api`: Get access to the [Inference Providers](https://huggingface.co/docs/inference-providers/index), you will be able to make inference requests on behalf of the user.
-- `read-endpoints`: Get read access to the user's [Inference Endpoints](https://huggingface.co/docs/inference-endpoints/index), and make inference requests to them on behalf of the user.
-- `write-endpoints`: Get write/read access to the user's Inference Endpoints. Also grants endpoint creation and deletion.
+- `read-repos`: Read the user's personal repos.
+- `gated-repos`: Read the content of public gated repos the user has been granted access to. Unlike `read-repos`, this does not grant access to private repos.
+- `contribute-repos`: Create repositories and access those created by this app. Cannot access any other repositories unless additional permissions are granted.
+- `write-repos`: Read and write the user's personal repos.
+- `manage-repos`: Fully manage the user's personal repos, including creating and deleting them.
+- `read-collections`: Read the user's personal collections.
+- `write-collections`: Read and write the user's personal collections, including creating and deleting them.
+- `inference-api`: Make inference requests to [Inference Providers](https://huggingface.co/docs/inference-providers/index) on behalf of the user.
+- `read-endpoints`: View the user's [Inference Endpoints](https://huggingface.co/docs/inference-endpoints/index) and make inference requests to them on behalf of the user.
+- `write-endpoints`: Manage the user's Inference Endpoints, including creating and deleting them. Includes `read-endpoints` access.
 - `jobs`: Run [jobs](https://huggingface.co/docs/huggingface_hub/main/en/guides/jobs)
 - `webhooks`: Manage [webhooks](https://huggingface.co/docs/huggingface_hub/main/en/guides/webhooks)
 - `write-discussions`: Open discussions and Pull Requests on behalf of the user as well as interact with discussions (including reactions, posting/editing comments, closing discussions, ...). To open Pull Requests on private repos, you need to request the `read-repos` scope as well.

--- a/docs/hub/oauth.md
+++ b/docs/hub/oauth.md
@@ -109,6 +109,8 @@ The currently supported scopes are:
 - `read-collections`: Get read access to the user's personal collections.
 - `write-collections`: Get write/read access to the user's personal collections. Also grants collection creation and deletion.
 - `inference-api`: Get access to the [Inference Providers](https://huggingface.co/docs/inference-providers/index), you will be able to make inference requests on behalf of the user.
+- `read-endpoints`: Get read access to the user's [Inference Endpoints](https://huggingface.co/docs/inference-endpoints/index), and make inference requests to them on behalf of the user.
+- `write-endpoints`: Get write/read access to the user's Inference Endpoints. Also grants endpoint creation and deletion.
 - `jobs`: Run [jobs](https://huggingface.co/docs/huggingface_hub/main/en/guides/jobs)
 - `webhooks`: Manage [webhooks](https://huggingface.co/docs/huggingface_hub/main/en/guides/webhooks)
 - `write-discussions`: Open discussions and Pull Requests on behalf of the user as well as interact with discussions (including reactions, posting/editing comments, closing discussions, ...). To open Pull Requests on private repos, you need to request the `read-repos` scope as well.

--- a/docs/hub/oauth.md
+++ b/docs/hub/oauth.md
@@ -98,8 +98,8 @@ curl -X POST https://huggingface.co/oauth/token \
 The currently supported scopes are:
 
 - `openid`: Receive an ID token in addition to the access token.
-- `profile`: Access the user's profile information (username, avatar, etc.)
-- `email`: Access the user's email address.
+- `profile`: Read the user's profile information (username, avatar, etc.)
+- `email`: Read the user's email address.
 - `read-billing`: Know whether the user has a payment method set up.
 - `read-repos`: Read the user's personal repos.
 - `gated-repos`: Read the content of public gated repos the user has been granted access to. Unlike `read-repos`, this does not grant access to private repos.

--- a/docs/hub/spaces-oauth.md
+++ b/docs/hub/spaces-oauth.md
@@ -81,6 +81,8 @@ Those scopes are optional and can be added by setting `hf_oauth_scopes` in your 
 - `read-collections`: Get read access to the user's personal collections.
 - `write-collections`: Get write/read access to the user's personal collections. Also grants collection creation and deletion.
 - `inference-api`: Get access to the [Inference Providers](https://huggingface.co/docs/inference-providers/index), you will be able to make inference requests on behalf of the user.
+- `read-endpoints`: Get read access to the user's [Inference Endpoints](https://huggingface.co/docs/inference-endpoints/index), and make inference requests to them on behalf of the user.
+- `write-endpoints`: Get write/read access to the user's Inference Endpoints. Also grants endpoint creation and deletion.
 - `jobs`: Run [jobs](https://huggingface.co/docs/huggingface_hub/main/en/guides/jobs) 
 - `webhooks`: Manage [webhooks](https://huggingface.co/docs/huggingface_hub/main/en/guides/webhooks)
 - `write-discussions`: Open discussions and Pull Requests on behalf of the user as well as interact with discussions (including reactions, posting/editing comments, closing discussions, ...). To open Pull Requests on private repos, you need to request the `read-repos` scope as well.

--- a/docs/hub/spaces-oauth.md
+++ b/docs/hub/spaces-oauth.md
@@ -67,11 +67,11 @@ For example, you can use `https://{SPACE_HOST}/login/callback` as a redirect URI
 The following scopes are always included for Spaces:
 
 - `openid`: Receive an ID token in addition to the access token.
-- `profile`: Access the user's profile information (username, avatar, etc.)
+- `profile`: Read the user's profile information (username, avatar, etc.)
 
 Those scopes are optional and can be added by setting `hf_oauth_scopes` in your Space's metadata:
 
-- `email`: Access the user's email address.
+- `email`: Read the user's email address.
 - `read-billing`: Know whether the user has a payment method set up.
 - `read-repos`: Read the user's personal repos.
 - `gated-repos`: Read the content of public gated repos the user has been granted access to. Unlike `read-repos`, this does not grant access to private repos.

--- a/docs/hub/spaces-oauth.md
+++ b/docs/hub/spaces-oauth.md
@@ -54,7 +54,7 @@ This will add the following [environment variables](https://huggingface.co/docs/
 
 As for any other environment variable, you can use them in your code by using `os.getenv("OAUTH_CLIENT_ID")`, for example.
 
-## Redirect URLs 
+## Redirect URLs
 
 You can use any redirect URL you want, as long as it targets your Space.
 
@@ -66,24 +66,24 @@ For example, you can use `https://{SPACE_HOST}/login/callback` as a redirect URI
 
 The following scopes are always included for Spaces:
 
-- `openid`: Get the ID token in addition to the access token.
-- `profile`: Get the user's profile information (username, avatar, etc.)
+- `openid`: Receive an ID token in addition to the access token.
+- `profile`: Access the user's profile information (username, avatar, etc.)
 
 Those scopes are optional and can be added by setting `hf_oauth_scopes` in your Space's metadata:
 
-- `email`: Get the user's email address.
+- `email`: Access the user's email address.
 - `read-billing`: Know whether the user has a payment method set up.
-- `read-repos`: Get read access to the user's personal repos.
-- `gated-repos`: Get read access to the content of public gated repos the user has been granted access to. Unlike `read-repos`, this does not grant access to private repos.
-- `contribute-repos`: Can create repositories and access those created by this app. Cannot access any other repositories unless additional permissions are granted.
-- `write-repos`: Get write/read access to the user's personal repos.
-- `manage-repos`: Get full access to the user's personal repos. Also grants repo creation and deletion.
-- `read-collections`: Get read access to the user's personal collections.
-- `write-collections`: Get write/read access to the user's personal collections. Also grants collection creation and deletion.
-- `inference-api`: Get access to the [Inference Providers](https://huggingface.co/docs/inference-providers/index), you will be able to make inference requests on behalf of the user.
-- `read-endpoints`: Get read access to the user's [Inference Endpoints](https://huggingface.co/docs/inference-endpoints/index), and make inference requests to them on behalf of the user.
-- `write-endpoints`: Get write/read access to the user's Inference Endpoints. Also grants endpoint creation and deletion.
-- `jobs`: Run [jobs](https://huggingface.co/docs/huggingface_hub/main/en/guides/jobs) 
+- `read-repos`: Read the user's personal repos.
+- `gated-repos`: Read the content of public gated repos the user has been granted access to. Unlike `read-repos`, this does not grant access to private repos.
+- `contribute-repos`: Create repositories and access those created by this app. Cannot access any other repositories unless additional permissions are granted.
+- `write-repos`: Read and write the user's personal repos.
+- `manage-repos`: Fully manage the user's personal repos, including creating and deleting them.
+- `read-collections`: Read the user's personal collections.
+- `write-collections`: Read and write the user's personal collections, including creating and deleting them.
+- `inference-api`: Make inference requests to [Inference Providers](https://huggingface.co/docs/inference-providers/index) on behalf of the user.
+- `read-endpoints`: View the user's [Inference Endpoints](https://huggingface.co/docs/inference-endpoints/index) and make inference requests to them on behalf of the user.
+- `write-endpoints`: Manage the user's Inference Endpoints, including creating and deleting them. Includes `read-endpoints` access.
+- `jobs`: Run [jobs](https://huggingface.co/docs/huggingface_hub/main/en/guides/jobs)
 - `webhooks`: Manage [webhooks](https://huggingface.co/docs/huggingface_hub/main/en/guides/webhooks)
 - `write-discussions`: Open discussions and Pull Requests on behalf of the user as well as interact with discussions (including reactions, posting/editing comments, closing discussions, ...). To open Pull Requests on private repos, you need to request the `read-repos` scope as well.
 
@@ -97,7 +97,7 @@ The user can select which organizations to grant access to when authorizing the 
 
 ## Adding the button to your Space
 
-You now have all the information to add a "Sign-in with HF" button to your Space. Some libraries ([Python](https://github.com/lepture/authlib), [NodeJS](https://github.com/panva/node-openid-client)) can help you implement the OpenID/OAuth protocol. 
+You now have all the information to add a "Sign-in with HF" button to your Space. Some libraries ([Python](https://github.com/lepture/authlib), [NodeJS](https://github.com/panva/node-openid-client)) can help you implement the OpenID/OAuth protocol.
 
 Gradio and huggingface.js also provide **built-in support**, making implementing the Sign-in with HF button a breeze; you can check out the associated guides with [gradio](https://www.gradio.app/guides/sharing-your-app#o-auth-login-via-hugging-face) and with [huggingface.js](https://huggingface.co/docs/huggingface.js/hub/README#oauth-login).
 


### PR DESCRIPTION
Add the new Inference Endpoints OAuth scopes to the supported scope lists in the OAuth and Spaces OAuth pages.

https://moon-ci-docs.huggingface.co/docs/hub/pr_2686/en/oauth#currently-supported-scopes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no code or security impact.
> 
> **Overview**
> Documents the new **`read-endpoints`** and **`write-endpoints`** OAuth scopes for Inference Endpoints in both the general OAuth and Spaces OAuth docs.
> 
> Also rewords existing scope descriptions for consistency (e.g. "Get" → "Read"/"Receive").
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 236deceadb5366ba2a0a873a60a9b45e3828b279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->