### PR TITLE
Update Resource Groups docs for the redesigned UI

### DIFF
--- a/docs/hub/enterprise-resource-groups.md
+++ b/docs/hub/enterprise-resource-groups.md
@@ -9,12 +9,12 @@ Resource Groups allow organizations to enforce fine-grained access control to th
   <img
     class="block dark:hidden m-0!"
     src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/resource-groups.png"
-    alt="screenshot of Hugging Face Resource Groups feature"
+    alt="The Overview tab of a Resource Group in light mode: group name, the Overview/Resources/Users/Settings tabs, summary chips and the Resources and Users preview cards"
   />
   <img
     class="hidden dark:block m-0!"
     src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/dark-resource-groups.png"
-    alt="screenshot of Hugging Face Resource Groups feature"
+    alt="The Overview tab of a Resource Group in dark mode: group name, the Overview/Resources/Users/Settings tabs, summary chips and the Resources and Users preview cards"
   />
 </div>
 

--- a/docs/hub/enterprise-resource-groups.md
+++ b/docs/hub/enterprise-resource-groups.md
@@ -9,12 +9,12 @@ Resource Groups allow organizations to enforce fine-grained access control to th
   <img
     class="block dark:hidden m-0!"
     src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/resource-groups.png"
-    alt="The Overview tab of a Resource Group in light mode: group name, the Overview/Resources/Users/Settings tabs, summary chips and the Resources and Users preview cards"
+    alt="The Overview tab of a resource group"
   />
   <img
     class="hidden dark:block m-0!"
     src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/enterprise/dark-resource-groups.png"
-    alt="The Overview tab of a Resource Group in dark mode: group name, the Overview/Resources/Users/Settings tabs, summary chips and the Resources and Users preview cards"
+    alt="The Overview tab of a resource group"
   />
 </div>
 

--- a/docs/hub/jobs-pricing.md
+++ b/docs/hub/jobs-pricing.md
@@ -92,12 +92,12 @@ In this case the Job runs under the organization account, and you can see it in 
 If your organization has [Resource Groups](./security-resource-groups) set up, you can attribute job costs to a specific resource group. To do so:
 
 1. You must be a member of the resource group.
-2. Pass the resource group's ID as the `namespace` when running the job.
+2. Pass the resource group's ID as the `resourceGroupId` field when running the job. The `namespace` stays your organization's name, it identifies who is billed.
 
 You can find the resource group's ID in your organization's Resource Groups settings page.
 
 ```bash
-hf jobs run --namespace <resource-group-id> ...
+hf jobs run --namespace <org-name> --resource-group-id <resource-group-id> ...
 ```
 
 In Python:
@@ -107,7 +107,8 @@ In Python:
 >>> run_job(
 ...     image="python:3.12",
 ...     command=["python", "-c", "print('Hello!')"],
-...     namespace="<resource-group-id>",
+...     namespace="<org-name>",
+...     resource_group_id="<resource-group-id>",
 ... )
 ```
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -32,8 +32,8 @@ Resource Groups also affect the visibility of private repositories inside the or
 Head to your Organization's settings, then navigate to the "Resource Groups" entry in the left menu. The page is split in two tabs: **Resource Groups**, where the groups themselves are listed and managed, and **Access settings**, where org admins configure who can create Resource Groups and which members can use specific organization features.
 
 <div class="flex justify-center">
-    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-page.png" alt="The Resource Groups settings page in light mode: the Resource Groups tab is active, with the New Resource Group card and the list of groups in the left sidebar, and the explainer text with role chips on the right"/>
-    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-page-dark.png" alt="The Resource Groups settings page in dark mode: the Resource Groups tab is active, with the New Resource Group card and the list of groups in the left sidebar, and the explainer text with role chips on the right"/>
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-page.png" alt="The Resource Groups settings page"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-page-dark.png" alt="The Resource Groups settings page"/>
 </div>
 
 Organization admins can create and manage Resource Groups from that page. Depending on the organization's settings, members with lower roles may also be allowed to create Resource Groups (see [Who can create Resource Groups](#who-can-create-resource-groups) below).
@@ -46,15 +46,15 @@ After creating a Resource Group and giving it a meaningful name, you land on the
 - **Settings**: the group's auto-include and spend limits configuration.
 
 <div class="flex justify-center">
-    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-overview.png" alt="The Overview tab of a Resource Group in light mode: the group name and description, the four tabs (Overview active, Resources, Users, Settings), the summary chips (repository type counts, member role counts, auto-include state, spend limit) and the Resources and Users preview cards with View all links"/>
-    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-overview-dark.png" alt="The Overview tab of a Resource Group in dark mode: the group name and description, the four tabs (Overview active, Resources, Users, Settings), the summary chips (repository type counts, member role counts, auto-include state, spend limit) and the Resources and Users preview cards with View all links"/>
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-overview.png" alt="The Overview tab of a resource group"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-overview-dark.png" alt="The Overview tab of a resource group"/>
 </div>
 
 You can start adding repositories and users to the group from the **Resources** and **Users** tabs.
 
 <div class="flex justify-center">
-    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-add-resources-modal.png" alt="The Add resources modal in light mode: the repository quick search and a staged repository chip ready to be added"/>
-    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-add-resources-modal-dark.png" alt="The Add resources modal in dark mode: the repository quick search and a staged repository chip ready to be added"/>
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-add-resources-modal.png" alt="The Add resources modal"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-add-resources-modal-dark.png" alt="The Add resources modal"/>
 </div>
 
 > [!TIP]
@@ -75,8 +75,8 @@ This is useful for Resource Groups that should be accessible to your entire orga
 - **Via the API**: See [Configure auto-join via API](./programmatic-user-access-control#configure-auto-join-via-api).
 
 <div class="flex justify-center">
-    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-auto-include.png" alt="The Auto-include org members section of a Resource Group Settings tab in light mode: the Automatically include all org members checkbox enabled, the Include no_access members option, the default role selector set to read, and the Save button"/>
-    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-auto-include-dark.png" alt="The Auto-include org members section of a Resource Group Settings tab in dark mode: the Automatically include all org members checkbox enabled, the Include no_access members option, the default role selector set to read, and the Save button"/>
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-auto-include.png" alt="The Auto-include org members settings"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-auto-include-dark.png" alt="The Auto-include org members settings"/>
 </div>
 
 When auto-join is enabled on an existing Resource Group, current org members matching the selected scope are **immediately added** to the group at the configured role (backfill).
@@ -119,8 +119,8 @@ When a non-admin member creates a Resource Group through the UI, they are automa
 Org admins can also control who's allowed to use a given organization feature, separately from repository access. The setting lives on the **Access settings** tab of the Resource Groups settings page.
 
 <div class="flex justify-center">
-    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/feature-access.png" alt="The Granular feature access table in light mode: rounded card with Feature and Who has access columns, one row per feature (Blog, Inference Providers, Inference Endpoints, Jobs, Collections) with an Everyone tag and an edit button at the end of each row"/>
-    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/dark-feature-access.png" alt="The Granular feature access table in dark mode: rounded card with Feature and Who has access columns, one row per feature (Blog, Inference Providers, Inference Endpoints, Jobs, Collections) with an Everyone tag and an edit button at the end of each row"/>
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/feature-access.png" alt="The Granular feature access table"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/dark-feature-access.png" alt="The Granular feature access table"/>
 </div>
 
 The following features can be restricted:
@@ -164,8 +164,8 @@ You can use the <a href="https://huggingface.co/spaces/huggingface/openapi#tag/o
 On top of tracking costs, you can cap them. Organization admins and resource group admins can set monthly spending limits in the group's **Settings** tab, under **Spend limits**.
 
 <div class="flex justify-center">
-    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-spend-limits.png" alt="The Spend limits section of a Resource Group's Settings tab in light mode: the Total (all products) input with a dollar prefix, the description text, the four per-product inputs (Inference Providers, Spaces, Jobs, Inference Endpoints) and the Save button"/>
-    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-spend-limits-dark.png" alt="The Spend limits section of a Resource Group's Settings tab in dark mode: the Total (all products) input with a dollar prefix, the description text, the four per-product inputs (Inference Providers, Spaces, Jobs, Inference Endpoints) and the Save button"/>
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-spend-limits.png" alt="The Spend limits settings"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-spend-limits-dark.png" alt="The Spend limits settings"/>
 </div>
 
 Two kinds of limits are available, both expressed in USD:

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -138,7 +138,9 @@ For each one, you can pick who has access:
 - **Org admins only**: only organization admins keep access.
 - **Specific resource groups**: only members of the selected Resource Groups depending on their role in the group.
 
-Organization admins always keep access to every feature, whichever option is selected. If a feature is restricted to specific resource groups, only members of those groups (and org admins) keep the feature's permission in the organization. For those members the permission applies org-wide, including on resources at the organization's top level, as long as their organization role grants it.
+Organization admins always keep access to every feature, whichever option is selected.
+
+Restricting a feature to specific resource groups controls **who** can use the feature, not **where**. Members of the selected groups can keep using the feature anywhere in the organization (for example, creating a collection that belongs to no resource group), while other members lose access to the feature entirely. The restriction never grants extra permissions: what a member can do is still determined by their organization role.
 
 Members without access can no longer use the feature in the organization's context, from the API as well as the UI. API requests return an authorization error. Nothing changes for them under their personal account or in another org.
 

--- a/docs/hub/security-resource-groups.md
+++ b/docs/hub/security-resource-groups.md
@@ -7,41 +7,54 @@ In your Hugging Face organization, you can use Resource Groups to control which 
 
 ## How does it work?
 
-Resource Groups allow organization administrators to group related repositories together, allowing different teams in your organization to work on independent sets of repositories.
+Resource Groups allow organization administrators to **group related repositories together**, allowing different teams in your organization to work on independent sets of repositories.
 
-A repository can belong to only one Resource Group.
+- **Resources**: the group's repositories and collections. Each resource can belong to **only one** Resource Group, and can be moved between groups by members with the appropriate permissions.
+- **Members**: organization members **need to be added** to a Resource Group to access its repositories. A member can belong to **several Resource Groups**.
 
-Organization collections can also be assigned to a Resource Group, following the same rules as repositories: a collection can belong to only one Resource Group, and can be moved between groups by members with the appropriate permissions.
+Members are assigned a **role** in each Resource Group that determines their permissions for the group's repositories. Four distinct roles exist for Resource Groups:
 
-Organizations members need to be added to the Resource Group to access its repositories. An Organization Member can belong to several Resource Groups.
+- `read`: Grants **read access** to repositories within the Resource Group.
+- `contributor`: Provides **write rights limited to the repositories created by the user** (i.e., users can create repos and then modify only those repos). Similar to the 'Write' role, but limited to repos created by the user.
+- `write`: Offers **write access to all repositories** in the Resource Group. Users can create, delete, or rename any repository in the Resource Group.
+- `admin`: In addition to write permissions on repositories, admin members can **administer the Resource Group**: add, remove, and alter the roles of other members. They can also manage already existing repositories in a Resource Group.
 
-Members are assigned a role in each Resource Group that determines their permissions for the group's repositories. Four distinct roles exist for Resource Groups:
+In addition, Organization admins can manage **all resource groups** inside the organization. This includes moving repositories in and out of any Resource Group.
 
-- `read`: Grants read access to repositories within the Resource Group.
-- `contributor`: Provides extra write rights to the subset of the Organization's repositories created by the user (i.e., users can create repos and then modify only those repos). Similar to the 'Write' role, but limited to repos created by the user.
-- `write`: Offers write access to all repositories in the Resource Group. Users can create, delete, or rename any repository in the Resource Group.
-- `admin`: In addition to write permissions on repositories, admin members can administer the Resource Group — add, remove, and alter the roles of other members. They can also manage already existing repositories in a Resource Group.
+Resource Groups also affect the visibility of private repositories inside the organization:
 
-In addition, Organization admins can manage all resource groups inside the organization. This includes moving repositories in and out of any Resource Group.
-
-Resource Groups also affect the visibility of private repositories inside the organization. A private repository that is part of a Resource Group will only be visible to members of that Resource Group. Public repositories, on the other hand, are visible to anyone, inside and outside the organization. The same visibility rules apply to private collections that belong to a Resource Group.
+- A **private** repository that is part of a Resource Group is only visible to **members of that Resource Group**.
+- **Public** repositories are visible to **anyone**, inside and outside the organization.
+- The same visibility rules apply to private **collections** that belong to a Resource Group.
 
 ## Getting started
 
-Head to your Organization's settings, then navigate to the "Resource Group" entry in the left menu. The page is split in two tabs: **Resource Groups**, where the groups themselves are listed and managed, and **Access settings**, where org admins configure who can create Resource Groups and which members can use specific organization features.
+Head to your Organization's settings, then navigate to the "Resource Groups" entry in the left menu. The page is split in two tabs: **Resource Groups**, where the groups themselves are listed and managed, and **Access settings**, where org admins configure who can create Resource Groups and which members can use specific organization features.
 
 <div class="flex justify-center">
-    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-page.png"/>
-    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-page-dark.png"/>
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-page.png" alt="The Resource Groups settings page in light mode: the Resource Groups tab is active, with the New Resource Group card and the list of groups in the left sidebar, and the explainer text with role chips on the right"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-page-dark.png" alt="The Resource Groups settings page in dark mode: the Resource Groups tab is active, with the New Resource Group card and the list of groups in the left sidebar, and the explainer text with role chips on the right"/>
 </div>
 
 Organization admins can create and manage Resource Groups from that page. Depending on the organization's settings, members with lower roles may also be allowed to create Resource Groups (see [Who can create Resource Groups](#who-can-create-resource-groups) below).
 
-After creating a Resource Group and giving it a meaningful name, you can start adding repositories and users to it.
+After creating a Resource Group and giving it a meaningful name, you land on the group's page. It is organized in four tabs:
+
+- **Overview**: a summary of the group (repository types, member roles, auto-include state and spend limit) along with a preview of its resources and users.
+- **Resources**: the full list of the group's repositories and collections, as well as the Jobs billed to the group, with search, sorting and pagination. This is where you add resources to the group.
+- **Users**: the group's members and their roles, with search and sorting. This is where you add users and manage their roles.
+- **Settings**: the group's auto-include and spend limits configuration.
 
 <div class="flex justify-center">
-    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-manage-empty-page.png"/>
-    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-manage-empty-page-dark.png"/>
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-overview.png" alt="The Overview tab of a Resource Group in light mode: the group name and description, the four tabs (Overview active, Resources, Users, Settings), the summary chips (repository type counts, member role counts, auto-include state, spend limit) and the Resources and Users preview cards with View all links"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-overview-dark.png" alt="The Overview tab of a Resource Group in dark mode: the group name and description, the four tabs (Overview active, Resources, Users, Settings), the summary chips (repository type counts, member role counts, auto-include state, spend limit) and the Resources and Users preview cards with View all links"/>
+</div>
+
+You can start adding repositories and users to the group from the **Resources** and **Users** tabs.
+
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-add-resources-modal.png" alt="The Add resources modal in light mode: the repository quick search and a staged repository chip ready to be added"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-add-resources-modal-dark.png" alt="The Add resources modal in dark mode: the repository quick search and a staged repository chip ready to be added"/>
 </div>
 
 > [!TIP]
@@ -49,22 +62,22 @@ After creating a Resource Group and giving it a meaningful name, you can start a
 
 Remember that a repository can be part of only one Resource Group. You'll be warned when trying to add a repository that already belongs to another Resource Group.
 
-<div class="flex justify-center">
-    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-manage-move-repo.png"/>
-    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-groups-manage-move-repo-dark.png"/>
-</div>
 
 ## Auto-join
 
-Auto-join automatically adds **org members** to a Resource Group at a specified role — both members who are already in the org when auto-join is enabled, and any new members who join in the future.
+Auto-join automatically adds **org members** to a Resource Group at a specified role: both members who are already in the org when auto-join is enabled, and any new members who join in the future.
 
 This is useful for Resource Groups that should be accessible to your entire organization without requiring manual membership management.
 
 ### Enabling auto-join
 
-**Via the UI**: Open the Resource Group's settings page and check the **Auto-include org members** option, then select the role to assign.
+- **Via the UI**: Open the Resource Group's **Settings** tab and check the **Automatically include all org members** option in the **Auto-include org members** section, then select the role to assign. The Users tab also links there, showing whether auto-include is on or off.
+- **Via the API**: See [Configure auto-join via API](./programmatic-user-access-control#configure-auto-join-via-api).
 
-**Via the API**: See [Configure auto-join via API](./programmatic-user-access-control#configure-auto-join-via-api).
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-auto-include.png" alt="The Auto-include org members section of a Resource Group Settings tab in light mode: the Automatically include all org members checkbox enabled, the Include no_access members option, the default role selector set to read, and the Save button"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-auto-include-dark.png" alt="The Auto-include org members section of a Resource Group Settings tab in dark mode: the Automatically include all org members checkbox enabled, the Include no_access members option, the default role selector set to read, and the Save button"/>
+</div>
 
 When auto-join is enabled on an existing Resource Group, current org members matching the selected scope are **immediately added** to the group at the configured role (backfill).
 
@@ -72,14 +85,14 @@ When auto-join is enabled on an existing Resource Group, current org members mat
 
 Auto-join can apply to:
 
-- **All org members**: Include every member, including members with the `no_access` organization role.
-- **Read+ members only**: Exclude members with the `no_access` organization role.
+- **All org members**: check **Include no_access members** to include every member, including members with the `no_access` organization role.
+- **Read+ members only** (default): leave **Include no_access members** unchecked to exclude members with the `no_access` organization role.
 
 Use **Read+ members only** when `no_access` members should keep access only to the specific Resource Groups where they are added manually or through another provisioning flow.
 
 ### Auto-join and SCIM
 
-Auto-join and SCIM management are **mutually exclusive** on the same Resource Group. Auto-join adds org members automatically; SCIM management means only the IdP controls membership. These two behaviors conflict, so:
+Auto-join and SCIM management are **mutually exclusive** on the same Resource Group. Auto-join adds org members automatically, while SCIM management means only the IdP controls membership. These two behaviors conflict, so:
 
 - You cannot enable auto-join on a Resource Group that is linked to a SCIM group.
 - You cannot link a SCIM group to a Resource Group that has auto-join enabled.
@@ -91,10 +104,10 @@ To switch a Resource Group from auto-join to SCIM-managed (or vice versa), disab
 By default, only organization admins can create new Resource Groups. Org admins can change this by setting the **minimum member role required to create Resource Groups** in the **Access settings** tab of the Resource Groups settings page.
 
 The available options are:
-- **Admins only** (default) — only org admins can create Resource Groups.
-- **Write** — members with Write or Admin role can create Resource Groups.
-- **Contributor** — members with Contributor, Write, or Admin role can create Resource Groups.
-- **Read+** — any org member can create Resource Groups.
+- **Admins only** (default): only org admins can create Resource Groups.
+- **Write+**: members with Write or Admin role can create Resource Groups.
+- **Contributor+**: members with Contributor, Write, or Admin role can create Resource Groups.
+- **Read+**: any org member can create Resource Groups, except members with the `no_access` organization role.
 
 When a non-admin member creates a Resource Group through the UI, they are automatically added as an **admin** of that newly created group. Through the API, this does not happen automatically, since API callers may be creating groups on behalf of others. Non-admin API callers must include at least one user with the admin role in the group's initial member list.
 
@@ -106,8 +119,8 @@ When a non-admin member creates a Resource Group through the UI, they are automa
 Org admins can also control who's allowed to use a given organization feature, separately from repository access. The setting lives on the **Access settings** tab of the Resource Groups settings page.
 
 <div class="flex justify-center">
-    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/feature-access.png"/>
-    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/dark-feature-access.png"/>
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/feature-access.png" alt="The Granular feature access table in light mode: rounded card with Feature and Who has access columns, one row per feature (Blog, Inference Providers, Inference Endpoints, Jobs, Collections) with an Everyone tag and an edit button at the end of each row"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/dark-feature-access.png" alt="The Granular feature access table in dark mode: rounded card with Feature and Who has access columns, one row per feature (Blog, Inference Providers, Inference Endpoints, Jobs, Collections) with an Everyone tag and an edit button at the end of each row"/>
 </div>
 
 The following features can be restricted:
@@ -125,9 +138,9 @@ For each one, you can pick who has access:
 - **Org admins only**: only organization admins keep access.
 - **Specific resource groups**: only members of the selected Resource Groups depending on their role in the group.
 
-Organization admins always keep access to every feature, whichever option is selected. If a feature is restricted to specific resource groups, associated resources must reside within those resource groups (only organization admins retain the ability to do so at the organization root level).
+Organization admins always keep access to every feature, whichever option is selected. If a feature is restricted to specific resource groups, only members of those groups (and org admins) keep the feature's permission in the organization. For those members the permission applies org-wide, including on resources at the organization's top level, as long as their organization role grants it.
 
-Members without access can no longer use the feature in the organization's context, from the API as well as the UI — API requests return an authorization error. Nothing changes for them under their personal account or in another org.
+Members without access can no longer use the feature in the organization's context, from the API as well as the UI. API requests return an authorization error. Nothing changes for them under their personal account or in another org.
 
 ## Cost attribution
 
@@ -137,7 +150,7 @@ Members without access can no longer use the feature in the organization's conte
 Resource Groups also serve as a cost attribution unit for compute services. When compute is billed to a resource group, costs are tracked separately per group, making it easier to understand spending across teams.
 
 - **Spaces**: cost is automatically attributed to the resource group the Space belongs to.
-- **Jobs**: pass the resource group's ID as the `namespace` when creating a job. See [Bill to a resource group](./jobs-pricing#bill-to-a-resource-group).
+- **Jobs**: pass the resource group's ID as the `resourceGroupId` field when creating a job. See [Bill to a resource group](./jobs-pricing#bill-to-a-resource-group).
 - **Inference Providers**: pass the resource group's ID via the `X-HF-Bill-To` header (or `bill_to` parameter in the SDK). See [Billing for Team and Enterprise organizations](/docs/inference-providers/pricing#billing-for-team-and-enterprise-organizations).
 - **Inference Endpoints**: cost is automatically attributed to the resource group the model repository belongs to. Endpoints instantiated directly from the built-in Inference Endpoints catalog aren't supported at this time.
 
@@ -148,7 +161,12 @@ You can use the <a href="https://huggingface.co/spaces/huggingface/openapi#tag/o
 > [!WARNING]
 > This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> plan and above.
 
-On top of tracking costs, you can cap them. Organization admins and resource group admins can set monthly spending limits on the group's page in the Resource Groups settings, from the **Spend limits** card.
+On top of tracking costs, you can cap them. Organization admins and resource group admins can set monthly spending limits in the group's **Settings** tab, under **Spend limits**.
+
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-spend-limits.png" alt="The Spend limits section of a Resource Group's Settings tab in light mode: the Total (all products) input with a dollar prefix, the description text, the four per-product inputs (Inference Providers, Spaces, Jobs, Inference Endpoints) and the Save button"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/org-resource-group-spend-limits-dark.png" alt="The Spend limits section of a Resource Group's Settings tab in dark mode: the Total (all products) input with a dollar prefix, the description text, the four per-product inputs (Inference Providers, Spaces, Jobs, Inference Endpoints) and the Save button"/>
+</div>
 
 Two kinds of limits are available, both expressed in USD:
 
@@ -157,7 +175,7 @@ Two kinds of limits are available, both expressed in USD:
 
 Leave a field empty for no limit. When a total limit and a per-product limit both apply, the stricter of the two wins.
 
-Limits apply to the spend attributed to the group for the current calendar month, so a group that hit its limit is unblocked at the beginning of the next month — or as soon as an admin raises the limit.
+Limits apply to the spend attributed to the group for the current calendar month, so a group that hit its limit is unblocked at the beginning of the next month, or as soon as an admin raises the limit.
 
 ### What happens when a limit is reached
 


### PR DESCRIPTION
<img width="985" height="721" alt="image" src="https://github.com/user-attachments/assets/89ad61fe-5cd9-4447-9b0d-21fae2d18022" />

The Resource Groups pages in org settings were redesigned recently, this updates the docs to match.

## Changes

- **Getting started** now describes the resource group page and its four tabs: Overview (summary chips and resource/user previews), Resources, Users, and Settings.
- **Auto-join** and **Spend limits** instructions now point at their new home in the group Settings tab, and the auto-join section gained a screenshot.
- **All screenshots retaken** for the new UI, in light and dark mode at 3x, using a demo org (no real data). The images are already uploaded to the documentation-images dataset under their existing names, so this PR only touches the markdown.
- **Accuracy fixes**, verified against the actual behavior:
  - "Read+" creation setting excludes members with the no_access org role, the previous wording said any org member.
  - Granular feature access is enforced as a membership-based permission gate org-wide, not as a requirement that resources live inside the allowed groups.
  - Jobs cost attribution uses the resourceGroupId field in the job payload, not the namespace.
- **Copy cleanup**: key terms bolded, nested bullets flattened, role names shown as code, creator role labels matched to the UI (Write+, Contributor+).

The enterprise-resource-groups page gets updated screenshot alt text.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact; accuracy fixes reduce misconfiguration risk for admins.
> 
> **Overview**
> Updates **Team & Enterprise** Resource Groups documentation to match the redesigned org settings UI—markdown only; screenshots were re-uploaded to the documentation-images dataset under new hub asset names.
> 
> **Getting started** now walks through the group page’s four tabs (**Overview**, **Resources**, **Users**, **Settings**), retargets screenshots (overview, add-resources modal), drops the old “move repo” image, and adds descriptive `alt` text across pages including `enterprise-resource-groups.md`.
> 
> **Auto-join** and **Spend limits** instructions point at the **Settings** tab (Auto-include org members, spend limits card) with new screenshots; auto-join scope is reframed around the **Include no_access members** checkbox.
> 
> **Behavioral corrections**: **Read+** creation excludes `no_access` org members; granular feature access is documented as a **who** gate org-wide, not a requirement that resources live in allowed groups; **Jobs** billing uses `resource_group_id` (plus org `namespace`), not namespace alone.
> 
> Copy edits: bold key terms, `code` role names, UI-aligned labels (**Write+**, **Contributor+**), and clearer Resources/Members bullets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0cca8597f99933753784bf318758374f01d33f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->