### PR TITLE
Rename SCIM Step 0 heading and add it to Entra ID doc

### DIFF
--- a/docs/hub/security-sso-entra-id-scim.md
+++ b/docs/hub/security-sso-entra-id-scim.md
@@ -5,7 +5,7 @@ This guide explains how to set up automatic user and group provisioning between 
 > [!WARNING]
 > This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> and <a href="https://huggingface.co/contact/sales?from=enterprise" target="_blank">Enterprise Plus</a> plans.
 
-## Step 0: Confirm your organization is properly set up for managed users
+## Step 0: Confirm your organization is properly set up
 
 > [!NOTE]
 > This step is only required if you're setting up managed users on Hugging Face.

--- a/docs/hub/security-sso-entra-id-scim.md
+++ b/docs/hub/security-sso-entra-id-scim.md
@@ -5,12 +5,20 @@ This guide explains how to set up automatic user and group provisioning between 
 > [!WARNING]
 > This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> and <a href="https://huggingface.co/contact/sales?from=enterprise" target="_blank">Enterprise Plus</a> plans.
 
+## Step 0: Confirm your organization is properly set up for managed users
+
+> [!NOTE]
+> This step is only required if you're setting up managed users on Hugging Face.
+
+Before proceeding, make sure your organization has been converted to a Hugging Face **managed organization**. SCIM provisioning for managed users is only available on managed organizations — if yours hasn't been converted yet, contact your Hugging Face account team before continuing with the steps below.
+
 ## Step 1: Get SCIM configuration from Hugging Face
 
-1.  Navigate to your organization's settings page on Hugging Face.
-2.  Go to the **SSO** tab, then click on the **SCIM** sub-tab.
-3.  Copy the **SCIM Tenant URL**. You will need this for the Entra ID configuration.
-4.  Click **Generate an access token**. A new SCIM token will be generated. Copy this token immediately and store it securely, as you will not be able to see it again.
+1.  Log in to a Hugging Face account that is an owner of the organization (for managed users, use the owner account provided after the managed user conversion).
+2.  Navigate to your organization's settings page on Hugging Face.
+3.  Go to the **SSO** tab, then click on the **SCIM** sub-tab.
+4.  Copy the **SCIM Tenant URL**. You will need this for the Entra ID configuration.
+5.  Click **Generate an access token**. A new SCIM token will be generated. Copy this token immediately and store it securely, as you will not be able to see it again.
 
 <div class="flex justify-center">
     <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/sso/scim-settings.png"/>

--- a/docs/hub/security-sso-okta-scim.md
+++ b/docs/hub/security-sso-okta-scim.md
@@ -5,7 +5,7 @@ This guide explains how to set up SCIM user and group provisioning between Okta 
 > [!WARNING]
 > This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> and <a href="https://huggingface.co/contact/sales?from=enterprise" target="_blank">Enterprise Plus</a> plans.
 
-## Step 0: Confirm your organization is properly set up for managed users
+## Step 0: Confirm your organization is properly set up
 
 > [!NOTE]
 > This step is only required if you're setting up managed users on Hugging Face.

--- a/docs/hub/security-sso-okta-scim.md
+++ b/docs/hub/security-sso-okta-scim.md
@@ -5,7 +5,7 @@ This guide explains how to set up SCIM user and group provisioning between Okta 
 > [!WARNING]
 > This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> and <a href="https://huggingface.co/contact/sales?from=enterprise" target="_blank">Enterprise Plus</a> plans.
 
-## Step 0: Confirm your organization is managed by Hugging Face
+## Step 0: Confirm your organization is properly set up for managed users
 
 > [!NOTE]
 > This step is only required if you're setting up managed users on Hugging Face.
@@ -73,6 +73,7 @@ For SCIM provisioning with a managed organization configured with SAML SSO, upda
 4. In the mapping modal the Username needs to be edited to comply with the following rules.
 
 > [!WARNING]
+>
 > <ul>
 > <li>Only regular characters and `-` are accepted in the Username.</li>
 > <li>`--` (double dash) is forbidden.</li>


### PR DESCRIPTION
## Summary
- Follow-up to #2690: apply Pierrci's suggested Step 0 heading wording which was merged without being applied.
- Add the same Step 0 (managed organization prerequisite) and owner-login instruction to the Entra ID (Azure AD) SCIM guide, mirroring the Okta guide.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and consistency updates with no code or security impact.
> 
> **Overview**
> Aligns the Entra ID and Okta SCIM setup docs so both start with the same **Step 0** prerequisite for managed organizations.
> 
> Adds the managed-organization check and owner-login instruction to the Entra ID guide, and renames the Okta Step 0 heading to **"Confirm your organization is properly set up"**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e95a04f6047dd76225ff65261fa601721877ade. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->