### PR TITLE
Add DataTrove to Jobs examples

### DIFF
--- a/docs/hub/jobs-examples.md
+++ b/docs/hub/jobs-examples.md
@@ -17,6 +17,16 @@ hf jobs uv run --flavor a10g-small --secrets HF_TOKEN \
   --push_to_hub
 ```
 
+## Process data at scale
+
+[DataTrove](https://github.com/huggingface/datatrove) provides an experimental [`JobsPipelineExecutor`](https://github.com/huggingface/datatrove#jobspipelineexecutor) for distributing data processing pipelines across a pool of Jobs. It supports concurrency limits, multi-stage dependencies, retries, and resuming completed tasks.
+
+See the ready-to-run examples for:
+
+- [Filtering a Hub dataset](https://github.com/huggingface/datatrove/blob/main/examples/filter_hf_dataset_jobs.py)
+- [Tokenizing and merging a Hub dataset](https://github.com/huggingface/datatrove/blob/main/examples/tokenize_hf_dataset_jobs.py)
+- [Multi-stage MinHash deduplication](https://github.com/huggingface/datatrove/blob/main/examples/minhash_deduplication_jobs.py)
+
 ## UV Scripts
 
 The [uv-scripts](https://huggingface.co/uv-scripts) organization maintains a collection of self-contained uv scripts that run on Jobs with a single command. Scripts cover OCR, batch inference, text classification, object detection, dataset statistics, embedding visualization, and more.

--- a/docs/hub/jobs-examples.md
+++ b/docs/hub/jobs-examples.md
@@ -19,7 +19,7 @@ hf jobs uv run --flavor a10g-small --secrets HF_TOKEN \
 
 ## Process data at scale
 
-[DataTrove](https://github.com/huggingface/datatrove) provides an experimental [`JobsPipelineExecutor`](https://github.com/huggingface/datatrove#jobspipelineexecutor) for distributing data processing pipelines across a pool of Jobs. It supports concurrency limits, multi-stage dependencies, retries, and resuming completed tasks.
+[DataTrove](https://github.com/huggingface/datatrove) provides an experimental [`JobsPipelineExecutor`](https://github.com/huggingface/datatrove#jobspipelineexecutor) for distributing data processing pipelines across a pool of Jobs. It supports concurrency limits, multi-stage dependencies, retries, and resumable runs — re-running a pipeline skips tasks that already completed and only runs the remaining ones.
 
 See the ready-to-run examples for:
 


### PR DESCRIPTION
## What does this PR do?

Adds DataTrove to the Jobs examples page as an option for running large-scale data processing pipelines.

It links to the experimental `JobsPipelineExecutor` and ready-to-run examples for:

- filtering a Hub dataset
- tokenizing and merging a Hub dataset
- multi-stage MinHash deduplication

## Draft status

Waiting for the first official PyPI release containing `JobsPipelineExecutor`. The current `datatrove==0.9.0` wheel does not include it.

## Checks

- `git diff --check`
- verified all added links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `jobs-examples.md` with no runtime or product behavior impact.
> 
> **Overview**
> Adds a **Process data at scale** section to the Jobs examples page, positioned after the Transformers training snippet and before **UV Scripts**.
> 
> The new copy points readers to DataTrove’s experimental `JobsPipelineExecutor` for running distributed data pipelines on Jobs (concurrency, multi-stage deps, retries, resumable runs) and links three ready-to-run examples: Hub dataset filtering, tokenize/merge, and multi-stage MinHash deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3c8f8752555b2c28bb9139a7912fdafacbfb015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->