### PR TITLE
Fix tokens management doc: token-id revoke API + 50 admin notifications

### DIFF
--- a/docs/hub/enterprise-tokens-management.md
+++ b/docs/hub/enterprise-tokens-management.md
@@ -89,18 +89,7 @@ Administrators have two ways to remove a token's access to an organization:
 
 Use **deny** when managing access within the approval workflow (the token transitions to a `denied` state and can be re-approved later). Use **revoke** when you need to permanently cut off a token's access to the organization.
 
-## Revoking Tokens
-
-> [!WARNING]
-> This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> plan and above.
-
-Organization administrators can revoke any member's access token from the token detail page. Revocation is available regardless of whether the organization uses the "Require administrator approval" policy. A revoked token can no longer access the organization's resources, but continues to work elsewhere. The token owner receives an email notification upon revocation.
-
-Revoked tokens remain revoked even if the organization's token policy is later changed or disabled. Revocation is permanent at the organization level — there is no un-revoke action. If a member needs access restored, they must delete the revoked token and create a new one. If the organization uses the "Require administrator approval" policy, the new token will start in the pending state and require admin approval.
-
-Members whose tokens have been revoked receive a `403` error with the message: _"Your token has been revoked by the organization administrator, you can no longer access organization resources. Please contact them for more information."_ This message is shown regardless of whether the organization uses the "Require administrator approval" policy.
-
-### Listing Tokens via API
+## Listing Tokens via API
 
 > [!WARNING]
 > This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
@@ -116,6 +105,17 @@ curl -H "Authorization: Bearer ${ADMIN_HF_TOKEN}" \
 The response is an array of member access tokens. See the OpenAPI reference for the full schema: <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/%7Bname%7D/settings/tokens" rel="nofollow">GET /api/organizations/<name>/settings/tokens</a>
 
 By default, revoked tokens are hidden; pass `q=status:all` to include them, like the **Show revoked tokens** toggle in the UI.
+
+## Revoking Tokens
+
+> [!WARNING]
+> This feature is part of the <a href="https://huggingface.co/enterprise">Enterprise</a> plan and above.
+
+Organization administrators can revoke any member's access token from the token detail page. Revocation is available regardless of whether the organization uses the "Require administrator approval" policy. A revoked token can no longer access the organization's resources, but continues to work elsewhere. The token owner receives an email notification upon revocation.
+
+Revoked tokens remain revoked even if the organization's token policy is later changed or disabled. Revocation is permanent at the organization level — there is no un-revoke action. If a member needs access restored, they must delete the revoked token and create a new one. If the organization uses the "Require administrator approval" policy, the new token will start in the pending state and require admin approval.
+
+Members whose tokens have been revoked receive a `403` error with the message: _"Your token has been revoked by the organization administrator, you can no longer access organization resources. Please contact them for more information."_ This message is shown regardless of whether the organization uses the "Require administrator approval" policy.
 
 ### Revoking via API
 

--- a/docs/hub/enterprise-tokens-management.md
+++ b/docs/hub/enterprise-tokens-management.md
@@ -113,9 +113,9 @@ curl -H "Authorization: Bearer ${ADMIN_HF_TOKEN}" \
   "https://huggingface.co/api/organizations/${ORG_NAME}/settings/tokens"
 ```
 
-The response is an array of member access tokens, with the token id (`_id`), kind (`role`: `read`, `write` or `fineGrained`), last 4 characters (`last4`), creation date (`createdAt`), last-used date (`lastUsedAt`, absent if never used), owner and authorization status (`pending`, `approved`, `denied` or `revoked`). Fine-grained tokens also include their specific permissions.
+The response is an array of member access tokens. See the OpenAPI reference for the full schema: <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/%7Bname%7D/settings/tokens" rel="nofollow">GET /api/organizations/<name>/settings/tokens</a>
 
-Pagination uses the `Link` header (`rel="next"`, up to 100 tokens per page). The `q` parameter filters the list on `owner:`, `role:`, `status:` and `token:` (last 4 characters), each negatable with `-`; by default, revoked tokens are hidden. Pass `q=status:all` to include them, like the **Show revoked tokens** toggle in the UI.
+By default, revoked tokens are hidden; pass `q=status:all` to include them, like the **Show revoked tokens** toggle in the UI.
 
 ### Revoking via API
 

--- a/docs/hub/enterprise-tokens-management.md
+++ b/docs/hub/enterprise-tokens-management.md
@@ -100,6 +100,23 @@ Revoked tokens remain revoked even if the organization's token policy is later c
 
 Members whose tokens have been revoked receive a `403` error with the message: _"Your token has been revoked by the organization administrator, you can no longer access organization resources. Please contact them for more information."_ This message is shown regardless of whether the organization uses the "Require administrator approval" policy.
 
+### Listing Tokens via API
+
+> [!WARNING]
+> This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
+
+The token listing shown in the settings UI is also available programmatically:
+
+```bash
+# ORG_NAME should be your organization name and ADMIN_HF_TOKEN an admin's access token
+curl -H "Authorization: Bearer ${ADMIN_HF_TOKEN}" \
+  "https://huggingface.co/api/organizations/${ORG_NAME}/settings/tokens"
+```
+
+The response is an array of member access tokens, with the token id (`_id`), kind (`role`: `read`, `write` or `fineGrained`), last 4 characters (`last4`), creation date (`createdAt`), last-used date (`lastUsedAt`, absent if never used), owner and authorization status (`pending`, `approved`, `denied` or `revoked`). Fine-grained tokens also include their specific permissions.
+
+Pagination uses the `Link` header (`rel="next"`, up to 100 tokens per page). The `q` parameter filters the list on `owner:`, `role:`, `status:` and `token:` (last 4 characters), each negatable with `-`; by default, revoked tokens are hidden. Pass `q=status:all` to include them, like the **Show revoked tokens** toggle in the UI.
+
 ### Revoking via API
 
 Administrators can also revoke a token programmatically using its token id. This is useful for automated workflows, where a token needs to be revoked immediately.

--- a/docs/hub/enterprise-tokens-management.md
+++ b/docs/hub/enterprise-tokens-management.md
@@ -91,9 +91,6 @@ Use **deny** when managing access within the approval workflow (the token transi
 
 ## Listing Tokens via API
 
-> [!WARNING]
-> This feature is part of the <a href="https://huggingface.co/enterprise">Team & Enterprise</a> plans.
-
 The token listing shown in the settings UI is also available programmatically:
 
 ```bash

--- a/docs/hub/enterprise-tokens-management.md
+++ b/docs/hub/enterprise-tokens-management.md
@@ -51,7 +51,7 @@ Team & Enterprise organization administrators can enforce the following policies
 
 ## Reviewing Token Authorization
 
-When token policy is set to "Require administrator approval", organization administrators can review details of all fine-grained tokens accessing organization-owned resources and approve or deny access. When a new token enters the pending state, up to 5 organization administrators with confirmed email addresses receive a notification with a direct link to the token review page. No notification is sent when a token is auto-approved (e.g., because the creator is an org admin).
+When token policy is set to "Require administrator approval", organization administrators can review details of all fine-grained tokens accessing organization-owned resources and approve or deny access. When a new token enters the pending state, up to 50 organization administrators with confirmed email addresses receive a notification with a direct link to the token review page. No notification is sent when a token is auto-approved (e.g., because the creator is an org admin).
 
 - **Pending** tokens are awaiting an administrator decision
 - **Approved** tokens have been authorized and are active
@@ -102,21 +102,16 @@ Members whose tokens have been revoked receive a `403` error with the message: _
 
 ### Revoking via API
 
-Administrators can also revoke a token programmatically by providing the raw token value. This is useful for automated workflows such as secrets scanning, where a leaked token is detected and needs to be revoked immediately.
+Administrators can also revoke a token programmatically using its token id. This is useful for automated workflows, where a token needs to be revoked immediately.
 
 ```bash
 # ORG_NAME should be your organization name and ADMIN_HF_TOKEN an admin's access token
-# LEAKED_HF_TOKEN should contain the raw token value to revoke
-curl -X POST "https://huggingface.co/api/organizations/${ORG_NAME}/settings/tokens/revoke" \
-  -H "Authorization: Bearer ${ADMIN_HF_TOKEN}" \
-  -H "Content-Type: application/json" \
-    -d "{\"token\": \"${LEAKED_HF_TOKEN}\"}"
+# TOKEN_ID is the 24-character id shown on the org token settings page (or returned by the tokens listing API)
+curl -X POST "https://huggingface.co/api/organizations/${ORG_NAME}/settings/tokens/${TOKEN_ID}/revoke" \
+  -H "Authorization: Bearer ${ADMIN_HF_TOKEN}"
 ```
 
-> [!TIP]
-> To avoid leaking token values in shell history or logs, pass them via environment variables or files, and avoid pasting raw tokens directly into command lines.
-
-An administrator cannot revoke their own token (`LEAKED_HF_TOKEN` cannot have the same value as `ADMIN_HF_TOKEN` in the snippet above).
+An administrator cannot revoke their own token: a request whose token id matches the token used for authentication is rejected with a `403` error.
 
 > [!NOTE]
 > This endpoint only revokes the token's access to your organization; the token keeps working for its owner's other resources. To invalidate a leaked token everywhere, use [`POST /api/credentials/revoke`](./security-tokens#revoking-a-leaked-token) instead, which requires no authentication and accepts a batch of raw token values.


### PR DESCRIPTION
Sections of [`enterprise-tokens-management`](https://huggingface.co/docs/hub/main/en/enterprise-tokens-management) drifted from the code:

- **Revoking via API**: the endpoint now takes a token id (`POST /api/organizations/:name/settings/tokens/:tokenId/revoke`); the raw-token-value endpoint (`POST .../settings/tokens/revoke` with `{"token": ...}`) was removed in huggingface-internal/moon-landing#19474. Updated the curl example and the self-revoke note (now a 403 when the id matches the token used for auth).
- **Pending-token notifications**: sent to up to **50** org admins, not 5 (huggingface-internal/moon-landing#19496).
- **New — Listing Tokens via API**: documents `GET /api/organizations/:name/settings/tokens` (curl example, OpenAPI link for the schema, `status:all` vs revoked-hidden default). The endpoint existed in the code but was undocumented.

Everything else on the page was verified against the codebase and is accurate.

> [!NOTE]
> Generated with Claude Code (GLM 5.3 Flash), agent acting for @Pierrci.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to enterprise token management; no application code or runtime behavior changes.
> 
> **Overview**
> Updates **enterprise tokens management** docs so they match current Hub behavior.
> 
> **Pending-token emails** now say up to **50** org admins are notified (was 5).
> 
> Adds **Listing Tokens via API**: `GET /api/organizations/{name}/settings/tokens`, with a curl example, OpenAPI link, and `q=status:all` to mirror the UI’s revoked-token toggle.
> 
> **Revoking via API** is rewritten for the token-id route `POST .../settings/tokens/{TOKEN_ID}/revoke` instead of posting the raw token to `.../tokens/revoke`. The self-revoke case is documented as a **403** when the id matches the bearer token; the shell-history tip for raw tokens is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99b328e15aca67558121dfb6f59981b8d9b3c009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->