### PR TITLE
Document the robotics Video Preview card

### DIFF
--- a/docs/hub/models-widgets.md
+++ b/docs/hub/models-widgets.md
@@ -157,6 +157,24 @@ We can also surface the example outputs in the Hugging Face UI, for instance, fo
 <img width="650" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/models-gallery.png"/>
 </div>
 
+## Video previews for robotics models
+
+Models with `pipeline_tag: robotics` show a **Video Preview** card rather than an inference widget. This card does not read `widget` metadata. It looks for a file named `replay.mp4` at the root of the model repository, on the `main` revision:
+
+```
+https://huggingface.co/<namespace>/<model>/resolve/main/replay.mp4
+```
+
+When the file is present it is played inline on a loop, and when it is missing the card reads "Preview not found". Since the path is fixed, a robotics model can surface a single preview video, it has to be named `replay.mp4`, and it has to sit at the repository root. Adding `widget` entries with an `output.url` has no effect on this card.
+
+The file should be tracked with Git LFS:
+
+```
+replay.mp4 filter=lfs diff=lfs merge=lfs -text
+```
+
+[`lerobot/diffusion_pusht`](https://huggingface.co/lerobot/diffusion_pusht) is an example of a repository with the file in place.
+
 ## Widget Availability and Provider Support
 
 Not all models have widgets available. Widget availability depends on:
@@ -169,7 +187,7 @@ To view the full list of supported tasks, check out [our dedicated documentation
 
 The list of all providers and the tasks they support is available in [this documentation page](https://huggingface.co/docs/inference-providers/index#partners).
 
-For models without provider support, you can still showcase functionality using [example outputs](#example-outputs) in your model card.
+For models without provider support, you can still showcase functionality using [example outputs](#example-outputs) in your model card. Robotics models are an exception, see [Video previews for robotics models](#video-previews-for-robotics-models).
 
 You can also click _Ask for provider support_ directly on the model page to encourage providers to serve the model, given there is enough community interest.
 


### PR DESCRIPTION
Documents how the Video Preview card on robotics model pages is populated. This is not covered by the current widget metadata spec, and the existing guidance points readers toward example outputs, which the card ignores.

- Add a "Video previews for robotics models" section covering the `replay.mp4` lookup at the repository root on `main`, the "Preview not found" fallback, and the fact that `widget` metadata is not read.
- Note the Git LFS tracking rule and link `lerobot/diffusion_pusht` as a repository with the file in place.
- Flag the robotics exception in "Widget Availability and Provider Support", where models without provider support are currently pointed at example outputs.

**Validation:** Checked against the widget bundle served on model pages, which issues a single `HEAD` request for `/{model_id}/resolve/main/replay.mp4` and falls back to "Preview not found" when that returns an error. `widget` entries using `output.url`, `src`, and both together were tested on a scratch robotics repo and none of them populated the card. A repository with `replay.mp4` at the root rendered the video as described. This covers the robotics card only, not the other task widgets.

Related: https://github.com/huggingface/huggingface.js/issues/722 and https://github.com/huggingface/lerobot/issues/227.

Assisted by [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds a **Video previews for robotics models** section to the Hub widgets docs, placed after the example-outputs gallery and before widget availability.
> 
> The new text explains that `pipeline_tag: robotics` model pages use a **Video Preview** card instead of the normal inference widget, that **`widget` metadata (including `output.url`) is ignored**, and that the UI loads a single fixed asset: **`replay.mp4` at the repository root on `main`**, with inline looping playback or a **"Preview not found"** message when the file is absent. It also documents **Git LFS** tracking for `replay.mp4` and points to **`lerobot/diffusion_pusht`** as a working example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b80b85d90c298590db9c5637894455a8e8e60db6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->