### PR TITLE
Document the audit log export API endpoint

### DIFF
--- a/docs/hub/audit-logs.md
+++ b/docs/hub/audit-logs.md
@@ -40,7 +40,7 @@ GET https://huggingface.co/api/organizations/{org}/audit-log/export
 
 Authenticate with a user access token or service-account token that has the **Export the audit log** permission (`org.auditLog.write`) for the organization. The response is a JSON array of log entries, identical to the file downloaded from the settings page. Like the manual export, the API call is recorded as `org.audit_log.export`.
 
-The endpoint is also documented in the [OpenAPI reference](https://huggingface.co/openapi/) (source: [`.well-known/openapi.json`](https://huggingface.co/.well-known/openapi.json)).
+The endpoint is also documented in the [OpenAPI reference](https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/%7Bname%7D/audit-log/export).
 
 ## What Events Are Tracked?
 

--- a/docs/hub/audit-logs.md
+++ b/docs/hub/audit-logs.md
@@ -30,6 +30,16 @@ Audit Logs are accessible through your organization settings. Each log entry inc
 
 You can also download the complete audit log as a JSON file for further analysis.
 
+### Export via API
+
+Programmatic export is available at:
+
+```
+GET https://huggingface.co/api/organizations/{org}/audit-log/export
+```
+
+Authenticate with a user access token or service-account token that has the **Export the audit log** permission (`org.auditLog.write`) for the organization. The response is a JSON array of log entries, identical to the file downloaded from the settings page. Like the manual export, the API call is recorded as `org.audit_log.export`.
+
 ## What Events Are Tracked?
 
 Each action has an **event name** in `scope.action` format (e.g. `repo.create`, `collection.delete`). This is the `type` field in each log entry and in the exported JSON—use it when searching or filtering logs.

--- a/docs/hub/audit-logs.md
+++ b/docs/hub/audit-logs.md
@@ -40,6 +40,8 @@ GET https://huggingface.co/api/organizations/{org}/audit-log/export
 
 Authenticate with a user access token or service-account token that has the **Export the audit log** permission (`org.auditLog.write`) for the organization. The response is a JSON array of log entries, identical to the file downloaded from the settings page. Like the manual export, the API call is recorded as `org.audit_log.export`.
 
+The endpoint is also documented in the [OpenAPI reference](https://huggingface.co/openapi/) (source: [`.well-known/openapi.json`](https://huggingface.co/.well-known/openapi.json)).
+
 ## What Events Are Tracked?
 
 Each action has an **event name** in `scope.action` format (e.g. `repo.create`, `collection.delete`). This is the `type` field in each log entry and in the exported JSON—use it when searching or filtering logs.

--- a/docs/hub/audit-logs.md
+++ b/docs/hub/audit-logs.md
@@ -40,7 +40,7 @@ GET https://huggingface.co/api/organizations/{org}/audit-log/export
 
 Authenticate with a user access token or service-account token that has the **Export the audit log** permission (`org.auditLog.write`) for the organization. The response is a JSON array of log entries, identical to the file downloaded from the settings page. Like the manual export, the API call is recorded as `org.audit_log.export`.
 
-The endpoint is also documented in the [OpenAPI reference](https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/%7Bname%7D/audit-log/export).
+The endpoint is also documented in the <a href="https://huggingface.co/spaces/huggingface/openapi#tag/orgs/GET/api/organizations/%7Bname%7D/audit-log/export">OpenAPI reference</a>.
 
 ## What Events Are Tracked?
 


### PR DESCRIPTION
## Context

Adds a subsection to the [Audit Logs doc](https://huggingface.co/docs/hub/audit-logs) under **Accessing Audit Logs** documenting the programmatic export endpoint `GET /api/organizations/{org}/audit-log/export` — it exists (requires a paid plan and the `org.auditLog.write` token permission) but was undocumented.

## Changes

- New **Export via API** subsection: endpoint URL, required permission (`org.auditLog.write`, user or service-account token), JSON response, and note that the API call is itself logged as `org.audit_log.export`.

> [!NOTE]
> Generated with Claude Code (GLM-5.3-Flash) acting for @Pierrci.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security behavior impact.
> 
> **Overview**
> Adds an **Export via API** subsection under **Accessing Audit Logs** in `docs/hub/audit-logs.md`, describing programmatic export via `GET /api/organizations/{org}/audit-log/export`.
> 
> The new text covers authentication (user or service-account token with `org.auditLog.write`), that the response matches the settings-page JSON download, that exports are logged as `org.audit_log.export`, and links to the OpenAPI reference for the same route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b98f7598291a57e6f15df79d712d20c9653df634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->