### PR TITLE
Document per-resource-group feature access for organizations

### DIFF
--- a/docs/hub/enterprise-resource-groups.md
+++ b/docs/hub/enterprise-resource-groups.md
@@ -26,6 +26,7 @@ This feature allows organization administrators to:
 - Keep private repositories visible only to authorized group members
 - Enable multiple teams to work independently within the same organization
 - Configure which member roles are allowed to create new resource groups
+- Restrict organization features such as Blog, Collections, Jobs, Inference Endpoints and Inference Providers to the members of specific resource groups
 - Attribute costs to specific resource groups for better budget management
 
 This Team & Enterprise feature helps organizations manage complex team structures and maintain proper access control over their repositories.

--- a/docs/hub/enterprise.md
+++ b/docs/hub/enterprise.md
@@ -88,7 +88,7 @@ Team & Enterprise organization plans add advanced capabilities to organizations,
 | RBAC                                                                           |  ✅  | ✅ Advanced | ✅ Advanced |   ✅ Advanced   |
 | [Audit logs](./audit-logs)                                                     |  ❌  |     ✅      |     ✅      |       ✅        |
 | [Resource groups](./enterprise-advanced-security)                              |  ❌  |     ✅      |     ✅      |       ✅        |
-| [Feature access per resource group](./security-resource-groups#feature-access) |  ❌  |     ❌      |     ✅      |       ✅        |
+| [Feature access per resource group](./security-resource-groups#granular-feature-access) |  ❌  |     ❌      |     ✅      |       ✅        |
 | [Tokens admin / management](./enterprise-tokens-management)                    |  ❌  |     ✅      |     ✅      |       ✅        |
 | [Token revocation](./enterprise-tokens-management#revoking-via-api)            |  ❌  |     ❌      |     ✅      |       ✅        |
 | [Download analytics](./download-analytics)                                     |  ✅  |     ✅      |     ✅      |       ✅        |

--- a/docs/hub/enterprise.md
+++ b/docs/hub/enterprise.md
@@ -83,18 +83,18 @@ Team & Enterprise organization plans add advanced capabilities to organizations,
 
 ### Governance, auditing, compliance
 
-| Feature                                                                        | Free |    Team     | Enterprise  | Enterprise Plus |
-| ------------------------------------------------------------------------------ | :--: | :---------: | :---------: | :-------------: |
-| RBAC                                                                           |  ✅  | ✅ Advanced | ✅ Advanced |   ✅ Advanced   |
-| [Audit logs](./audit-logs)                                                     |  ❌  |     ✅      |     ✅      |       ✅        |
-| [Resource groups](./enterprise-advanced-security)                              |  ❌  |     ✅      |     ✅      |       ✅        |
-| [Feature access per resource group](./security-resource-groups#granular-feature-access) |  ❌  |     ❌      |     ✅      |       ✅        |
-| [Tokens admin / management](./enterprise-tokens-management)                    |  ❌  |     ✅      |     ✅      |       ✅        |
-| [Token revocation](./enterprise-tokens-management#revoking-via-api)            |  ❌  |     ❌      |     ✅      |       ✅        |
-| [Download analytics](./download-analytics)                                     |  ✅  |     ✅      |     ✅      |       ✅        |
-| [Content access / policy controls](./enterprise-network-security)              |  ❌  |     ❌      |     ❌      |       ✅        |
-| [Network access controls](./enterprise-network-security)                       |  ❌  |     ❌      |     ❌      |       ✅        |
-| [Enforced authentication (advanced)](./enterprise-network-security)            |  ❌  |     ❌      |     ❌      |       ✅        |
+| Feature                                                                                | Free |    Team     | Enterprise  | Enterprise Plus |
+|----------------------------------------------------------------------------------------| :--: | :---------: | :---------: | :-------------: |
+| RBAC                                                                                   |  ✅  | ✅ Advanced | ✅ Advanced |   ✅ Advanced   |
+| [Audit logs](./audit-logs)                                                             |  ❌  |     ✅      |     ✅      |       ✅        |
+| [Resource groups](./enterprise-advanced-security)                                      |  ❌  |     ✅      |     ✅      |       ✅        |
+| [Feature access per resource group](./security-resource-groups#granular-feature-access)|  ❌  |     ❌      |     ✅      |       ✅        |
+| [Tokens admin / management](./enterprise-tokens-management)                            |  ❌  |     ✅      |     ✅      |       ✅        |
+| [Token revocation](./enterprise-tokens-management#revoking-via-api)                    |  ❌  |     ❌      |     ✅      |       ✅        |
+| [Download analytics](./download-analytics)                                             |  ✅  |     ✅      |     ✅      |       ✅        |
+| [Content access / policy controls](./enterprise-network-security)                      |  ❌  |     ❌      |     ❌      |       ✅        |
+| [Network access controls](./enterprise-network-security)                               |  ❌  |     ❌      |     ❌      |       ✅        |
+| [Enforced authentication (advanced)](./enterprise-network-security)                    |  ❌  |     ❌      |     ❌      |       ✅        |
 
 ### User provisioning & admin
 

--- a/docs/hub/enterprise.md
+++ b/docs/hub/enterprise.md
@@ -88,6 +88,7 @@ Team & Enterprise organization plans add advanced capabilities to organizations,
 | RBAC                                                                    |  ✅  | ✅ Advanced | ✅ Advanced |   ✅ Advanced   |
 | [Audit logs](./audit-logs)                                              |  ❌  |     ✅      |     ✅      |       ✅        |
 | [Resource groups](./enterprise-advanced-security)                   |  ❌  |     ✅      |     ✅      |       ✅        |
+| [Feature access per resource group](./security-resource-groups#feature-access) |  ❌  |     ❌      |     ✅      |       ✅        |
 | [Tokens admin / management](./enterprise-tokens-management)         |  ❌  |     ✅      |     ✅      |       ✅        |
 | [Token revocation](./enterprise-tokens-management#revoking-via-api) |  ❌  |     ❌      |     ✅      |       ✅        |
 | [Download analytics](./download-analytics)                          |  ✅  |     ✅      |     ✅      |       ✅        |

--- a/docs/hub/enterprise.md
+++ b/docs/hub/enterprise.md
@@ -83,18 +83,18 @@ Team & Enterprise organization plans add advanced capabilities to organizations,
 
 ### Governance, auditing, compliance
 
-| Feature                                                                 | Free |    Team     | Enterprise  | Enterprise Plus |
-| ----------------------------------------------------------------------- | :--: | :---------: | :---------: | :-------------: |
-| RBAC                                                                    |  ✅  | ✅ Advanced | ✅ Advanced |   ✅ Advanced   |
-| [Audit logs](./audit-logs)                                              |  ❌  |     ✅      |     ✅      |       ✅        |
-| [Resource groups](./enterprise-advanced-security)                   |  ❌  |     ✅      |     ✅      |       ✅        |
+| Feature                                                                        | Free |    Team     | Enterprise  | Enterprise Plus |
+| ------------------------------------------------------------------------------ | :--: | :---------: | :---------: | :-------------: |
+| RBAC                                                                           |  ✅  | ✅ Advanced | ✅ Advanced |   ✅ Advanced   |
+| [Audit logs](./audit-logs)                                                     |  ❌  |     ✅      |     ✅      |       ✅        |
+| [Resource groups](./enterprise-advanced-security)                              |  ❌  |     ✅      |     ✅      |       ✅        |
 | [Feature access per resource group](./security-resource-groups#feature-access) |  ❌  |     ❌      |     ✅      |       ✅        |
-| [Tokens admin / management](./enterprise-tokens-management)         |  ❌  |     ✅      |     ✅      |       ✅        |
-| [Token revocation](./enterprise-tokens-management#revoking-via-api) |  ❌  |     ❌      |     ✅      |       ✅        |
-| [Download analytics](./download-analytics)                          |  ✅  |     ✅      |     ✅      |       ✅        |
-| [Content access / policy controls](./enterprise-network-security)   |  ❌  |     ❌      |     ❌      |       ✅        |
-| [Network access controls](./enterprise-network-security)            |  ❌  |     ❌      |     ❌      |       ✅        |
-| [Enforced authentication (advanced)](./enterprise-network-security) |  ❌  |     ❌      |     ❌      |       ✅        |
+| [Tokens admin / management](./enterprise-tokens-management)                    |  ❌  |     ✅      |     ✅      |       ✅        |
+| [Token revocation](./enterprise-tokens-management#revoking-via-api)            |  ❌  |     ❌      |     ✅      |       ✅        |
+| [Download analytics](./download-analytics)                                     |  ✅  |     ✅      |     ✅      |       ✅        |
+| [Content access / policy controls](./enterprise-network-security)              |  ❌  |     ❌      |     ❌      |       ✅        |
+| [Network access controls](./enterprise-network-security)                       |  ❌  |     ❌      |     ❌      |       ✅        |
+| [Enforced authentication (advanced)](./enterprise-network-security)            |  ❌  |     ❌      |     ❌      |       ✅        |
 
 ### User provisioning & admin
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -28,7 +28,7 @@ Resource Groups also affect the visibility of private repositories inside the or
 
 ## Getting started
 
-Head to your Organization's settings, then navigate to the "Resource Group" tab in the left menu.
+Head to your Organization's settings, then navigate to the "Resource Group" entry in the left menu. The page is split in two tabs: **Resource Groups**, where the groups themselves are listed and managed, and **Access settings**, where org admins configure who can create Resource Groups and which members can use specific organization features.
 
 <div class="flex justify-center">
     <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-page.png"/>
@@ -88,7 +88,7 @@ To switch a Resource Group from auto-join to SCIM-managed (or vice versa), disab
 
 ## Who can create Resource Groups
 
-By default, only organization admins can create new Resource Groups. Org admins can change this by setting the **minimum member role required to create Resource Groups** on the Resource Groups settings page.
+By default, only organization admins can create new Resource Groups. Org admins can change this by setting the **minimum member role required to create Resource Groups** in the **Access settings** tab of the Resource Groups settings page.
 
 The available options are:
 - **Admins only** (default) — only org admins can create Resource Groups.
@@ -97,6 +97,33 @@ The available options are:
 - **Read+** — any org member can create Resource Groups.
 
 When a non-admin member creates a Resource Group through the UI, they are automatically added as an **admin** of that newly created group. Through the API, this does not happen automatically, since API callers may be creating groups on behalf of others. Non-admin API callers must include at least one user with the admin role in the group's initial member list.
+
+## Feature access
+
+> [!WARNING]
+> This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> plan and above.
+
+Beyond repository access, org admins can control which members are allowed to use a given organization feature. This is configured from the **Access settings** tab of the Resource Groups settings page.
+
+The following features can be restricted:
+
+- **Blog**: writing and publishing organization [blog articles](./enterprise-blog-articles).
+- **Collections**: creating and editing organization [collections](./collections).
+- **Jobs**: running and viewing [Jobs](./jobs) billed to the organization.
+- **Inference Endpoints**: creating, managing, and calling Inference Endpoints owned by the organization.
+- **Inference Providers**: [Inference Providers](/docs/inference-providers) requests billed to the organization.
+
+For each feature, you can pick who has access:
+
+- **Everyone** (default): every member of the organization.
+- **Org admins only**: only organization admins keep access.
+- **Specific resource groups**: only members of the selected Resource Groups.
+
+Organization admins always keep access to every feature, whichever option is selected.
+
+Members who don't have access to a feature can no longer use it in the organization's context, from the UI as well as from the API, where the corresponding requests are rejected with a `403` error. This has no effect on what those members can do under their personal account or in other organizations.
+
+When a Resource Group is deleted, it is automatically removed from every feature's access list. If it was the only Resource Group granting access to a feature, that feature then remains available to org admins only.
 
 ## Cost attribution
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -125,7 +125,7 @@ For each one, you can pick who has access:
 - **Org admins only**: only organization admins keep access.
 - **Specific resource groups**: only members of the selected Resource Groups depending on their role in the group.
 
-Organization admins always keep access to every feature, whichever option is selected.
+Organization admins always keep access to every feature, whichever option is selected. If a feature is restricted to specific resource groups, associated resources must reside within those resource groups (only organization admins retain the ability to do so at the organization root level).
 
 Members without access can no longer use the feature in the organization's context, from the API as well as the UI — API requests return an authorization error. Nothing changes for them under their personal account or in another org.
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -98,7 +98,7 @@ The available options are:
 
 When a non-admin member creates a Resource Group through the UI, they are automatically added as an **admin** of that newly created group. Through the API, this does not happen automatically, since API callers may be creating groups on behalf of others. Non-admin API callers must include at least one user with the admin role in the group's initial member list.
 
-## Feature access
+## Granular feature access
 
 > [!WARNING]
 > This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> plan and above.

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -103,7 +103,12 @@ When a non-admin member creates a Resource Group through the UI, they are automa
 > [!WARNING]
 > This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> plan and above.
 
-Beyond repository access, org admins can control which members are allowed to use a given organization feature. This is configured from the **Access settings** tab of the Resource Groups settings page.
+Org admins can also control who's allowed to use a given organization feature, separately from repository access. The setting lives on the **Access settings** tab of the Resource Groups settings page.
+
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/feature-access.png"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/dark-feature-access.png"/>
+</div>
 
 The following features can be restricted:
 
@@ -113,17 +118,16 @@ The following features can be restricted:
 - **Inference Endpoints**: creating, managing, and calling Inference Endpoints owned by the organization.
 - **Inference Providers**: [Inference Providers](/docs/inference-providers) requests billed to the organization.
 
-For each feature, you can pick who has access:
 
-- **Everyone** (default): every member of the organization.
+For each one, you can pick who has access:
+
+- **Everyone** (default): every member of the organization depending on their organization role.
 - **Org admins only**: only organization admins keep access.
-- **Specific resource groups**: only members of the selected Resource Groups.
+- **Specific resource groups**: only members of the selected Resource Groups depending on their role in the group.
 
 Organization admins always keep access to every feature, whichever option is selected.
 
-Members who don't have access to a feature can no longer use it in the organization's context, from the UI as well as from the API, where the corresponding requests are rejected with a `403` error. This has no effect on what those members can do under their personal account or in other organizations.
-
-When a Resource Group is deleted, it is automatically removed from every feature's access list. If it was the only Resource Group granting access to a feature, that feature then remains available to org admins only.
+Members without access can no longer use the feature in the organization's context, from the API as well as the UI — API requests return an authorization error. Nothing changes for them under their personal account or in another org.
 
 ## Cost attribution
 


### PR DESCRIPTION
Org admins on Enterprise plans and above can now restrict Blog, Collections, Jobs, Inference Endpoints and Inference Providers to org admins only or to the members of specific resource groups, from the new "Access settings" tab of the Resource Groups settings page.

- Add a "Feature access" section to the Resource Groups guide
- Note the new tab layout, including where the "who can create resource groups" setting now lives
- Mention feature access in the Enterprise resource groups overview and in the plan comparison table

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no application or security logic changes.
> 
> **Overview**
> Documents **granular feature access** for Enterprise orgs: admins can limit Blog, Collections, Jobs, Inference Endpoints, and Inference Providers to everyone, org admins only, or members of selected resource groups.
> 
> The Resource Groups guide adds a **Granular feature access** section (with UI screenshots), clarifies that settings live on the new **Access settings** tab alongside **Resource Groups**, and updates where the “who can create resource groups” control is described. The enterprise resource groups overview and **enterprise.md** plan comparison table now call out feature access per resource group as Enterprise / Enterprise Plus only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38318ed012ba0ab4efbae818cffd1633179eff5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->