### PR TITLE
add: updated hf-vllm tag in available images

### DIFF
--- a/docs/sagemaker/source/dlcs/available.md
+++ b/docs/sagemaker/source/dlcs/available.md
@@ -38,7 +38,7 @@ In case you want to serve text generation models with vLLM, there are specific D
 
 | vLLM version | Container URI                                                                                                                    | Accelerator |
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| 0.25.1         | 763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-vllm:0.25.1-transformers5.10-gpu-py312-cu130-ubuntu22.04 | GPU         |
+| 0.28.0         | 763104351884.dkr.ecr.us-east-1.amazonaws.com/huggingface-vllm:0.28.0-transformers5.15.0-gpu-py312-cu130-ubuntu24.04 | GPU         |
 | 0.11.0         | 763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-vllm-inference-neuronx:0.11.0-optimum0.4.5-neuronx-py310-sdk2.26.1-ubuntu22.04 | Neuron         |
 
 ### vLLM Omni


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to a container URI table; no runtime or SDK behavior is modified.
> 
> **Overview**
> Updates the **vLLM** GPU row in `docs/sagemaker/source/dlcs/available.md` so the listed Deep Learning Container matches the current Hugging Face vLLM release.
> 
> The documented image moves from **vLLM 0.25.1** (`transformers5.10`, `ubuntu22.04`, `us-west-2`) to **vLLM 0.28.0** with URI `763104351884.dkr.ecr.us-east-1.amazonaws.com/huggingface-vllm:0.28.0-transformers5.15.0-gpu-py312-cu130-ubuntu24.04`. Neuron and other inference tables are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ee96b7e1d21ce4eb2675970443915e0fa28ed87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->