### PR TITLE
Count modular_model_index.json downloads for diffusers repos

### DIFF
--- a/docs/hub/models-download-stats.md
+++ b/docs/hub/models-download-stats.md
@@ -32,6 +32,10 @@ filter: [
 					{
 						term: { path: "model_index.json" },
 					},
+					/// Downloaded from diffusers lib through modular pipelines
+					{
+						term: { path: "modular_model_index.json" },
+					},
 					/// Direct downloads (LoRa, Auto1111 and others)
 					/// Filter out nested safetensors and pickle weights to avoid double counting downloads from the diffusers lib
 					{


### PR DESCRIPTION
Mirrors the counting-query change from huggingface-internal/moon-landing#19441 in the docs snippet.

## Changes

Adds `modular_model_index.json` to the `should` clauses of the diffusers filter snippet in `docs/hub/models-download-stats.md`, matching the internal codebase. Modular pipelines (e.g. `MiniMaxAI/MiniMax-H3`, `krea/krea-realtime-video`, LTX) load `modular_model_index.json` at the repo root instead of `model_index.json`; the filter now lists it as a counted file.

Exact `term` match, root-level only — consistent with the existing `model_index.json` clause.

---

> [!NOTE]
> Authored by Claude Code acting for @Pierrci. Linked: huggingface-internal/moon-landing#19438, huggingface-internal/moon-landing#19441.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an example filter snippet; no production code or download logic is modified in this repo.
> 
> **Overview**
> Updates the documented **diffusers** download-counting filter in `models-download-stats.md` so modular pipeline repos are counted the same way as classic diffusers loads.
> 
> Adds a root-level `term` match for `modular_model_index.json` alongside `model_index.json`, with a short comment that modular pipelines use that file instead. This aligns the public docs with the internal counting query (moon-landing#19441).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 070c9d53df623a44788be70df76208ec8f4fc7ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->