### PR TITLE
Update Pi links to the renamed repo and npm package

### DIFF
--- a/docs/hub/agents-local.md
+++ b/docs/hub/agents-local.md
@@ -36,7 +36,7 @@ Pick one of the agents below and follow the setup instructions.
 Install Pi:
 
 ```bash
-npm install -g @mariozechner/pi-coding-agent
+npm install -g @earendil-works/pi-coding-agent
 ```
 
 Then add your local model to Pi's configuration file at `~/.pi/agent/models.json`:

--- a/docs/inference-providers/integrations/index.md
+++ b/docs/inference-providers/integrations/index.md
@@ -15,7 +15,7 @@ This table lists _some_ tools, libraries, and applications that work with Huggin
 
 | Integration                                                        | Description                                                              | Resources                                                                                                                                          |
 | ------------------------------------------------------------------ | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Pi](https://github.com/badlogic/pi-mono)                          | Minimalist terminal-based coding assistant                              | [Getting started](./pi)                                                                     |
+| [Pi](https://github.com/earendil-works/pi)                          | Minimalist terminal-based coding assistant                              | [Getting started](./pi)                                                                     |
 | [OpenCode](https://opencode.ai/)                                   | AI coding agent built for the terminal                                  | [Getting started](./opencode)                                                   |
 | [Codex](https://developers.openai.com/codex)                       | OpenAI's agentic coding CLI for the terminal                            | [Getting started](./codex)                                                                                                                         |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code)      | Agentic coding tool for the terminal                                    | [Getting started](./claude-code)                                                                                                                   |
@@ -53,7 +53,7 @@ End-user applications and interfaces powered by LLMs.
 
 AI-powered coding assistants and development environments.
 
-- [Pi](https://github.com/badlogic/pi-mono) - Minimalist terminal-based coding assistant ([Getting started](./pi))
+- [Pi](https://github.com/earendil-works/pi) - Minimalist terminal-based coding assistant ([Getting started](./pi))
 - [OpenCode](https://opencode.ai/) - AI coding agent built for the terminal ([Getting started](./opencode))
 - [Codex](https://developers.openai.com/codex) - OpenAI's agentic coding CLI for the terminal ([Getting started](./codex))
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) - Agentic coding tool for the terminal ([Getting started](./claude-code))

--- a/docs/inference-providers/integrations/pi.md
+++ b/docs/inference-providers/integrations/pi.md
@@ -1,6 +1,6 @@
 # Pi
 
-[Pi](https://github.com/badlogic/pi-mono) is a minimalist, extensible terminal-based coding assistant designed to adapt to your workflows rather than the other way around.
+[Pi](https://github.com/earendil-works/pi) is a minimalist, extensible terminal-based coding assistant designed to adapt to your workflows rather than the other way around.
 
 ## Overview
 


### PR DESCRIPTION
Pi's GitHub repo was renamed from `badlogic/pi-mono` to `earendil-works/pi`, and its npm package moved from `@mariozechner/pi-coding-agent` (now deprecated, frozen at 0.73.1) to `@earendil-works/pi-coding-agent` (currently 0.84.2).

- `docs/hub/agents-local.md`: install command now uses the new package name
- `docs/inference-providers/integrations/pi.md` and `index.md`: repo links point to `https://github.com/earendil-works/pi`

`docs/hub/agent-traces.md` is left unchanged: it links `badlogic/pi-share-hf`, which was not part of the rename.

Docs counterpart of https://github.com/huggingface/huggingface.js/pull/2390.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and install-command updates with no runtime or security impact.
> 
> **Overview**
> Updates Hugging Face docs to match Pi’s **GitHub rename** (`badlogic/pi-mono` → `earendil-works/pi`) and the **current npm package** (`@mariozechner/pi-coding-agent` → `@earendil-works/pi-coding-agent`).
> 
> In `docs/hub/agents-local.md`, the global install command now uses `@earendil-works/pi-coding-agent` with `--ignore-scripts`. In `docs/inference-providers/integrations/pi.md` and `index.md`, Pi links in the overview table and Developer Tools list point at the new repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd701df49a8c8aba5e76e8f1301ab25bd50a5966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->