### PR TITLE
Fix resource-group Jobs billing instructions

### DIFF
--- a/docs/hub/jobs-pricing.md
+++ b/docs/hub/jobs-pricing.md
@@ -92,12 +92,12 @@ In this case the Job runs under the organization account, and you can see it in 
 If your organization has [Resource Groups](./security-resource-groups) set up, you can attribute job costs to a specific resource group. To do so:
 
 1. You must be a member of the resource group.
-2. Pass the resource group's ID as the `namespace` when running the job.
+2. Pass the organization that owns the resource group as the `namespace`, and the resource group's ID as `resource_group_id`. Both are required: a resource group is only taken into account for Jobs billed to its organization.
 
 You can find the resource group's ID in your organization's Resource Groups settings page.
 
 ```bash
-hf jobs run --namespace <resource-group-id> ...
+hf jobs run --namespace my-org-name --resource-group-id <resource-group-id> ...
 ```
 
 In Python:
@@ -107,7 +107,8 @@ In Python:
 >>> run_job(
 ...     image="python:3.12",
 ...     command=["python", "-c", "print('Hello!')"],
-...     namespace="<resource-group-id>",
+...     namespace="my-org-name",
+...     resource_group_id="<resource-group-id>",
 ... )
 ```
 


### PR DESCRIPTION
`jobs-pricing.md` tells you to pass a resource group's ID as the `namespace`. That doesn't work — the Jobs API resolves the namespace to a user or an organization, so an ID lands as a 404 (`Namespace <id> not found`).

The resource group is a separate argument, and it only takes effect when the Job is billed to the organization that owns it (access is checked against the resource-group role, and `spendLimits.jobs` is enforced, only for org-owned Jobs) — so both need to be passed:

```bash
hf jobs run --namespace my-org-name --resource-group-id <resource-group-id> ...
```

`huggingface_hub` has had both parameters for a while: `HfApi.run_job(namespace=..., resource_group_id=...)`, and `--resource-group-id` on `hf jobs run`, `hf jobs uv run`, and the `scheduled` variants.

Docs-only change, nothing else in the section touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to Jobs billing instructions; no runtime or API behavior is modified.
> 
> **Overview**
> Corrects **Bill to a resource group** in `jobs-pricing.md` so it matches how Jobs billing actually works.
> 
> Previously the doc said to pass the resource group ID as `namespace`, which fails because `namespace` must be a user or org name. The update requires **both** the owning org as `namespace` and the group ID via `resource_group_id` (CLI: `--resource-group-id`), with a short note that resource groups only apply for org-billed Jobs. Bash and `run_job()` examples are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4075af50a0e3da5db325cb93f70c638fdf69c9d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->