### PR TITLE
Document the read-memberships OAuth scope

### DIFF
--- a/docs/hub/oauth.md
+++ b/docs/hub/oauth.md
@@ -115,6 +115,7 @@ The currently supported scopes are:
 - `profile`: Read the user's profile information (username, avatar, etc.)
 - `email`: Read the user's email address.
 - `read-billing`: Know whether the user has a payment method set up.
+- `read-memberships`: Read which organizations the user belongs to, and their role in each of them. This does not grant access to the organizations' settings or resources.
 - `read-repos`: Read the user's personal repos.
 - `gated-repos`: Read the content of public gated repos the user has been granted access to. Unlike `read-repos`, this does not grant access to private repos.
 - `contribute-repos`: Create repositories and access those created by this app. Cannot access any other repositories unless additional permissions are granted.

--- a/docs/hub/spaces-oauth.md
+++ b/docs/hub/spaces-oauth.md
@@ -73,6 +73,7 @@ Those scopes are optional and can be added by setting `hf_oauth_scopes` in your 
 
 - `email`: Read the user's email address.
 - `read-billing`: Know whether the user has a payment method set up.
+- `read-memberships`: Read which organizations the user belongs to, and their role in each of them. This does not grant access to the organizations' settings or resources.
 - `read-repos`: Read the user's personal repos.
 - `gated-repos`: Read the content of public gated repos the user has been granted access to. Unlike `read-repos`, this does not grant access to private repos.
 - `contribute-repos`: Create repositories and access those created by this app. Cannot access any other repositories unless additional permissions are granted.


### PR DESCRIPTION
Adds the new `read-memberships` scope to the supported scope lists for OAuth apps and Spaces OAuth. The scope lets an app read which organizations the user belongs to and their role in each, without granting access to organization settings or resources.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to two markdown files; no runtime or API behavior changes in this PR.
> 
> **Overview**
> Documents the **`read-memberships`** OAuth scope in the Hub OAuth guides so integrators can discover and request it consistently for general OAuth apps and Spaces.
> 
> The new bullet is added after **`read-billing`** in **`docs/hub/oauth.md`** (supported scopes for Sign in with HF) and in **`docs/hub/spaces-oauth.md`** (optional scopes via **`hf_oauth_scopes`**). The description states the scope exposes which organizations the user belongs to and their role in each, and explicitly clarifies it does **not** grant access to organization settings or resources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5dc5a47f9e705cf952eefacaf769dedd369b27e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->