### PR TITLE
Clarify Jobs argument forwarding

### DIFF
--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -26,7 +26,7 @@ The `hf jobs uv run` command accepts an UV argument like `--with` and `--python`
 >>> hf jobs uv run --python 3.12 train.py
 ```
 
-Arguments following the command (or script) are not interpreted as arguments to uv. All options to uv must be provided before the command, e.g., uv run --verbose foo. A `--` can be used to separate the command from jobs/uv options for clarity, e.g.
+Put Jobs options before the script or command. Use `--` to forward arguments that Jobs also recognises:
 
 ```bash
 >>> hf jobs uv run --with trl-jobs -- trl-jobs sft --model_name Qwen/Qwen3-0.6B --dataset_name trl-lib/Capybara

--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -6,6 +6,17 @@ You need to be authenticated with `hf auth login` to run Jobs, and use a token w
 
 Alternatively, pass a Hugging Face token manually with `--token` in the CLI, or the `token` argument in Python.
 
+## Passing arguments
+
+Use `--` to separate Jobs options from arguments passed to your command or script.
+Jobs does not interpret options after `--`, so options such as `--help` or `--timeout`
+reach your command or script instead. This applies to both UV and Docker Jobs.
+
+```text
+hf jobs uv run --flavor t4-small -- script.py --early-stopping-patience 3
+               └─ Jobs option ┘    └─ script + arguments ─────────────┘
+```
+
 ## UV Jobs
 
 Specify the UV script or python command to run as you would with UV:
@@ -26,7 +37,7 @@ The `hf jobs uv run` command accepts an UV argument like `--with` and `--python`
 >>> hf jobs uv run --python 3.12 train.py
 ```
 
-Put Jobs options before the script or command. Use `--` to forward arguments that Jobs also recognises:
+For example, pass arguments to a command using `--`:
 
 ```bash
 >>> hf jobs uv run --with trl-jobs -- trl-jobs sft --model_name Qwen/Qwen3-0.6B --dataset_name trl-lib/Capybara
@@ -44,12 +55,10 @@ Specify the Docker image and the command to run as you would with docker:
 >>> hf jobs run ubuntu echo "Hello from the cloud!"
 ```
 
-Use `--` before the command and its arguments to prevent Jobs from interpreting their options.
-Here, `python --help` runs inside the image and shows Python's help, not Jobs help:
+Here, `--help` reaches Python rather than showing Jobs help:
 
-```text
-hf jobs run --flavor cpu-basic python:3.12 -- python --help
-            └─ Jobs option ─┘ └─ image ─┘    command + args
+```bash
+>>> hf jobs run --flavor cpu-basic python:3.12 -- python --help
 ```
 
 Find the list of all arguments in the [CLI documentation](https://huggingface.co/docs/huggingface_hub/package_reference/cli#hf-jobs-run).

--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -44,12 +44,12 @@ Specify the Docker image and the command to run as you would with docker:
 >>> hf jobs run ubuntu echo "Hello from the cloud!"
 ```
 
-Place Jobs options before the image. If your command uses options that Jobs also recognises,
-such as `--help` or `--timeout`, add `--` between the image and command. Otherwise, Jobs can
-consume those options instead of forwarding them to your command:
+Use `--` before the command and its arguments to prevent Jobs from interpreting their options.
+Here, `python --help` runs inside the image and shows Python's help, not Jobs help:
 
-```bash
->>> hf jobs run --flavor cpu-basic huggingface/trl -- trl --help
+```text
+hf jobs run --flavor cpu-basic python:3.12 -- python --help
+            └─ Jobs option ─┘ └─ image ─┘    command + args
 ```
 
 Find the list of all arguments in the [CLI documentation](https://huggingface.co/docs/huggingface_hub/package_reference/cli#hf-jobs-run).

--- a/docs/hub/jobs-configuration.md
+++ b/docs/hub/jobs-configuration.md
@@ -8,9 +8,9 @@ Alternatively, pass a Hugging Face token manually with `--token` in the CLI, or 
 
 ## Passing arguments
 
-Use `--` to separate Jobs options from arguments passed to your command or script.
-Jobs does not interpret options after `--`, so options such as `--help` or `--timeout`
-reach your command or script instead. This applies to both UV and Docker Jobs.
+Use `--` to separate Jobs options from your command or script and its arguments. Options after
+`--`, such as `--help` or `--timeout`, are passed through rather than interpreted by Jobs.
+This applies to both UV and Docker Jobs.
 
 ```text
 hf jobs uv run --flavor t4-small -- script.py --early-stopping-patience 3


### PR DESCRIPTION
Follow-up to #2758: clarify how `--` separates Jobs options from arguments intended for a command or script.

- Explain the shared `--` rule once in a "Passing arguments" section before UV and Docker Jobs, with an annotated UV script example.
- Keep the individual sections concise, with concrete examples of command arguments and forwarding `--help` to Python rather than Jobs.

The separator behavior was checked with the current parser and a CPU Job using `trl --help`. Both `python --help` and the UV separator-before-script form were checked against the parser, including forwarding a conflicting `--help` to the script. Docs only—no parser changes.

Related client-docs alignment: https://github.com/huggingface/huggingface_hub/pull/4809.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to Jobs configuration guidance with no runtime or API impact.
> 
> **Overview**
> **Documents how `--` separates Hugging Face Jobs CLI flags from the user’s command or script**, in one shared **Passing arguments** section (with an annotated `hf jobs uv run` example) instead of repeating the rule in UV and Docker subsections.
> 
> The **UV Jobs** section drops the long note about where UV options must go and points readers to that section plus the existing `trl-jobs` example. The **Docker Jobs** section is tightened to show that flags like `--help` are forwarded to the container command (e.g. `python --help`), including a new `python:3.12` example alongside the TRL case.
> 
> **Docs only**—no CLI or parser changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 642498e7b9e2bb7f91c9b8bfe2f437e2e4200df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->