### PR TITLE
Jobs: document auto-generated names and fix the labels example

### DIFF
--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -383,22 +383,24 @@ Note that you can pass a token with the right permission manually:
 Add one or more labels to a Job to add some metadata with `-l` or `--label`.
 You can use such metadata later to filter Jobs on the website or in the CLI.
 
-Add labels with `--label my-label` or key-value labels with `--label key=value`.
+Add labels with `--label my-label` or key-value labels with `--label key=value`. Keys and values can contain letters, digits, `-` and `_`.
 For example:
 
 ```bash
-hf jobs uv run --label fine-tuning --label model=Qwen3-0.6B --label dataset=Capybara ...
+hf jobs uv run --label fine-tuning --label model=Qwen3-06B --label dataset=Capybara ...
 ```
 
 Note that using the same `key` multiple times causes the last `key=value` to overwrite and discard any previous label with `key`.
 
 ### Name a Job
 
-Give a Job a name to make it easier to find and identify in the UI. The name is stored as the `name` label. Names are optional and do not have to be unique. In the UI Jobs will be grouped by name.
+Give a Job a name to make it easier to find and identify in the UI. The name is stored as the `name` label and does not have to be unique. In the UI Jobs will be grouped by name.
 
 ```bash
 hf jobs run --name daily-report python:3.12 python report.py
 ```
+
+If you don't pass `--name`, the Job is named after its Docker image or script plus a short hash of the command, so reruns of the same command share a name while different commands get different names (e.g. `python-3-12-6b9d662c` for a Job running on `python:3.12`).
 
 ### Update labels
 


### PR DESCRIPTION
Jobs get an automatic name since huggingface_hub v1.25 (huggingface/huggingface_hub#4566): image or script name plus a short hash of the command, so reruns of the same command group together. The "Name a Job" section still said names were optional — updated.

Also fixes the labels example: `model=Qwen3-0.6B` is rejected by the server (label values allow only alphanumerics, `-` and `_`), so it now uses `Qwen3-06B` and states the allowed characters.

Verified on v1.29.0.

cc @Wauplin @hanouticelina

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Jobs labels and naming; no runtime or API behavior is modified in this PR.
> 
> **Overview**
> Updates **Jobs configuration** docs so label behavior and naming match the product (since `huggingface_hub` v1.25).
> 
> The **Labels** section now states that label keys and values may only use letters, digits, `-`, and `_`, and the example switches `model=Qwen3-0.6B` to `model=Qwen3-06B` so it would pass server validation.
> 
> The **Name a Job** section is tightened (names are still non-unique and stored as the `name` label) and adds that omitting `--name` yields an auto-generated name from the Docker image or script plus a short command hash, so identical commands group in the UI (e.g. `python-3-12-6b9d662c`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4087ada141add242e15abbbe81e5b7e2780387b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->