### PR TITLE
Update WaveSpeed inference provider description

### DIFF
--- a/docs/inference-providers/providers/wavespeed.md
+++ b/docs/inference-providers/providers/wavespeed.md
@@ -36,7 +36,7 @@ For more details, check out the `generate.ts` script: https://github.com/hugging
     </a>
 </div>
 
-[WaveSpeedAI](https://wavespeed.ai/) is a high-performance AI inference platform specializing in image and video generation. Built with cutting-edge infrastructure and optimization techniques, [WaveSpeedAI](https://wavespeed.ai/) provides fast, scalable, and cost-effective model serving for creative AI applications.
+[WaveSpeedAI](https://wavespeed.ai/) is an inference platform for image and video generation. On Hugging Face it serves open-weight model families including FLUX, Qwen-Image, Z-Image, HiDream, Wan, HunyuanVideo, LTX-2 and MiniMax-H3, covering text-to-image, image-to-image, text-to-video and image-to-video from a single API, as well as LoRA adapters hosted on the Hub. The wider [WaveSpeedAI](https://wavespeed.ai/) catalog also includes closed-weight models such as Seedream, Seedance, Nano Banana and GPT Image.
 
 ## Supported tasks
 

--- a/scripts/inference-providers/templates/providers/wavespeed.handlebars
+++ b/scripts/inference-providers/templates/providers/wavespeed.handlebars
@@ -7,7 +7,7 @@
 
 {{{followUsSection}}}
 
-[WaveSpeedAI](https://wavespeed.ai/) is a high-performance AI inference platform specializing in image and video generation. Built with cutting-edge infrastructure and optimization techniques, [WaveSpeedAI](https://wavespeed.ai/) provides fast, scalable, and cost-effective model serving for creative AI applications.
+[WaveSpeedAI](https://wavespeed.ai/) is an inference platform for image and video generation. On Hugging Face it serves open-weight model families including FLUX, Qwen-Image, Z-Image, HiDream, Wan, HunyuanVideo, LTX-2 and MiniMax-H3, covering text-to-image, image-to-image, text-to-video and image-to-video from a single API, as well as LoRA adapters hosted on the Hub. The wider [WaveSpeedAI](https://wavespeed.ai/) catalog also includes closed-weight models such as Seedream, Seedance, Nano Banana and GPT Image.
 
 {{{tasksSection}}}
 


### PR DESCRIPTION
Hi! We're the WaveSpeed team (an Inference Provider on the Hub). This PR updates our provider description on `docs/inference-providers/providers/wavespeed.md`, edited via the `wavespeed.handlebars` template as the file header instructs, with the generated `.md` updated to match (same approach as #2027).

### Why

The current blurb is generic and doesn't tell a reader anything about what we actually serve:

> [WaveSpeedAI](https://wavespeed.ai/) is a high-performance AI inference platform specializing in image and video generation. Built with cutting-edge infrastructure and optimization techniques, [WaveSpeedAI](https://wavespeed.ai/) provides fast, scalable, and cost-effective model serving for creative AI applications.

### Proposed

> [WaveSpeedAI](https://wavespeed.ai/) is an inference platform for image and video generation. On Hugging Face it serves open-weight model families including FLUX, Qwen-Image, Z-Image, HiDream, Wan, HunyuanVideo, LTX-2 and MiniMax-H3, covering text-to-image, image-to-image, text-to-video and image-to-video from a single API, as well as LoRA adapters hosted on the Hub. The wider [WaveSpeedAI](https://wavespeed.ai/) catalog also includes closed-weight models such as Seedream, Seedance, Nano Banana and GPT Image.

We aimed to match the tone and length of the other provider templates (`fal-ai`, `replicate`, `together`, `baseten`) — factual, no superlatives, no performance claims.

### Evidence for the claims

From `https://huggingface.co/api/models?inference_provider=wavespeed&expand[]=inferenceProviderMapping`, counting live mappings where `provider == "wavespeed"`:

| Task | `single-model` mappings | `tag-filter` (LoRA) mappings |
| --- | --- | --- |
| text-to-image | 13 | 44,645 |
| image-to-image | 8 | 451 |
| text-to-video | 5 | 155 |
| image-to-video | 6 | 176 |
| image-text-to-video | 1 | 12 |
| image-text-to-image | 0 | 10 |

The 33 `single-model` repos behind the named families: FLUX.1-dev / -schnell / -Krea-dev / -Kontext-dev, FLUX.2-dev / -klein-*, Qwen-Image / -2512 / -Edit / -Edit-2509 / -Edit-2511, Tongyi-MAI/Z-Image (+ Turbo), HiDream-I1-Dev / -Full, Wan2.1/2.2 T2V, I2V and TI2V, tencent/HunyuanVideo / -1.5, tencent/HunyuanImage-2.1, Lightricks/LTX-2, MiniMaxAI/MiniMax-H3, ByteDance/lynx, chetwinlow1/Ovi, briaai/FIBO, ideogram-ai/ideogram-4-fp8, krea/Krea-2-Turbo.

### Scope

Deliberately minimal — copy only, two files, no other changes:

- **Partners table in `index.md`: untouched.** Its columns are Chat completion, Feature Extraction, Text to Image, Text to video, Speech to text — there's no image-to-image or image-to-video column, and other image/video providers are equally uncredited there. Mentioning it only as an observation; adding columns is a product decision for you, not something a vendor PR should push.
- **Featured code snippets: untouched.** Our text-to-video snippet currently points at `larryvrh/MiniMax-H3-Turbo-Lora`, a third-party user repo rather than `MiniMaxAI/MiniMax-H3`. We checked `generate.ts` and this is fully automated (`sort=likes30d`, top warm model per task/provider), and that repo genuinely leads by likes30d (750 vs 328 for the runner-up) — so it's working as designed and not ours to override. Flagging it only in case you consider it surprising that a community LoRA fine-tune is the featured example for a provider.
- Prettier: `.handlebars` is in `.prettierignore`, and `docs/` is outside the `scripts/inference-providers` format scope. `prettier --check` on `wavespeed.md` reports the same pre-existing warning before and after this change.

Happy to adjust the wording however you'd prefer. Note: this PR was prepared with AI assistance (Claude Code); all figures above were verified against the Hub API and the numbers/claims were reviewed by us.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change for a provider page; no code, API, or security impact.
> 
> **Overview**
> Replaces the generic WaveSpeedAI blurb with a factual description of what the provider serves on Hugging Face: named open-weight image/video families, Hub LoRAs, and a note that the wider WaveSpeed catalog also includes closed-weight models.
> 
> The copy is updated in `wavespeed.handlebars` and the generated `wavespeed.md`. No task snippets, logos, or partner-table changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eeeb35fcd40d9c4ab6c220d7564dce75c736194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->