### PR TITLE
Add Berget provider documentation

### DIFF
--- a/docs/inference-providers/_toctree.yml
+++ b/docs/inference-providers/_toctree.yml
@@ -108,6 +108,8 @@
   sections:
   - local: providers/baseten
     title: Baseten
+  - local: providers/berget
+    title: Berget
   - local: providers/cerebras
     title: Cerebras
   - local: providers/cohere

--- a/docs/inference-providers/index.md
+++ b/docs/inference-providers/index.md
@@ -41,6 +41,7 @@ Our platform integrates with leading AI infrastructure providers, giving you acc
 | Provider                                     | Chat completion (LLM) | Chat completion (VLM) | Feature Extraction | Text to Image | Text to video | Speech to text |
 | -------------------------------------------- | :-------------------: | :-------------------: | :----------------: | :-----------: | :-----------: | :------------: |
 | [Baseten](./providers/baseten)               |          ✅           |          ✅           |                    |               |               |                |
+| [Berget](./providers/berget)                 |          ✅           |          ✅           |                    |               |               |                |
 | [Cerebras](./providers/cerebras)             |          ✅           |                       |                    |               |               |                |
 | [Cohere](./providers/cohere)                 |          ✅           |          ✅           |                    |               |               |                |
 | [DeepInfra](./providers/deepinfra)           |          ✅           |          ✅           |                    |               |               |                |

--- a/docs/inference-providers/providers/berget.md
+++ b/docs/inference-providers/providers/berget.md
@@ -1,0 +1,45 @@
+<!---
+WARNING
+
+This markdown file has been generated from a script. Please do not edit it directly.
+
+### Template
+
+If you want to update the content related to berget's description, please edit the template file under `https://github.com/huggingface/hub-docs/tree/main/scripts/inference-providers/templates/providers/berget.handlebars`.
+
+### Logos
+
+If you want to update berget's logo, upload a file by opening a PR on https://huggingface.co/datasets/huggingface/documentation-images/tree/main/inference-providers/logos. Ping @wauplin and @celinah on the PR to let them know you uploaded a new logo.
+Logos must be in .png format and be named `berget-light.png` and `berget-dark.png`. Visit https://huggingface.co/settings/theme to switch between light and dark mode and check that the logos are displayed correctly.
+
+### Generation script
+
+For more details, check out the `generate.ts` script: https://github.com/huggingface/hub-docs/blob/main/scripts/inference-providers/scripts/generate.ts.
+--->
+
+# Berget
+
+> [!TIP]
+> All models supported by Berget can be found [here](https://huggingface.co/models?inference_provider=berget&sort=trending)
+
+<div class="flex justify-center">
+    <a href="https://berget.ai/" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/berget-light.png"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/inference-providers/logos/berget-dark.png"/>
+    </a>
+</div>
+
+<div class="flex">
+    <a href="https://huggingface.co/berget" target="_blank">
+        <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg.svg"/>
+        <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg"/>
+    </a>
+</div>
+
+Berget is a Swedish AI company providing sovereign, sustainable AI infrastructure. We run inference on open-weight models hosted entirely in Swedish data centers, built for organizations that need full data control and GDPR compliance — your data never leaves the EU.
+
+Our API is fully OpenAI-compatible, so any tool or SDK that works with OpenAI works with Berget. We focus on strong multilingual models (including Swedish and Nordic languages) and publish transparent carbon estimates alongside every response.
+
+## Supported tasks
+
+

--- a/docs/inference-providers/providers/berget.md
+++ b/docs/inference-providers/providers/berget.md
@@ -43,3 +43,5 @@ Our API is fully OpenAI-compatible, so any tool or SDK that works with OpenAI wo
 ## Supported tasks
 
 
+
+Berget currently offers conversational (chat) models — model mappings appear in the section above as they are validated by Hugging Face. The full Berget catalog is available at [docs.berget.ai](https://docs.berget.ai).

--- a/scripts/inference-providers/scripts/generate.ts
+++ b/scripts/inference-providers/scripts/generate.ts
@@ -35,6 +35,7 @@ const HEADERS: Record<string, string> = process.env.HF_TOKEN
 
 const PROVIDERS_URLS: Record<string, string> = {
   baseten: "https://www.baseten.co/",
+  berget: "https://berget.ai/",
   cerebras: "https://www.cerebras.ai/",
   cohere: "https://cohere.com/",
   deepinfra: "https://deepinfra.com/",

--- a/scripts/inference-providers/templates/providers/berget.handlebars
+++ b/scripts/inference-providers/templates/providers/berget.handlebars
@@ -12,3 +12,5 @@ Berget is a Swedish AI company providing sovereign, sustainable AI infrastructur
 Our API is fully OpenAI-compatible, so any tool or SDK that works with OpenAI works with Berget. We focus on strong multilingual models (including Swedish and Nordic languages) and publish transparent carbon estimates alongside every response.
 
 {{{tasksSection}}}
+
+Berget currently offers conversational (chat) models — model mappings appear in the section above as they are validated by Hugging Face. The full Berget catalog is available at [docs.berget.ai](https://docs.berget.ai).

--- a/scripts/inference-providers/templates/providers/berget.handlebars
+++ b/scripts/inference-providers/templates/providers/berget.handlebars
@@ -1,0 +1,14 @@
+# Berget
+
+> [!TIP]
+> All models supported by Berget can be found [here](https://huggingface.co/models?inference_provider=berget&sort=trending)
+
+{{{logoSection}}}
+
+{{{followUsSection}}}
+
+Berget is a Swedish AI company providing sovereign, sustainable AI infrastructure. We run inference on open-weight models hosted entirely in Swedish data centers, built for organizations that need full data control and GDPR compliance — your data never leaves the EU.
+
+Our API is fully OpenAI-compatible, so any tool or SDK that works with OpenAI works with Berget. We focus on strong multilingual models (including Swedish and Nordic languages) and publish transparent carbon estimates alongside every response.
+
+{{{tasksSection}}}


### PR DESCRIPTION
Hi! Adding the provider documentation page for [Berget](https://berget.ai) as part of our registration as a Hub inference provider ([guide](https://huggingface.co/docs/inference-providers/en/register-as-a-provider)).

Contents:
- New `templates/providers/berget.handlebars` page (Swedish sovereign inference, open-weight models in Swedish data centers, GDPR/EU focus, OpenAI-compatible API)
- Generated `docs/inference-providers/providers/berget.md` (ran `pnpm run generate`; the "Supported tasks" section is currently empty since no mappings are live yet — it populates automatically once our mappings go live)
- `_toctree.yml` entry (alphabetical), partners table row in `index.md` (LLM + VLM checkmarks — our multimodal models support vision), `berget` in `PROVIDERS_URLS`

Related client PRs:
- JS: https://github.com/huggingface/huggingface.js/pull/2446
- Python: https://github.com/huggingface/huggingface_hub/pull/4814

Logos (`berget-light.png` / `berget-dark.png`): we'll deliver them alongside the partnership activation — happy to send the files directly or open a PR on documentation-images, whichever you prefer.

We'll reach out about server-side activation of the berget partner account next. cc @Wauplin @SBrandeis @julien-c @hanouticelina — thanks!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doc-generation metadata only; no application logic, auth, or inference routing changes.
> 
> **Overview**
> Adds **Berget** as a new Hugging Face Inference Providers partner in the docs only (no runtime inference changes in this repo).
> 
> A new `berget.handlebars` template describes Berget’s EU/sovereign hosting, OpenAI-compatible API, and chat focus; running the generator produces `providers/berget.md` (the **Supported tasks** block is empty until Hub model mappings exist). Navigation picks up Berget in `_toctree.yml`, the partners matrix on `index.md` marks **LLM** and **VLM** chat completion, and `generate.ts` registers `berget: https://berget.ai/` so the page is included in provider generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37fa501aef354255d8589f78c8edf3b678dea31c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->