### PR TITLE
Buckets: document changing visibility after creation

### DIFF
--- a/docs/hub/storage-buckets.md
+++ b/docs/hub/storage-buckets.md
@@ -82,6 +82,25 @@ create_bucket("my-bucket", private=True)
 create_bucket("my-org/shared-bucket")
 ```
 
+### Changing visibility
+
+You can change a bucket's visibility after creation:
+
+```bash
+# Make a bucket private
+hf buckets settings username/my-bucket --private
+
+# Make it public again
+hf buckets settings username/my-bucket --public
+```
+
+```python
+from huggingface_hub import update_bucket_settings
+
+update_bucket_settings("username/my-bucket", private=True)
+update_bucket_settings("username/my-bucket", private=False)
+```
+
 For the full Python API reference including deleting, moving, and listing buckets, see the [`huggingface_hub` Buckets guide](https://huggingface.co/docs/huggingface_hub/guides/buckets).
 
 ## Browsing Buckets on the Hub


### PR DESCRIPTION
`huggingface_hub` v1.29.0 added `hf buckets settings --private|--public` and `update_bucket_settings()` (huggingface/huggingface_hub#4715). `storage-buckets.md` only covered visibility at creation — this adds a short "Changing visibility" section (CLI + Python), mirroring the [hh guide section](https://huggingface.co/docs/huggingface_hub/main/en/guides/buckets#change-bucket-visibility).

Commands verified on v1.29.0.

cc @hanouticelina

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or security behavior changes in this repository.
> 
> **Overview**
> Adds a **Changing visibility** subsection under bucket creation in `storage-buckets.md`, covering how to toggle public/private **after** a bucket exists (previously only creation-time visibility was documented).
> 
> The new content documents `hf buckets settings <owner/bucket> --private|--public` and `update_bucket_settings()` with `private=True/False`, aligned with `huggingface_hub` v1.29.0 and the hub library buckets guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c10e4a98e2312f99b6b10eefee35d489036e1e6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->