### PR TITLE
Document optional Inference Providers access for user trusted publishers

### DIFF
--- a/docs/hub/trusted-publishers.md
+++ b/docs/hub/trusted-publishers.md
@@ -97,7 +97,7 @@ Complete working examples:
 | Flavor | Configured on | What you get | Use it to… |
 | --- | --- | --- | --- |
 | **Repo publisher** | A repo's **Settings → Trusted Publishers** | A token with **write access to that one repo** | Publish a model, dataset, Space, kernel, or bucket from CI |
-| **User publisher** | Your account's [**Authentication settings → CI/CD Access**](https://huggingface.co/settings/authentication#ci-cd-access) | A read-only token with the `gated-repos` scope | Read **gated repos you have access to** and use your rate limits from CI |
+| **User publisher** | Your account's [**Authentication settings → CI/CD Access**](https://huggingface.co/settings/authentication#ci-cd-access) | A read-only token with the `gated-repos` scope, plus `inference-api` if you opt in | Read **gated repos you have access to**, use your rate limits, and optionally call Inference Providers from CI |
 
 Both tokens expire after 60 minutes. You need the **Write** role on a Hub repo to manage its trusted publishers.
 
@@ -134,6 +134,23 @@ The resulting token can read gated repos you have access to and uses your accoun
 > ```
 >
 > This works with both user publishers and repo publishers — the token is scoped to whatever `HF_OIDC_RESOURCE` points at.
+
+### Calling Inference Providers from CI
+
+By default, tokens from a user publisher only carry the `gated-repos` scope. When adding a user publisher under [**Authentication settings → CI/CD Access**](https://huggingface.co/settings/authentication#ci-cd-access), tick **Allow Inference Providers calls** to also grant the `inference-api` scope to the exchanged tokens. Publishers with that capability are marked with an **Inference** badge in the list.
+
+Inference usage is **billed to your account**, exactly as if you had made the requests yourself — so only enable it on publishers whose claims are pinned tightly (`repository` *and* `branch` and/or `workflow`).
+
+```yaml
+      - name: Run inference from CI
+        env:
+          HF_OIDC_RESOURCE: your-hf-username
+        run: |
+          export HF_TOKEN="$(hf auth token)"
+          python inference_script.py
+```
+
+The option is only available for user publishers — repo publishers mint repo-scoped tokens, which cannot call Inference Providers. Existing publishers keep the capabilities they were created with; to change them, delete the publisher and add it again.
 
 ## Supported CI providers
 
@@ -206,8 +223,8 @@ When the `hf` CLI performs the exchange, a failure surfaces the `error` code alo
 
 - **Tokens are short-lived.** 60 minutes from the moment of exchange — the clock only starts when you call the endpoint, not when the workflow starts. There's no refresh token; long jobs should re-exchange.
 - **Repo tokens are repo-scoped.** A token for `acme/awesome-model` cannot touch `acme/anything-else`. Pushes are attributed to a synthetic `[OIDC]` system user, with a reference to the originating issuer and subject.
-- **User tokens are read-only.** Only the `gated-repos` scope — no writes, no private repos, no account management.
-- - **Claims are matched exactly.** No regex, no prefix matching.
+- **User tokens are read-only.** By default only the `gated-repos` scope — no writes, no private repos, no account management. Adding the optional `inference-api` scope lets exchanged tokens call Inference Providers, billed to your account; it still grants no write or private-repo access.
+- **Claims are matched exactly.** No regex, no prefix matching.
 - **Audit logs.** Adding or removing a publisher is logged, and successful exchanges update last used time.
 
 ## See also

--- a/docs/hub/trusted-publishers.md
+++ b/docs/hub/trusted-publishers.md
@@ -92,18 +92,18 @@ Complete working examples:
 - GitHub Actions — [`github.com/coyotte508/publish-to-hf`](https://github.com/coyotte508/publish-to-hf)
 - GitLab CI — [`gitlab.com/coyotte508/publish-to-hf`](https://gitlab.com/coyotte508/publish-to-hf)
 
-## Two flavors: repo vs. user
+## Two flavors: repo publishers and CI/CD identities
 
 | Flavor | Configured on | What you get | Use it to… |
 | --- | --- | --- | --- |
-| **Repo publisher** | A repo's **Settings → Trusted Publishers** | A token with **write access to that one repo** | Publish a model, dataset, Space, kernel, or bucket from CI |
-| **User publisher** | Your account's [**Authentication settings → CI/CD Access**](https://huggingface.co/settings/authentication#ci-cd-access) | A read-only token with the `gated-repos` scope, plus `inference-api` if you opt in | Read **gated repos you have access to**, use your rate limits, and optionally call Inference Providers from CI |
+| **Repo trusted publisher** | A repo's **Settings → Trusted Publishers** | A token with **write access to that one repo** | Publish a model, dataset, Space, kernel, or bucket from CI |
+| **Account CI/CD identity** | Your account's [**Authentication settings → CI/CD Access**](https://huggingface.co/settings/authentication#ci-cd-access) | A read-only token with the `gated-repos` scope, plus `inference-api` if you opt in | Read **gated repos you have access to**, use your rate limits, and optionally call Inference Providers from CI |
 
 Both tokens expire after 60 minutes. You need the **Write** role on a Hub repo to manage its trusted publishers.
 
 ### Accessing gated repos from CI
 
-If you only need to *read* gated repos (e.g. download a model from a job), configure a publisher on your account under [**Authentication settings → CI/CD Access**](https://huggingface.co/settings/authentication#ci-cd-access) instead of on a specific repo, then use your **username** as the resource.
+If you only need to *read* gated repos (e.g. download a model from a job), add a CI/CD identity on your account under [**Authentication settings → CI/CD Access**](https://huggingface.co/settings/authentication#ci-cd-access) instead of on a specific repo, then use your **username** as the resource.
 
 On **GitHub Actions**, the `hf` CLI does the exchange for you, just set `HF_OIDC_RESOURCE`:
 
@@ -133,13 +133,13 @@ The resulting token can read gated repos you have access to and uses your accoun
 >         run: echo "HF_TOKEN=$(hf auth token)" >> "$GITHUB_ENV"
 > ```
 >
-> This works with both user publishers and repo publishers — the token is scoped to whatever `HF_OIDC_RESOURCE` points at.
+> This works with both CI/CD identities and repo publishers — the token is scoped to whatever `HF_OIDC_RESOURCE` points at.
 
 ### Calling Inference Providers from CI
 
-By default, tokens from a user publisher only carry the `gated-repos` scope. When adding a user publisher under [**Authentication settings → CI/CD Access**](https://huggingface.co/settings/authentication#ci-cd-access), tick **Allow Inference Providers calls** to also grant the `inference-api` scope to the exchanged tokens. Publishers with that capability are marked with an **Inference** badge in the list.
+Tokens from a CI/CD identity are read-only by default. To let them also call Inference Providers, tick **Allow Inference Providers calls** when adding the identity — exchanged tokens then carry the `inference-api` scope in addition to `gated-repos`, and the entry shows an **Inference** badge in the list.
 
-Inference usage is **billed to your account**, exactly as if you had made the requests yourself — so only enable it on publishers whose claims are pinned tightly (`repository` *and* `branch` and/or `workflow`).
+Inference usage is **billed to your account**, exactly as if you had made the requests yourself — so pin the claims tightly (`repository` *and* `branch` and/or `workflow`) before enabling it.
 
 ```yaml
       - name: Run inference from CI
@@ -150,7 +150,7 @@ Inference usage is **billed to your account**, exactly as if you had made the re
           python inference_script.py
 ```
 
-The option is only available for user publishers — repo publishers mint repo-scoped tokens, which cannot call Inference Providers. Existing publishers keep the capabilities they were created with; to change them, delete the publisher and add it again.
+Repo publishers aren't eligible — their tokens are repo-scoped and can't call Inference Providers. The capability is fixed at creation; to change it, delete the identity and add it again.
 
 ## Supported CI providers
 
@@ -223,7 +223,7 @@ When the `hf` CLI performs the exchange, a failure surfaces the `error` code alo
 
 - **Tokens are short-lived.** 60 minutes from the moment of exchange — the clock only starts when you call the endpoint, not when the workflow starts. There's no refresh token; long jobs should re-exchange.
 - **Repo tokens are repo-scoped.** A token for `acme/awesome-model` cannot touch `acme/anything-else`. Pushes are attributed to a synthetic `[OIDC]` system user, with a reference to the originating issuer and subject.
-- **User tokens are read-only.** By default only the `gated-repos` scope — no writes, no private repos, no account management. Adding the optional `inference-api` scope lets exchanged tokens call Inference Providers, billed to your account; it still grants no write or private-repo access.
+- **User tokens are read-only.** `gated-repos` scope by default — no writes, no private repos, no account management. The optional `inference-api` scope adds Inference Providers calls (billed to your account), but still no write or private-repo access.
 - **Claims are matched exactly.** No regex, no prefix matching.
 - **Audit logs.** Adding or removing a publisher is logged, and successful exchanges update last used time.
 


### PR DESCRIPTION
User-level trusted publishers can now opt in to grant the `inference-api` scope to exchanged tokens, letting CI call Inference Providers (billed to the account) in addition to reading gated repos.

- Note the optional scope in the repo vs. user flavors table
- Add a "Calling Inference Providers from CI" section
- Clarify the user-token bullet in the security model
- Fix a stray list marker in the security model

https://moon-ci-docs.huggingface.co/docs/hub/pr_2729/en/trusted-publishers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to trusted-publishers.md; no runtime or security logic modified.
> 
> **Overview**
> Updates **Trusted Publishers** docs to match new product naming (**repo trusted publishers** vs **account CI/CD identities**) and to document optional **Inference Providers** access for account-level OIDC exchanges.
> 
> The flavors table and gated-repo guidance now use **CI/CD identity** wording and note that exchanged tokens can include **`inference-api`** when you opt in at creation. A new **Calling Inference Providers from CI** section explains the **Allow Inference Providers calls** setting, account billing, a GitHub Actions example using `hf auth token`, and that **repo publishers** cannot use this capability (fixed at creation; delete and re-add to change).
> 
> The security model clarifies that user/CI tokens stay read-only: **`gated-repos` by default**, with optional **`inference-api`** for Inference Providers only, and fixes a stray list marker on the claims bullet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f52dae25a3447e3aa55e2980dc1565fed0cd47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->