### PR TITLE
docs: add Scalattice inference provider

### DIFF
--- a/docs/inference-providers/_toctree.yml
+++ b/docs/inference-providers/_toctree.yml
@@ -134,6 +134,8 @@
     title: Public AI
   - local: providers/replicate
     title: Replicate
+  - local: providers/scalattice
+    title: Scalattice
   - local: providers/scaleway
     title: Scaleway
   - local: providers/together

--- a/docs/inference-providers/providers/scalattice.md
+++ b/docs/inference-providers/providers/scalattice.md
@@ -1,0 +1,42 @@
+<!---
+WARNING
+
+This markdown file has been generated from a script. Please do not edit it directly.
+
+### Template
+
+If you want to update the content related to scalattice's description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/scalattice.handlebars`.
+
+### Logos
+
+If you want to update scalattice's logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `scalattice-light.png` and `scalattice-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
+
+For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.
+--->
+
+# Scalattice
+
+> [!TIP]
+> All supported Scalattice models can be found [here](https://huggingface.co/models?inference_provider=scalattice&sort=trending)
+
+Scalattice is an OpenAI-compatible inference marketplace. Send chat completions with a catalog model ID and an `slt_` key; the network places the work and bills prepaid credits per token.
+
+For latest pricing, visit the [pricing page](https://scalattice.com/pricing/).
+
+## Resources
+ - **Website**: https://scalattice.com/
+ - **Documentation**: https://scalattice.cloud/docs/developers
+ - **Cloud console**: https://scalattice.cloud/developers
+ - **CLI**: https://scalattice.com/cli/
+
+## Supported tasks
+
+
+### Chat Completion (LLM)
+
+Find out more about Chat Completion (LLM) [here](../tasks/chat-completion).
+
+Scalattice serves an OpenAI-compatible `/v1/chat/completions` API at `https://api.scalattice.cloud/v1`. Catalog IDs match `GET https://api.scalattice.cloud/v1/models` (for example `qwen-3-14b`).

--- a/scripts/inference-providers/scripts/generate.ts
+++ b/scripts/inference-providers/scripts/generate.ts
@@ -48,6 +48,7 @@ const PROVIDERS_URLS: Record<string, string> = {
   ovhcloud: "https://www.ovhcloud.com/",
   publicai: "https://publicai.co/",
   replicate: "https://replicate.com/",
+  scalattice: "https://scalattice.com/",
   scaleway: "https://www.scaleway.com",
   together: "https://together.xyz/",
   wavespeed: "https://wavespeed.ai/",

--- a/scripts/inference-providers/templates/providers/scalattice.handlebars
+++ b/scripts/inference-providers/templates/providers/scalattice.handlebars
@@ -1,0 +1,20 @@
+# Scalattice
+
+> [!TIP]
+> All supported Scalattice models can be found [here](https://huggingface.co/models?inference_provider=scalattice&sort=trending)
+
+{{{logoSection}}}
+
+{{{followUsSection}}}
+
+Scalattice is an OpenAI-compatible inference marketplace. Send chat completions with a catalog model ID and an `slt_` key; the network places the work and bills prepaid credits per token.
+
+For latest pricing, visit the [pricing page](https://scalattice.com/pricing/).
+
+## Resources
+ - **Website**: https://scalattice.com/
+ - **Documentation**: https://scalattice.cloud/docs/developers
+ - **Cloud console**: https://scalattice.cloud/developers
+ - **CLI**: https://scalattice.com/cli/
+
+{{{tasksSection}}}


### PR DESCRIPTION
## Summary
Adds Scalattice to Inference Providers docs.

- Handlebars template under `scripts/inference-providers/templates/providers/`
- Provider page and `_toctree.yml` entry
- `PROVIDERS_URLS` entry in `generate.ts`

Website: https://scalattice.com
Docs: https://scalattice.cloud/docs/developers

Logos (light/dark PNG) can follow in huggingface/documentation-images as `scalattice-light.png` and `scalattice-dark.png`.

cc @Wauplin @celinah @hanouticelina

## Test plan
- [ ] Page is listed under Providers
- [ ] Generate script picks up the new URL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doc-generation config only; no runtime or security-sensitive code paths.
> 
> **Overview**
> **Adds Scalattice** to the Inference Providers documentation, following the same provider onboarding pattern as existing entries.
> 
> A new Handlebars template (`scalattice.handlebars`) describes Scalattice as an OpenAI-compatible inference marketplace (`slt_` API keys, prepaid credits, links to pricing and developer resources). The doc generator picks it up via a new `scalattice` entry in `PROVIDERS_URLS` in `generate.ts`, which also emits the checked-in `scalattice.md` page (including generated **Chat Completion** task details when Hub partner data is available). **Scalattice** is listed in the Providers section of `_toctree.yml` between Replicate and Scaleway.
> 
> Provider logos are documented as a follow-up in `huggingface/documentation-images` (`scalattice-light.png` / `scalattice-dark.png`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aae4ba044d542fdd681dbd2bcb36fd76799fd6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->