### PR TITLE
agents-cli: reflect the hf-cli skill auto-install

### DIFF
--- a/docs/hub/agent-traces.md
+++ b/docs/hub/agent-traces.md
@@ -39,12 +39,11 @@ Buckets are especially useful if you want to keep syncing traces as new sessions
 
 ## Upload your traces
 
-After creating a dataset or bucket, install the `hf` CLI with the [recommended standalone installer](/docs/huggingface_hub/guides/cli#getting-started) and log in. If you want your coding agent to run `hf` commands for you, install the Hugging Face CLI skill with `hf skills add`.
+After creating a dataset or bucket, install the `hf` CLI with the [recommended standalone installer](/docs/huggingface_hub/guides/cli#getting-started) and log in. The installer also sets up the [Hugging Face CLI Skill](./agents-cli), so your coding agent can run `hf` commands for you.
 
 ```bash
 curl -LsSf https://hf.co/cli/install.sh | bash
 hf auth login
-hf skills add
 
 hf upload <username>/<dataset-name> ~/.codex/sessions . --repo-type dataset
 hf buckets sync ~/.codex/sessions hf://buckets/<username>/<bucket-name>/codex

--- a/docs/hub/agents-cli.md
+++ b/docs/hub/agents-cli.md
@@ -9,9 +9,11 @@ The `hf` CLI is a great way to connect your agents to the Hugging Face Hub and e
 
 Make sure the `hf` CLI is installed and up to date. See the [CLI installation guide](https://huggingface.co/docs/huggingface_hub/guides/cli#getting-started) for setup instructions.
 
+The recommended standalone installer also installs the CLI Skill globally, including the Claude Code location, so agents pick it up with no extra step. Pass `--exclude-skill` (or `-ExcludeSkill` on Windows) to skip it.
+
 ## Add the CLI Skill
 
-Skills give your agent the context it needs to use tools effectively. Install the CLI Skill so your agent knows every `hf` command and stays current with the latest updates. Learn more about Skills at [agentskills.io](https://agentskills.io).
+Skills give your agent the context it needs to use tools effectively. The standalone installer adds the CLI Skill for you — install it by hand if you used pip or Homebrew, skipped it, or want it in a single project. Learn more about Skills at [agentskills.io](https://agentskills.io).
 
 ```bash
 # install globally (available in all projects, works with Codex, Cursor, OpenCode,
@@ -30,7 +32,7 @@ hf skills add --claude
 ```
 
 > [!TIP]
-> The Skill is generated from your locally installed CLI version, so it's always up to date.
+> The Skill is generated from your locally installed CLI version, so it goes stale when you upgrade. `hf update` refreshes a globally installed Skill — never re-adding one you removed — and `hf skills update -g` refreshes it on its own. `hf` reminds you once a day if the Skill is missing or outdated; silence that with `HF_HUB_DISABLE_UPDATE_CHECK=1`.
 
 Alternatively, you can install via the Claude Code plugin system:
 


### PR DESCRIPTION
`huggingface_hub` v1.27.0 changed how the `hf-cli` skill gets installed, and `agents-cli.md` still describes the old flow. The release notes link to this page, so it's the first thing a reader lands on.

https://github.com/huggingface/huggingface_hub/pull/4608
https://github.com/huggingface/huggingface_hub/releases/tag/v1.27.0

What changed here:

- The standalone installer now installs the Skill globally (including the Claude Code location), so that's stated up front, with `--exclude-skill` / `-ExcludeSkill` to opt out.
- "Add the CLI Skill" is reframed as the path for people the installer doesn't cover — pip, Homebrew, opting out, or wanting it in one project.
- The tip said the Skill is "always up to date". That is now the opposite of true: it's generated at install time, and v1.27.0 ships a once-a-day reminder precisely because it drifts. Replaced with how to refresh it (`hf update`, `hf skills update -g`) and how to silence the reminder.
- `agent-traces.md` told readers to run `hf skills add` right after the installer. That step is now redundant, so it links here instead.

The equivalent guidance landed in the `huggingface_hub` guides with #4608; this mirrors it in hub-docs.

Commands verified against v1.27.0, and the `--exclude-skill` / `-ExcludeSkill` flags against the deployed scripts at hf.co/cli/.

Unrelated but adjacent: #2539 is a one-line fix to this same file, approved since June 8 and still unmerged. Different line, no conflict.
