### PR TITLE
Document Network Security exemption for service account tokens

### DIFF
--- a/docs/hub/enterprise-network-security.md
+++ b/docs/hub/enterprise-network-security.md
@@ -41,7 +41,7 @@ For more information about rate limits, see the [Hub Rate limits](./rate-limits)
 This option restricts access to your organization's resources to only those coming from your defined IP ranges. No one can access your organization resources outside your IP ranges. The rules also apply to access tokens. When enabled, this option unlocks additional nested security settings below.
 
 > [!TIP]
-> For automated workflows that run outside your corporate network, you can exempt an individual [service account](./enterprise-service-accounts#network-security-exemption) token from these restrictions and from the Content Access Policy.
+> For automated workflows that run outside your corporate network, you can exempt an individual [service account token](./enterprise-service-accounts#network-security-exemption) from these restrictions and from the Content Access Policy.
 
 
 ### Require login for users in your IP ranges

--- a/docs/hub/enterprise-network-security.md
+++ b/docs/hub/enterprise-network-security.md
@@ -40,6 +40,9 @@ For more information about rate limits, see the [Hub Rate limits](./rate-limits)
 
 This option restricts access to your organization's resources to only those coming from your defined IP ranges. No one can access your organization resources outside your IP ranges. The rules also apply to access tokens. When enabled, this option unlocks additional nested security settings below.
 
+> [!TIP]
+> For automated workflows that run outside your corporate network, you can exempt an individual [service account](./enterprise-service-accounts#network-security-exemption) token from these restrictions and from the Content Access Policy.
+
 
 ### Require login for users in your IP ranges
 

--- a/docs/hub/enterprise-service-accounts.md
+++ b/docs/hub/enterprise-service-accounts.md
@@ -66,7 +66,7 @@ When enabled:
 - The token is listed with a **No IP restrictions** badge on the service account's page.
 - Rotating the token preserves the exemption.
 
-Enabling the exemption, and rotating a token that is already exempt, requires permission to manage the organization's Network Security settings.
+Only organization admins can enable the exemption or rotate a token that is already exempt. If you automate this through the API, the token also needs the `org.networkSecurity.write` permission.
 
 Because an exempt token is no longer protected by your network perimeter, the token itself becomes the only credential guarding the resources it can reach. We recommend scoping it to the smallest possible set of repositories, granting read-only permissions where that is sufficient, and rotating it regularly.
 

--- a/docs/hub/enterprise-service-accounts.md
+++ b/docs/hub/enterprise-service-accounts.md
@@ -49,6 +49,27 @@ From the service account's page, administrators can:
 > [!WARNING]
 > An access token is only displayed once, at the time it is created or rotated. Store it securely — it cannot be retrieved later. If you lose it, rotate the token to generate a new value.
 
+### Network Security exemption
+
+> [!WARNING]
+> This option is part of the <a href="https://huggingface.co/contact/sales?from=enterprise" target="_blank">Enterprise Plus</a> plan.
+
+If your organization uses [Network Security](./enterprise-network-security) settings, service account tokens are subject to them like any other credential: they only work from your organization's IP ranges, and the Content Access Policy applies to what they can reach.
+
+Some automated workflows run outside your corporate network — for example, a CI job hosted by a cloud provider. For those cases, you can exempt an individual token from your organization's Network Security enforcement with the **Bypass IP restrictions and the Content Access Policy** option in the token form.
+
+When enabled:
+
+- The token works from any IP address, even when **Restrict organization access to your IP ranges only** is on.
+- The token can reach content that your organization's Content Access Policy would otherwise block.
+- The exemption only applies to your own organization's Network Security settings. It never bypasses another organization's policy.
+- The token is listed with a **No IP restrictions** badge on the service account's page.
+- Rotating the token preserves the exemption.
+
+Enabling the exemption requires permission to manage the organization's Network Security settings, which is separate from the permission to manage service accounts. This means a member who manages service account tokens cannot grant an exemption on their own. The same permission is required to rotate a token that is already exempt.
+
+Because an exempt token is no longer protected by your network perimeter, the token itself becomes the only credential guarding the resources it can reach. We recommend scoping it to the smallest possible set of repositories, granting read-only permissions where that is sufficient, and rotating it regularly.
+
 ## Billing
 
 Service accounts are not counted as billable members of your organization, so creating them does not consume a paid seat in your plan.

--- a/docs/hub/enterprise-service-accounts.md
+++ b/docs/hub/enterprise-service-accounts.md
@@ -66,7 +66,7 @@ When enabled:
 - The token is listed with a **No IP restrictions** badge on the service account's page.
 - Rotating the token preserves the exemption.
 
-Only organization admins can enable the exemption or rotate a token that is already exempt. If you automate this through the API, the token also needs the `org.networkSecurity.write` permission.
+Only organization admins can enable the exemption or rotate a token that is already exempt.
 
 Because an exempt token is no longer protected by your network perimeter, the token itself becomes the only credential guarding the resources it can reach. We recommend scoping it to the smallest possible set of repositories, granting read-only permissions where that is sufficient, and rotating it regularly.
 

--- a/docs/hub/enterprise-service-accounts.md
+++ b/docs/hub/enterprise-service-accounts.md
@@ -66,7 +66,7 @@ When enabled:
 - The token is listed with a **No IP restrictions** badge on the service account's page.
 - Rotating the token preserves the exemption.
 
-Enabling the exemption requires permission to manage the organization's Network Security settings, which is separate from the permission to manage service accounts. This means a member who manages service account tokens cannot grant an exemption on their own. The same permission is required to rotate a token that is already exempt.
+Enabling the exemption, and rotating a token that is already exempt, requires permission to manage the organization's Network Security settings.
 
 Because an exempt token is no longer protected by your network perimeter, the token itself becomes the only credential guarding the resources it can reach. We recommend scoping it to the smallest possible set of repositories, granting read-only permissions where that is sufficient, and rotating it regularly.
 


### PR DESCRIPTION
Documents the **Bypass IP restrictions and the Content Access Policy** option for Enterprise Plus service account tokens.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or security behavior changes in this PR.
> 
> **Overview**
> Adds Enterprise Plus documentation for **Bypass IP restrictions and the Content Access Policy** on service account tokens, aimed at CI and other automation outside corporate IP ranges.
> 
> The new **Network Security exemption** section in `enterprise-service-accounts.md` explains default token behavior under Network Security, what the bypass option does (any IP, CAP bypass, org-scoped only, **No IP restrictions** badge, exemption survives rotation), admin-only controls, and hardening guidance.
> 
> A cross-linked tip on `enterprise-network-security.md` under IP-range restriction points readers to that exemption section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58ff4bc9942e26fc20aafdf1f836c27b82eb81ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->