### PR TITLE
Jobs: document that GPU performance counters are unavailable

### DIFF
--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -227,6 +227,9 @@ l40sx4           4x Nvidia L40S          48 vCPU   382 GB   3200 GB   4x L40S (1
 l40sx8           8x Nvidia L40S          192 vCPU  1534 GB  6500 GB   8x L40S (384 GB)          $0.3917   $23.50
 ```
 
+> [!NOTE]
+> NVIDIA GPU performance counters are not accessible from inside a Job. Profilers that read them, such as Nsight Compute, fail with `ERR_NVGPUCTRPERM` even after attaching to the process. The restriction is enforced on the host, so it cannot be enabled from the job's image, command, or environment (see [NVIDIA's documentation](https://developer.nvidia.com/nvidia-development-tools-solutions-err_nvgpuctrperm-permission-issue-performance-counters)). Tools that do not read performance counters, such as `nvidia-smi` and CUDA events, work normally.
+
 ## Expose Ports
 
 Jobs can expose container ports through the public jobs proxy using `--expose <port>` (CLI) or `expose=[<port>]` (Python API). Each exposed port is reachable at `https://<job_id>--<port>.hf.jobs` and requires an HF token with `read` access to the job's namespace:


### PR DESCRIPTION
Adds a note under **Hardware flavor** in `jobs-configuration.md`: NVIDIA GPU performance counters are not accessible from inside a Job.

The failure mode is confusing. Nsight Compute installs and even attaches to the target process, then fails:

```
==PROF== Connected to process 9012 (/usr/local/bin/my-benchmark)
==ERROR== ERR_NVGPUCTRPERM - The user does not have permission to access NVIDIA GPU Performance Counters on the target device 0.
==PROF== Disconnected from process 9012
```

This looks like a problem with the image, so you keep trying variants (different CUDA base, different `ncu` version, `--target-processes all`, running as root). None of that can work: counter access is gated by the host's NVIDIA kernel module (`NVreg_RestrictProfilingToAdminUsers`), and nothing inside the job can change it. A note in the docs would have saved me that time.

For the record: observed on `l40sx1`, driver 580.159.03, nsight-compute-2024.1.1 installed from the CUDA apt repo. On the same job, `nvidia-smi` queries and CUDA event timing work fine.

I only hit the counter restriction, so that is all the note claims. Happy to reword this or move it if another spot fits better.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or API impact.
> 
> **Overview**
> Adds a **[!NOTE]** under **Hardware flavor** in `jobs-configuration.md` (right after the `hf jobs hardware` table) explaining that **NVIDIA GPU performance counters cannot be used inside Jobs**.
> 
> The note calls out the **`ERR_NVGPUCTRPERM`** failure mode for profilers like **Nsight Compute**, states the limit is **host-enforced** (not fixable via image, command, or env), links **NVIDIA’s docs**, and clarifies that **`nvidia-smi`** and **CUDA event timing** still work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bc07a06c62b486a99e74e43238bea461a771f7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->