### PR TITLE
Reference /.well-known/meta.json in proxy and firewall allowlists

### DIFF
--- a/docs/hub/datasets-downloading.md
+++ b/docs/hub/datasets-downloading.md
@@ -79,17 +79,17 @@ If your network restricts outbound traffic through a firewall or proxy, download
 
 Allowlist the following hostnames (all over HTTPS / port 443):
 
-| Hostname                     | Purpose                                   |
-|------------------------------|-------------------------------------------|
-| `huggingface.co`             | Hub API, metadata, and download redirects |
-| `cas-server.xethub.hf.co`    | Xet storage protocol APIs + upload (US)   |
-| `cas-server.xethub-eu.hf.co` | Xet storage protocol APIs + upload (EU)   |
-| `transfer.xethub.hf.co`      | Xet storage download APIs (US)            |
-| `transfer.xethub-eu.hf.co`   | Xet storage download APIs (EU)            |
-| `us.aws.cdn.hf.co`           | CDN edge (US)                             |
-| `us.gcp.cdn.hf.co`           | CDN edge (US)                             |
-| `cdn-lfs-us-1.hf.co`         | LFS CDN (US)                              |
-| `cdn-lfs-eu-1.hf.co`         | LFS CDN (EU)                              |
+| Hostname                     | Purpose                                     |
+|------------------------------|---------------------------------------------|
+| `huggingface.co`             | Hub API, metadata, and download redirects   |
+| `cas-server.xethub.hf.co`    | Xet protocol APIs, download and upload (US) |
+| `cas-server.xethub-eu.hf.co` | Xet protocol APIs, download and upload (EU) |
+| `transfer.xethub.hf.co`      | Xet storage download APIs (US)              |
+| `transfer.xethub-eu.hf.co`   | Xet storage download APIs (EU)              |
+| `us.aws.cdn.hf.co`           | CDN edge (US)                               |
+| `us.gcp.cdn.hf.co`           | CDN edge (US)                               |
+| `cdn-lfs-us-1.hf.co`         | LFS CDN (US)                                |
+| `cdn-lfs-eu-1.hf.co`         | LFS CDN (EU)                                |
 
 > [!TIP]
 > Downloads follow HTTP redirects from `huggingface.co` to these hostnames, so
@@ -113,3 +113,13 @@ Allowlist the following hostnames (all over HTTPS / port 443):
 > These hostnames may change as our storage and CDN infrastructure evolves. Where your
 > security policy allows it, allowlist the `hf.co` and `huggingface.co` suffixes (all
 > subdomains) so your rules don't break when a specific endpoint changes.
+
+### Machine-readable list
+
+The hostnames above are also published as JSON at
+[`https://huggingface.co/.well-known/meta.json`](https://huggingface.co/.well-known/meta.json),
+so you can generate proxy or firewall rules from it rather than copying the table by hand.
+
+> [!WARNING]
+> The file changes as endpoints are added and removed. Fetch it when you build your rules
+> rather than pinning a copy.

--- a/docs/hub/models-downloading.md
+++ b/docs/hub/models-downloading.md
@@ -90,17 +90,17 @@ If your network restricts outbound traffic through a firewall or proxy, download
 Allowlist the following hostnames (all over HTTPS / port 443):
 
 
-| Hostname                     | Purpose                                   |
-|------------------------------|-------------------------------------------|
-| `huggingface.co`             | Hub API, metadata, and download redirects |
-| `cas-server.xethub.hf.co`    | Xet storage protocol APIs + upload (US)   |
-| `cas-server.xethub-eu.hf.co` | Xet storage protocol APIs + upload (EU)   |
-| `transfer.xethub.hf.co`      | Xet storage download APIs (US)            |
-| `transfer.xethub-eu.hf.co`   | Xet storage download APIs (EU)            |
-| `us.aws.cdn.hf.co`           | CDN edge (US)                             |
-| `us.gcp.cdn.hf.co`           | CDN edge (US)                             |
-| `cdn-lfs-us-1.hf.co`         | LFS CDN (US)                              |
-| `cdn-lfs-eu-1.hf.co`         | LFS CDN (EU)                              |
+| Hostname                     | Purpose                                     |
+|------------------------------|---------------------------------------------|
+| `huggingface.co`             | Hub API, metadata, and download redirects   |
+| `cas-server.xethub.hf.co`    | Xet protocol APIs, download and upload (US) |
+| `cas-server.xethub-eu.hf.co` | Xet protocol APIs, download and upload (EU) |
+| `transfer.xethub.hf.co`      | Xet storage download APIs (US)              |
+| `transfer.xethub-eu.hf.co`   | Xet storage download APIs (EU)              |
+| `us.aws.cdn.hf.co`           | CDN edge (US)                               |
+| `us.gcp.cdn.hf.co`           | CDN edge (US)                               |
+| `cdn-lfs-us-1.hf.co`         | LFS CDN (US)                                |
+| `cdn-lfs-eu-1.hf.co`         | LFS CDN (EU)                                |
 
 > [!TIP]
 > Downloads follow HTTP redirects from `huggingface.co` to these hostnames, so
@@ -124,3 +124,13 @@ Allowlist the following hostnames (all over HTTPS / port 443):
 > These hostnames may change as our storage and CDN infrastructure evolves. Where your
 > security policy allows it, allowlist the `hf.co` and `huggingface.co` suffixes (all
 > subdomains) so your rules don't break when a specific endpoint changes.
+
+### Machine-readable list
+
+The hostnames above are also published as JSON at
+[`https://huggingface.co/.well-known/meta.json`](https://huggingface.co/.well-known/meta.json),
+so you can generate proxy or firewall rules from it rather than copying the table by hand.
+
+> [!WARNING]
+> The file changes as endpoints are added and removed. Fetch it when you build your rules
+> rather than pinning a copy.


### PR DESCRIPTION
Adds a pointer to /.well-known/meta.json in the proxy/firewall sections of models-downloading.md and datasets-downloading.md, for those generating allowlist rules instead of copying the table by hand.

Also fixes the Purpose column for the two cas-server hosts as they were labeled upload-only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Hub download/firewall guidance; no code, auth, or runtime behavior changes.
> 
> **Overview**
> Points proxy/firewall allowlist docs at the machine-readable hostname list at `https://huggingface.co/.well-known/meta.json`, so rules can be generated instead of copied from the table. Warns not to pin a static copy because endpoints change.
> 
> Also corrects the `cas-server` purpose text: those hosts are for Xet protocol APIs including **download and upload**, not upload-only. Same updates in `models-downloading.md` and `datasets-downloading.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd821aba0a1e2ea3b8cf822c2d3428992fd8b200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->