### PR TITLE
Clarify "Higher Hub rate limits"

### DIFF
--- a/docs/hub/enterprise-network-security.md
+++ b/docs/hub/enterprise-network-security.md
@@ -5,7 +5,7 @@
 
 ## Define your organization IP Ranges
 
-You can list the IP addresses of your organization's outbound traffic to apply for higher rate limits and/or to enforce authenticated access to Hugging Face from your corporate network.
+You can list the IP addresses of your organization's outbound traffic to enforce authenticated access to Hugging Face from your corporate network.
 The outbound IP address ranges are defined in <a href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing" target="_blank">CIDR</a> format. For example, `52.219.168.0/24` or `2600:1f69:7400::/40`.
 
 You can set multiple ranges, one per line. 
@@ -24,9 +24,9 @@ After the “Organization IP Ranges” have been manually verified, and the orga
 
 ## Higher Hub Rate Limits
 
-Most of the actions on the Hub have limits; for example, users are limited to creating a certain number of repositories per day. Enterprise Plus automatically gives your users the highest rate limits possible for every action.
+Most of the actions on the Hub have limits; for example, users are limited to creating a certain number of repositories per day. Enterprise Plus automatically gives your users high rate limits for every action.
 
-Additionally, once your IP ranges are set, enabling the "Higher Hub Rate Limits" option allows your organization to benefit from the highest HTTP rate limits on the Hub API, unlocking large volumes of model or dataset downloads.
+Additionally, enabling the "Higher Hub Rate Limits" option allows your organization to benefit from the highest HTTP rate limits on the Hub API, unlocking large volumes of model or dataset downloads.
 
 For more information about rate limits, see the [Hub Rate limits](./rate-limits) documentation.
 

--- a/docs/hub/rate-limits.md
+++ b/docs/hub/rate-limits.md
@@ -67,7 +67,7 @@ Here are the current rate limits (in September '25) based on your plan:
 | Team organization                                                         | 3,000    | 20,000    | 400    |
 | Enterprise organization                                                   | 6,000    | 50,000    | 600    |
 | Enterprise Plus organization                                              | 10,000   | 100,000   | 1,000  |
-| Enterprise Plus organization <br> When Organization IP Ranges are defined | 100,000  | 500,000   | 10,000 |
+| Enterprise Plus organization <br> With "Higher Hub Rate Limits" enabled   | 100,000  | 500,000   | 10,000 |
 | Academia Hub organization                                                 | 3,000    | 20,000    | 400    |
 
 \* Anonymous and Free users are subject to change over time depending on platform health 🤞


### PR DESCRIPTION
Not tied to "Organization IP ranges".
Context: [PR](https://github.com/huggingface-internal/moon-landing/pull/19482), [comment](https://github.com/huggingface-internal/moon-landing/pull/19473#issuecomment-5219698676), [Slack question](https://huggingface.slack.com/archives/C0BGCS5S732/p1787295043758319) (internal links).

Follow up work:
- Update screenshot [here](https://huggingface.co/docs/hub/main/en/enterprise-network-security#define-your-organization-ip-ranges)
- Clarify UI further (cc @gary149):
  - Move the "Higher Hub rate limits" above or below the IP ranges settings (see screenshot attached).
  - Or potentially just remove it and auto-apply the higher limits to all E+.


<img width="883" height="647" alt="Screenshot 2026-08-21 at 11 47 50" src="https://github.com/user-attachments/assets/186c7e82-081d-4f68-853d-ad1e2729b46d" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation wording only; no product or security behavior changes.
> 
> **Overview**
> Clarifies that Enterprise Plus **Higher Hub Rate Limits** are a standalone setting, not something that requires Organization IP Ranges.
> 
> IP range docs now describe only authenticated-access enforcement. Rate-limit docs label the top tier as applying when **"Higher Hub Rate Limits" is enabled**, and Enterprise Plus default limits are described as high rather than the highest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6161ec72bfd8b73dc931223a7d097b56a3c1d86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->