### PR TITLE
Document monthly spend limits per resource group

### DIFF
--- a/docs/hub/enterprise-resource-groups.md
+++ b/docs/hub/enterprise-resource-groups.md
@@ -28,6 +28,7 @@ This feature allows organization administrators to:
 - Configure which member roles are allowed to create new resource groups
 - Restrict organization features such as Blog, Collections, Jobs, Inference Endpoints and Inference Providers to the members of specific resource groups
 - Attribute costs to specific resource groups for better budget management
+- Cap monthly compute spend per resource group, in total or per product
 
 This Team & Enterprise feature helps organizations manage complex team structures and maintain proper access control over their repositories.
 

--- a/docs/hub/programmatic-user-access-control.md
+++ b/docs/hub/programmatic-user-access-control.md
@@ -467,3 +467,55 @@ Content-Type: application/json
 
 > [!NOTE]
 > Disabling auto-join does **not** remove members who were previously auto-joined. It only stops future org members from being added automatically. Existing members remain in the Resource Group.
+
+## Set spend limits via API
+
+[Spend limits](./security-resource-groups#spend-limits) cap the monthly compute spend attributed to a Resource Group. Set them with the update endpoint:
+
+```http
+PATCH /api/organizations/{org_name}/resource-groups/{resource_group_id}
+Authorization: Bearer <your_access_token>
+Content-Type: application/json
+
+{
+  "spendLimits": {
+    "total": 500000,
+    "spaces": 100000,
+    "jobs": 50000
+  }
+}
+```
+
+- **Path parameters**
+  - `org_name`: Organization slug (e.g. `my-org`).
+  - `resource_group_id`: The Resource Group's ID (24-character hex string; get IDs from the [list resource groups endpoint](#list-resource-groups)).
+- **Body**
+  - `spendLimits`: Monthly limits **in cents**. The example above sets a $5,000 total limit, with $1,000 for Spaces and $500 for Jobs.
+    - `total`: Limit on the group's combined spend across every product.
+    - `inferenceProviders`, `spaces`, `jobs`, `endpoints`: Per-product limits, applied on top of the total. The stricter of the two wins.
+
+Only the keys you send are updated, the others keep their current value. Send `null` to remove a limit:
+
+```http
+PATCH /api/organizations/{org_name}/resource-groups/{resource_group_id}
+Authorization: Bearer <your_access_token>
+Content-Type: application/json
+
+{
+  "spendLimits": {
+    "jobs": null
+  }
+}
+```
+
+**Example (curl)**
+
+```bash
+curl -s -X PATCH \
+  -H "Authorization: Bearer $HF_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"spendLimits": {"total": 500000}}' \
+  "https://huggingface.co/api/organizations/my-org/resource-groups/507f1f77bcf86cd799439011"
+```
+
+The response is the updated resource group, including its `spendLimits`.

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -143,6 +143,40 @@ Resource Groups also serve as a cost attribution unit for compute services. When
 
 You can use the <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/&#123;name&#125;/billing/usage-by-resource-group">dedicated API endpoint</a> to retrieve cost attribution data for resource groups.
 
+## Spend limits
+
+> [!WARNING]
+> This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> plan and above.
+
+On top of tracking costs, you can cap them. Organization admins and resource group admins can set monthly spending limits on the group's page in the Resource Groups settings, from the **Spend limits** card.
+
+Two kinds of limits are available, both expressed in USD:
+
+- **Total (all products)**: caps the group's combined compute spend.
+- A per-product limit for **Inference Providers**, **Spaces**, **Jobs** and **Inference Endpoints**, on top of the total.
+
+Leave a field empty for no limit. When a total limit and a per-product limit both apply, the stricter of the two wins.
+
+Limits apply to the spend attributed to the group for the current calendar month, so a group that hit its limit is unblocked at the beginning of the next month — or as soon as an admin raises the limit.
+
+### What happens when a limit is reached
+
+New usage billed to the resource group is refused with an authorization error:
+
+- **Inference Providers**: requests billed to the group are rejected.
+- **Jobs**: creating, resubmitting or resuming a job in the group is rejected, scheduled jobs included.
+- **Spaces**: upgrading a Space in the group to paid hardware is rejected.
+- **Inference Endpoints**: requests to endpoints that incur cost for the group are rejected.
+
+Workloads that are already running in the group are stopped as well, shortly after the limit is reached:
+
+- Paid **Spaces** are paused. Spaces on free hardware are left alone, and so are Spaces running on a [hardware grant](./spaces-gpus).
+- **Jobs** are cancelled, with `Resource group spend limit reached` as their stop reason.
+
+Raising the limit, or the start of a new month, lets members start new workloads again. Spaces and Jobs that were stopped are not restarted automatically.
+
+You can also set spend limits programmatically, see [Set spend limits via API](./programmatic-user-access-control#set-spend-limits-via-api).
+
 ## Resource Groups API
 
 You can list resource groups and add users to them (or change a member's org role and resource group assignments) via the Hub API. For the full reference, examples, and batch workflows, see the [Programmatic User Access Control Management](./programmatic-user-access-control) guide.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security code paths modified.
> 
> **Overview**
> Documents **Enterprise monthly spend limits** for Resource Groups—caps on compute attributed to a group, in total and per product (Inference Providers, Spaces, Jobs, Inference Endpoints).
> 
> **`security-resource-groups.md`** adds a **Spend limits** section: UI configuration via the Spend limits card, calendar-month scope, stricter-of-total-vs-product behavior, and enforcement when a cap is hit (new billed usage rejected; paid Spaces paused and Jobs cancelled with `Resource group spend limit reached`; free/grant Spaces exempt). **`programmatic-user-access-control.md`** documents **`PATCH .../resource-groups/{id}`** with `spendLimits` (cents), partial updates, and `null` to clear limits. **`enterprise-resource-groups.md`** adds spend capping to the feature bullet list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e2d98c441348a8011bed49e936c62656a54178. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->