### PR TITLE
Document that webhook handlers must answer with a 2xx status

### DIFF
--- a/docs/hub/webhooks.md
+++ b/docs/hub/webhooks.md
@@ -274,6 +274,8 @@ If you set a secret for your Webhook, it will be sent along as an `X-Webhook-Sec
 
 Webhook payloads are delivered asynchronously, shortly after the event happens on the Hub. Order is not guaranteed: if several events occur close together, they may arrive out of sequence.
 
+Your handler should acknowledge a delivery with a `2xx` status code. Any other status code counts as a failed delivery, just like a connection error: it is retried with a backoff. If your processing is slow, answer with a `2xx` right away and do the work asynchronously, so the delivery is not considered failed.
+
 Each delivery has a unique `Webhook-Id` HTTP header. Retries of a failed delivery reuse the same ID, so you can treat it as an idempotency key and process each event once.
 
 When deliveries to a Webhook keep failing, the Webhook is automatically suspended and its owner is notified by email. You can troubleshoot it and re-enable it from your Webhooks [settings](https://huggingface.co/settings/webhooks).


### PR DESCRIPTION
Non-2xx responses are now treated as failed deliveries: they are retried and count towards automatic suspension of the webhook.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code or runtime impact.
> 
> **Overview**
> Documents Hub webhook **delivery acknowledgment** in the **Delivery and retries** section: handlers must return a **`2xx`** status to mark a delivery successful.
> 
> **Non-`2xx` responses** are now described the same as connection failures—they trigger **backoff retries** and can contribute to **automatic webhook suspension**. The doc also recommends returning **`2xx` immediately** and processing work asynchronously when handlers are slow, so deliveries are not marked failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 368b61eb1aa63849225e7dcb77db29aabdffc07c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->